### PR TITLE
Phase 0 hygiene: CI scanning, crosswalk regeneration, packaging fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+  schedule:
+    - cron: '17 3 * * 2'
+
+permissions: read-all
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python", "javascript"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: ["main", "develop"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: always

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,8 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Runs the gitleaks CLI directly (AGPL-3.0, free) rather than gitleaks/gitleaks-action,
+      # whose v2 wrapper now requires a paid license for GitHub Organization accounts
+      # ("[org] is an organization. License key is required.") -- the underlying tool has
+      # no such restriction, only the maintained wrapper action added one.
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+        uses: docker://zricethezav/gitleaks:latest
+        with:
+          args: detect --source=/github/workspace --config=/github/workspace/.gitleaks.toml --redact --verbose

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,25 @@
+name: Secret scan
+
+on:
+  pull_request:
+    branches: ["main", "develop"]
+  push:
+    branches: ["main", "develop"]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,37 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Validate all records against the schema
+        run: python scripts/validate_records.py
+
+      - name: Check every rule has positive and negative fixtures
+        run: python scripts/check_fixtures.py
+
+      - name: Check every record has a detection rule
+        run: python scripts/check_rule_coverage.py
+
+      - name: Run tests with coverage (rules/)
+        run: pytest tests/ -x -q --cov=rules --cov-report=term-missing --cov-fail-under=95

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/agents/handoffs/
 .env
 .DS_Store
 node_modules/
+.coverage

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+title = "gitleaks config for bawbel/ave"
+
+# Extend the default gitleaks ruleset rather than replace it.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "AVE test fixtures intentionally contain credential-shaped strings as positive-detection test data (e.g. AVE-2026-00047, hardcoded-credential detection). These are fake values, not real secrets."
+paths = [
+  '''tests/fixtures/.*''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,7 +5,8 @@ title = "gitleaks config for bawbel/ave"
 useDefault = true
 
 [allowlist]
-description = "AVE test fixtures intentionally contain credential-shaped strings as positive-detection test data (e.g. AVE-2026-00047, hardcoded-credential detection). These are fake values, not real secrets."
+description = "AVE test fixtures intentionally contain credential-shaped strings as positive-detection test data (e.g. AVE-2026-00047, hardcoded-credential detection). These are fake values, not real secrets. Covers both the generated fixture files and scripts/generate-rules-and-fixtures.js, the generator script that embeds the same synthetic values as a template."
 paths = [
   '''tests/fixtures/.*''',
+  '''scripts/generate-rules-and-fixtures\.js''',
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,105 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 
 ---
 
+## [1.2.0] - 2026-07-12
+
+### Summary
+
+- Schema v1.1.0: 3 field renames, 1 field removal, 4 new optional fields, draft-vs-active
+  conditional required set. `schema/ave-record-1.1.0.schema.json` is now canonical;
+  `ave-record-1.0.0.schema.json` stays frozen permanently. Merged via PR #37.
+- All 51 original records migrated to `schema_version: "1.1.0"` and enriched with the 3
+  new classification objects
+- 5 new records: AVE-2026-00052 through AVE-2026-00056 — record set now at 56, 112 tests
+  passing. Merged via PR #37.
+- Phase 0 repo hygiene: CI code/dependency/secret scanning, OpenSSF Scorecard, 8 new
+  README badges, two pre-existing packaging bugs fixed. On PR #38 (open, pending review
+  at time of writing).
+- `crosswalks/ave-to-owasp-mcp.md` regenerated from source-of-truth record data (found
+  pre-existing drift, not just missing rows). `crosswalks/ave-to-ast10.json`/`.md`
+  extended for the 5 new records. `clawscan-to-ave.json` / `skillspector-to-ave.json`
+  target metadata synced to v1.1.0/56 records; their rule-level mappings are unchanged,
+  since re-checking them requires each external tool's own current rule catalog.
+
+### Schema v1.1.0
+
+Field renames (owasp_mapping -> owasp_asi, mitre_atlas_mapping -> mitre_atlas,
+nist_ai_rmf_mapping -> nist_ai_rmf) and removal (`aivss.owasp_mcp_mapping`, redundant
+with top-level `owasp_mcp` and had drifted out of sync on 5 records) applied across all
+51 records. Four new optional fields added: `provenance_vector`, `trifecta_profile`,
+`mitigation` (vendor-neutral only — no enforcement-tool config, per the standard-vs-tool
+boundary in `AVE_V1.1.0_MIGRATION_BRIEF.md` Section 0), and `example_patterns`.
+`status: "draft"` records now need only an 8-field submit-required core; the full
+15-field set still applies once `status` is `active` or `deprecated`.
+
+`behavioral_vector` misuse corrected: 12 records (AVE-2026-00004 through 00015) had it
+empty and got fresh tags; 11 records (AVE-2026-00041 through 00051) had repurposed it to
+hold full example payloads — moved to the new `example_patterns` field, fresh tags
+drafted. (Corrected scope from the migration brief's original claim of records
+00016-00051; verification found 00016-00040 already had correct tags.)
+
+`provenance_vector`/`trifecta_profile`/`mitigation` drafted for all 51 records by an LLM
+pass, per the migration brief's Section 6.2 workflow. Two drift bugs found via human
+spot-check and fixed: AVE-2026-00041 and AVE-2026-00042 both had `mitigation.strategy`
+values that didn't match what each record's own `remediation` field actually
+recommended (missing `pin_integrity` and `deny_by_default` respectively, both explicitly
+named in the prose remediation text). Priority-1 records 00045/00046/00050/00051 remain
+unreviewed LLM drafts as of this release.
+
+### New records
+
+| AVE ID | Attack class | Severity | AIVSS |
+|---|---|---|---|
+| AVE-2026-00052 | Tool Abuse - Implementation Command Injection | HIGH | 7.5 |
+| AVE-2026-00053 | Tool Abuse - Resource Path Traversal | MEDIUM | 6.3 |
+| AVE-2026-00054 | Execution Hijack - Code Execution Sandbox Escape | MEDIUM | 6.7 |
+| AVE-2026-00055 | Supply Chain - MCP STDIO Launch Configuration Injection | HIGH | 7.7 |
+| AVE-2026-00056 | Data Exfiltration - Rendered Content Auto-Fetch | MEDIUM | 5.8 |
+
+Identified from the 2026-07-10 research-new-attack-classes benchmark
+(`docs/agents/research/2026-07-10-benchmark.md`); each traces to an NVD-confirmed CVE or
+a named trusted-vendor disclosure (OX Security), verified by direct fetch against
+nvd.nist.gov rather than search-summary text. Implementation plan and three
+cross-cutting decisions (detection_layer for code-implementation vulnerabilities,
+attack_class category, dual-CVSS-assessor handling) recorded in
+`docs/agents/prds/2026-07-10-critical-high-attack-class-batch.md`. Four of the five
+scored below their pre-implementation severity estimate once AIVSS was actually
+computed — see each record's `aivss.notes` for why.
+
+### Repo hygiene (Phase 0, `TRUST_STRATEGY.md`)
+
+- `.github/workflows/tests.yml`, `codeql.yml`, `dependency-review.yml` (+
+  `.github/dependabot.yml`), `secret-scan.yml` (+ `.gitleaks.toml`), `scorecard.yml` —
+  none of this CI existed before this release
+- Enabled natively via repo settings: secret scanning, secret scanning push protection,
+  Dependabot security updates, dependency graph — all were disabled
+- Two pre-existing `pyproject.toml` packaging bugs fixed, found while building the tests
+  workflow and verified against a clean virtualenv: an invalid `build-backend`, and
+  missing `[tool.setuptools] packages = []` (this repo isn't a Python library — nothing
+  imports it as a package). Both meant `pip install -e ".[dev]"`, the exact command
+  CONTRIBUTING.md and CLAUDE.md document, was already broken on a clean machine.
+- `gitleaks/gitleaks-action@v2` requires a paid license for GitHub Organization accounts
+  as of a breaking change in the wrapper action; switched to running the gitleaks Docker
+  image directly (the underlying AGPL-3.0 tool has no such restriction)
+- 8 new README badges: Tests, Coverage, CodeQL, Dependency Review, Secret Scan, OpenSSF
+  Scorecard, Security Policy, Code of Conduct
+
+### Crosswalks
+
+- `ave-to-owasp-mcp.md` regenerated programmatically from every record's own `owasp_mcp`
+  field rather than patched — found the previous hand-maintained version had drifted for
+  several existing entries (e.g. AVE-2026-00004 was listed under the wrong categories),
+  not just missing the newest records
+- `ave-to-ast10.json`/`.md`: AVE-2026-00054 -> AST06, AVE-2026-00055 -> AST02.
+  AVE-2026-00052/00053/00056 recorded as new gaps rather than forced into an existing
+  category — see the crosswalk files for the reasoning
+- `clawscan-to-ave.json`, `skillspector-to-ave.json`: `target.version`/`record_count`
+  updated to 1.1.0/56; the rule-level mappings and gaps sections are unchanged, since
+  updating them requires each external tool's current rule catalog, which this repo
+  does not have
+
+---
+
 ## [1.1.0] - 2026-06-21
 
 ### Summary
@@ -203,13 +302,31 @@ Three ADRs are locked and documented in `docs/adr/`:
 
 ---
 
-## Planned for v1.2
+## Done since the original "Planned for v1.2" list
 
-- `GOVERNANCE.md` — decision-making process, record proposal and review workflow, path toward neutral governance
-- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
-- `docs/specs/ave-implementer-guide.md` — consumption patterns for scanner implementers: runtime API, bundled offline (air-gapped), and ID-only emission with downstream resolution
-- Offline release artifact: `ave-records-v1.1.0.json` — single downloadable JSON array of all 51 records, published as a GitHub Release asset for air-gapped and bundled-install use cases
-- AST10 crosswalk PR — submit `crosswalks/ave-to-ast10.json` as a contribution to the OWASP AST10 project repo
-- CWE AI Working Group outreach — open a contribution issue on `github.com/CWE-CAPEC/AI-Working-Group` with a gap-mapping document covering how AVE records address the agentic behavioral classes missing from CWE-1446
-- Second implementer outreach — contact scanner maintainers with crosswalk packages to enable `ave_id` emission in their finding output
-- Resource exhaustion / agentic DoS record — the one confirmed genuine gap from the benchmark-2026-06 research report
+- `GOVERNANCE.md` — shipped
+- `CODE_OF_CONDUCT.md` — shipped (Contributor Covenant v2.1)
+- `docs/specs/ave-implementer-guide.md` — shipped
+- Offline release artifact — shipped as the `v1.1.0` GitHub Release
+  (`ave-records-v1.1.0.json`); a `v1.2.0` release with the 56-record set has not been cut
+  yet, see below
+
+## Planned for v1.3
+
+- Cut a `v1.2.0` GitHub Release with the 56-record offline artifact (`ave-records-v1.2.0.json`)
+- AST10 crosswalk PR — submit `crosswalks/ave-to-ast10.json` as a contribution to the
+  OWASP AST10 project repo; the crosswalk file itself is current, the external
+  submission has not happened
+- Re-check `clawscan-to-ave.json` / `skillspector-to-ave.json` rule-level mappings
+  against each tool's current rule catalog for AVE-2026-00052 through 00056 — this
+  release only updated their AVE-side target metadata (see 1.2.0 above)
+- CWE AI Working Group outreach — open a contribution issue on
+  `github.com/CWE-CAPEC/AI-Working-Group` with a gap-mapping document covering how AVE
+  records address the agentic behavioral classes missing from CWE-1446
+- Second implementer outreach — contact scanner maintainers with crosswalk packages to
+  enable `ave_id` emission in their finding output
+- Resource exhaustion / agentic DoS record — the one confirmed genuine gap from the
+  benchmark-2026-06 research report
+- Section 6.2 review priorities 2-4 from `AVE_V1.1.0_MIGRATION_BRIEF.md` — only 2 of the
+  6 priority-1 records got a human spot-check in 1.2.0 (both had real bugs, since fixed);
+  00045/00046/00050/00051 remain unreviewed LLM drafts, and priorities 2-4 haven't started

--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ Stable IDs, AIVSS scores, and behavioral fingerprints for every way a skill file
 MCP server, system prompt, or agent plugin can be weaponized — scored consistently,
 mapped to the frameworks security teams already report against.
 
-[![Records](https://img.shields.io/badge/records-51-0f6e56?style=flat-square)](records/)
+[![Records](https://img.shields.io/badge/records-56-0f6e56?style=flat-square)](records/)
 [![Schema](https://img.shields.io/badge/schema-v1.1.0-0a3024?style=flat-square)](schema/ave-record-1.1.0.schema.json)
 [![AIVSS](https://img.shields.io/badge/AIVSS-v0.8-d4a017?style=flat-square)](https://aivss.owasp.org)
 [![OWASP MCP](https://img.shields.io/badge/OWASP-MCP%20Top%2010-0a3024?style=flat-square)](https://owasp.org)
 [![MITRE ATLAS](https://img.shields.io/badge/MITRE-ATLAS-4a3f9e?style=flat-square)](https://atlas.mitre.org)
 [![SARIF](https://img.shields.io/badge/SARIF-v2.1.0-0057b7?style=flat-square)](docs/specs/ave-in-sarif.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bawbel/ave/badge)](https://scorecard.dev/viewer/?uri=github.com/bawbel/ave)
 
 [Registry](https://ave.bawbel.io/registry.html) · [Schema](https://ave.bawbel.io/schema.html) · [Crosswalks](https://ave.bawbel.io/crosswalks.html) · [Architecture](https://ave.bawbel.io/architecture.html) · [Scoring](https://ave.bawbel.io/scoring.html) · [Scanner](https://github.com/bawbel/scanner)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ mapped to the frameworks security teams already report against.
 [![MITRE ATLAS](https://img.shields.io/badge/MITRE-ATLAS-4a3f9e?style=flat-square)](https://atlas.mitre.org)
 [![SARIF](https://img.shields.io/badge/SARIF-v2.1.0-0057b7?style=flat-square)](docs/specs/ave-in-sarif.md)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)](LICENSE)
+
+[![Tests](https://github.com/bawbel/ave/actions/workflows/tests.yml/badge.svg)](https://github.com/bawbel/ave/actions/workflows/tests.yml)
+[![Coverage](https://img.shields.io/badge/coverage-100%25%20(rules%2F)-0f6e56?style=flat-square)](.github/workflows/tests.yml)
+[![CodeQL](https://github.com/bawbel/ave/actions/workflows/codeql.yml/badge.svg)](https://github.com/bawbel/ave/actions/workflows/codeql.yml)
+[![Dependency Review](https://github.com/bawbel/ave/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/bawbel/ave/actions/workflows/dependency-review.yml)
+[![Secret Scan](https://github.com/bawbel/ave/actions/workflows/secret-scan.yml/badge.svg)](https://github.com/bawbel/ave/actions/workflows/secret-scan.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bawbel/ave/badge)](https://scorecard.dev/viewer/?uri=github.com/bawbel/ave)
+[![Security Policy](https://img.shields.io/badge/security-policy-blue?style=flat-square)](SECURITY.md)
+[![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Contributor%20Covenant-blueviolet?style=flat-square)](CODE_OF_CONDUCT.md)
 
 [Registry](https://ave.bawbel.io/registry.html) · [Schema](https://ave.bawbel.io/schema.html) · [Crosswalks](https://ave.bawbel.io/crosswalks.html) · [Architecture](https://ave.bawbel.io/architecture.html) · [Scoring](https://ave.bawbel.io/scoring.html) · [Scanner](https://github.com/bawbel/scanner)
 

--- a/crosswalks/ave-to-ast10.json
+++ b/crosswalks/ave-to-ast10.json
@@ -2,9 +2,9 @@
   "$schema": "https://ave.bawbel.io/schema/crosswalk-1.0.0.schema.json",
   "source": {
     "standard": "AVE",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "url": "https://ave.bawbel.io",
-    "record_count": 51
+    "record_count": 56
   },
   "target": {
     "tool": "OWASP Agentic Skills Top 10 (AST10)",
@@ -14,9 +14,9 @@
     "status": "OWASP Incubator project, incubated at OWASP Project Summit Oslo 2026",
     "checked_against_live_site": "2026-06-21"
   },
-  "generated": "2026-06-21",
-  "note": "Crosswalk from AVE behavioral vulnerability records to OWASP AST10 risk categories. Updated for the 51-record set (v1.1 migration added AVE-2026-00049, 00050, 00051). AST10 documents 10 categories of skill-layer risk at the principle level, each with a Critical/High/Medium severity rating; AVE provides 51 records at the level of individual behavioral classes with AIVSS v0.8 scores, detection layers, and indicators of compromise. This crosswalk is offered as a basis for collaboration, not as a competing taxonomy.",
-  "revision_note": "AST05 was retitled from 'Prompt Injection' to 'Unsafe Deserialization' between an earlier draft of this crosswalk and verification against the live site. Prompt-injection-as-mechanism is distributed across AST01 (prose instructions that hijack the agent) and AST03 (excess access weaponised by injection). This revision adds the 3 records from the v1.1 migration: AVE-2026-00049 (HTTP Host Header Injection / BadHost) maps to AST01 with a secondary AST06 angle; AVE-2026-00050 (Parasitic Toolchain) maps to AST06, extending the same weak-isolation reasoning already applied to AVE-2026-00046; AVE-2026-00051 (OAuth Discovery Rebinding) maps to AST04, since the vulnerability is in the server's own discovery metadata document.",
+  "generated": "2026-07-11",
+  "note": "Crosswalk from AVE behavioral vulnerability records to OWASP AST10 risk categories. Updated for the 56-record set (a 2026-07-10 research batch added AVE-2026-00052 through 00056). AST10 documents 10 categories of skill-layer risk at the principle level, each with a Critical/High/Medium severity rating; AVE provides 56 records at the level of individual behavioral classes with AIVSS v0.8 scores, detection layers, and indicators of compromise. This crosswalk is offered as a basis for collaboration, not as a competing taxonomy. Note: checked_against_live_site is unchanged from 2026-06-21 -- this update maps new AVE records against the previously-verified category descriptions, it does not re-verify AST10's site content.",
+  "revision_note": "AST05 was retitled from 'Prompt Injection' to 'Unsafe Deserialization' between an earlier draft of this crosswalk and verification against the live site. Prompt-injection-as-mechanism is distributed across AST01 (prose instructions that hijack the agent) and AST03 (excess access weaponised by injection). The 2026-06-21 revision added AVE-2026-00049/00050/00051 from the v1.1 migration. This revision adds AVE-2026-00054 (Code-Execution Sandbox Escape) to AST06 and AVE-2026-00055 (MCP STDIO Launch Configuration Injection) to AST02. AVE-2026-00052 and AVE-2026-00053 (tool/server implementation vulnerabilities -- CWE-78 and CWE-22 code bugs, not intentional malice or parse-time deserialization) and AVE-2026-00056 (zero-click rendered-content exfiltration) do not fit any existing AST10 category cleanly and are recorded in gaps_in_ast10 instead of forced into one.",
   "mappings": [
     {
       "ast_id": "AST01",
@@ -32,9 +32,9 @@
       "ast_title": "Supply Chain Compromise",
       "ast_severity": "Critical",
       "ast_description": "Registries without provenance let attackers mass-upload, take over accounts, and poison distribution channels.",
-      "ave_ids": ["AVE-2026-00001", "AVE-2026-00017", "AVE-2026-00024", "AVE-2026-00034"],
+      "ave_ids": ["AVE-2026-00001", "AVE-2026-00017", "AVE-2026-00024", "AVE-2026-00034", "AVE-2026-00055"],
       "primary_ave_id": "AVE-2026-00001",
-      "notes": "AVE-2026-00001 (metamorphic payload via external fetch) and AVE-2026-00034 (dynamic third-party skill import) map directly. AVE-2026-00024 adds a detection mechanism (Magika file-type mismatch) not currently specified in AST02."
+      "notes": "AVE-2026-00001 (metamorphic payload via external fetch) and AVE-2026-00034 (dynamic third-party skill import) map directly. AVE-2026-00024 adds a detection mechanism (Magika file-type mismatch) not currently specified in AST02. AVE-2026-00055 (MCP STDIO Launch Configuration Injection) added here: OX Security's own disclosure found 9 of 11 tested MCP registries accepted a malicious proof-of-concept submission with no review -- almost exactly AST02's 'registries without provenance let attackers mass-upload' framing, applied to the STDIO process-launch mechanism specifically rather than skill content."
     },
     {
       "ast_id": "AST03",
@@ -68,9 +68,9 @@
       "ast_title": "Weak Isolation",
       "ast_severity": "High",
       "ast_description": "Skills run in the agent's full security context -- with no sandbox, every skill is a potential full-system compromise.",
-      "ave_ids": ["AVE-2026-00036", "AVE-2026-00046", "AVE-2026-00050"],
+      "ave_ids": ["AVE-2026-00036", "AVE-2026-00046", "AVE-2026-00050", "AVE-2026-00054"],
       "primary_ave_id": "AVE-2026-00046",
-      "notes": "AVE-2026-00046 (MCP tool hook hijacking) is AVE's only CRITICAL-severity record and is a direct example of full-security-context abuse with no isolation boundary. AVE-2026-00036 (lateral movement) covers the consequence of weak isolation across systems. AVE-2026-00050 (Parasitic Toolchain) added here: the record's own description explicitly distinguishes it from AVE-2026-00046 by registration mechanism (local runtime registration vs external callback) but both share the same root cause -- the agent's tool dispatch layer has no boundary preventing a component from registering capabilities beyond its declared manifest scope. detection_layer=runtime and detection_stage=runtime_observed for both."
+      "notes": "AVE-2026-00046 (MCP tool hook hijacking) is AVE's only CRITICAL-severity record and is a direct example of full-security-context abuse with no isolation boundary. AVE-2026-00036 (lateral movement) covers the consequence of weak isolation across systems. AVE-2026-00050 (Parasitic Toolchain) added here: the record's own description explicitly distinguishes it from AVE-2026-00046 by registration mechanism (local runtime registration vs external callback) but both share the same root cause -- the agent's tool dispatch layer has no boundary preventing a component from registering capabilities beyond its declared manifest scope. detection_layer=runtime and detection_stage=runtime_observed for both. AVE-2026-00054 (Code-Execution Sandbox Escape) added here: AST06's description assumes no sandbox exists at all, whereas AVE-2026-00054 is a sandbox whose isolation boundary fails under a specific payload (JavaScript prototype-chain traversal) -- the starting architecture differs but the outcome (full-system compromise, no effective isolation) is identical, the same reasoning already applied to AVE-2026-00046 and AVE-2026-00050."
     },
     {
       "ast_id": "AST07",
@@ -152,15 +152,25 @@
     },
     {
       "topic": "AIVSS v0.8 quantitative scoring",
-      "ave_id": "all 51 records",
+      "ave_id": "all 56 records",
       "reason": "AST10 risks carry a qualitative severity label (Critical/High/Medium) per category. Every AVE record carries a full AIVSS v0.8 score (cvss_base, AARF ten-factor breakdown, aars, thm, mitigation_factor) at the individual-class level -- a finer-grained quantitative layer AST10 does not currently have per-record."
+    },
+    {
+      "topic": "Tool/server implementation vulnerabilities (code-level bugs in a tool's own handler)",
+      "ave_id": "AVE-2026-00052, AVE-2026-00053",
+      "reason": "AST01 assumes intentional malice ('skills that... hide credential stealers'); AST05 assumes parse-time payload execution ('at skill-load time -- before any user action'). Neither matches a legitimate, otherwise-useful tool whose own runtime parameter-handling code has an accidental CWE-78 (AVE-2026-00052, command injection) or CWE-22 (AVE-2026-00053, path traversal) bug, triggered by a tool-call parameter after the tool is already loaded and running. Both records trace to real, disclosed CVEs in legitimate MCP tool packages (gemini-mcp-tool, Zen MCP Server, tumf mcp-text-editor, Google's own MCP Toolbox for Databases), none malicious by design. This is a distinct mechanism AST10's current 10 categories do not yet name."
+    },
+    {
+      "topic": "Zero-click exfiltration via rendered-content auto-fetch",
+      "ave_id": "AVE-2026-00056",
+      "reason": "None of AST10's current 10 categories address data exfiltration specifically, the same reason 16 of AVE's original 51 records were already unmapped (exfiltration/disclosure classes sit closer to OWASP LLM/Agentic AI Top 10 territory). AVE-2026-00056's mechanism -- a markdown image reference whose client-side auto-fetch is itself the exfiltration channel, no tool call or obfuscation required -- traces to CVE-2025-32711 (EchoLeak), the first documented real-world zero-click prompt injection exploit in a production system."
     }
   ],
   "coverage": {
     "ast_categories_with_ave_mapping": 8,
     "ast_categories_without_ave_mapping": 2,
-    "ave_records_referenced": 35,
-    "ave_records_unmapped": 16,
-    "note_on_unmapped": "The 16 unmapped AVE records are mostly data-exfiltration, information-disclosure, and standalone prompt-injection classes (PII theft, covert channels, credential theft via instruction, system prompt leak, vision injection, MCP App UI injection) that sit closer to OWASP LLM Top 10 / Agentic AI Top 10 territory, or that AST10's current 10 categories do not yet have a dedicated slot for."
+    "ave_records_referenced": 37,
+    "ave_records_unmapped": 19,
+    "note_on_unmapped": "The 19 unmapped AVE records are mostly data-exfiltration, information-disclosure, and standalone prompt-injection classes (PII theft, covert channels, credential theft via instruction, system prompt leak, vision injection, MCP App UI injection, rendered-content auto-fetch exfiltration), plus the two new tool-implementation-vulnerability records (AVE-2026-00052, AVE-2026-00053) that don't cleanly fit any existing AST10 category -- see gaps_in_ast10."
   }
 }

--- a/crosswalks/ave-to-ast10.md
+++ b/crosswalks/ave-to-ast10.md
@@ -1,11 +1,13 @@
 # AVE → OWASP AST10 crosswalk
 
-**Source:** AVE v1.0.0 — 51 records
+**Source:** AVE v1.1.0 — 56 records
 **Target:** OWASP Agentic Skills Top 10 (AST10) — incubated at OWASP Project Summit, Oslo 2026
 **Target lead:** Ken Huang (also OWASP AIVSS lead)
-**Verified against live AST10 site:** 2026-06-21
+**Verified against live AST10 site:** 2026-06-21 (unchanged — this update maps new AVE
+records against the previously-verified category descriptions, it does not re-verify
+AST10's site content)
 
-This crosswalk maps AVE's 51 behavioral vulnerability records to the 10 risk categories
+This crosswalk maps AVE's 56 behavioral vulnerability records to the 10 risk categories
 in OWASP's AST10. It is offered as a basis for collaboration — AVE is not a competing
 taxonomy. AST10 documents risk at the principle level, each with a Critical/High/Medium
 severity rating; AVE adds individual behavioral classes with AIVSS v0.8 scores, detection
@@ -19,6 +21,10 @@ layers, and indicators of compromise underneath each principle.
 > AVE-2026-00049 (HTTP Host Header Injection / BadHost), AVE-2026-00050 (Parasitic
 > Toolchain), and AVE-2026-00051 (OAuth Discovery Rebinding) — each placed below with
 > reasoning, not by default.
+> - 2026-07-11: updated for the 56-record set. A 2026-07-10 research batch added five
+> records; two map cleanly (AVE-2026-00054 → AST06, AVE-2026-00055 → AST02) and three do
+> not fit any existing category (AVE-2026-00052, AVE-2026-00053, AVE-2026-00056) — see
+> "The 5 new records" below and the updated gaps table, rather than forced placements.
 
 ---
 
@@ -27,11 +33,11 @@ layers, and indicators of compromise underneath each principle.
 | AST | Title | Severity | AVE record count | AVE ids |
 |---|---|---|---|---|
 | AST01 | Malicious Skills | Critical | 10 | AVE-2026-00004, AVE-2026-00005, AVE-2026-00006, AVE-2026-00007, AVE-2026-00008, AVE-2026-00009, AVE-2026-00010, AVE-2026-00032, AVE-2026-00047, AVE-2026-00049 |
-| AST02 | Supply Chain Compromise | Critical | 4 | AVE-2026-00001, AVE-2026-00017, AVE-2026-00024, AVE-2026-00034 |
+| AST02 | Supply Chain Compromise | Critical | 5 | AVE-2026-00001, AVE-2026-00017, AVE-2026-00024, AVE-2026-00034, AVE-2026-00055 |
 | AST03 | Over-Privileged Skills | High | 9 | AVE-2026-00012, AVE-2026-00016, AVE-2026-00020, AVE-2026-00021, AVE-2026-00022, AVE-2026-00038, AVE-2026-00044, AVE-2026-00045, AVE-2026-00048 |
 | AST04 | Insecure Metadata | High | 4 | AVE-2026-00002, AVE-2026-00029, AVE-2026-00041, AVE-2026-00051 |
 | AST05 | Unsafe Deserialization | High | 2 | AVE-2026-00033, AVE-2026-00042 |
-| AST06 | Weak Isolation | High | 3 | AVE-2026-00036, AVE-2026-00046, AVE-2026-00050 |
+| AST06 | Weak Isolation | High | 4 | AVE-2026-00036, AVE-2026-00046, AVE-2026-00050, AVE-2026-00054 |
 | AST07 | Update Drift | Medium | 1 | AVE-2026-00001 |
 | AST08 | Poor Scanning | Medium | 0 | — (not an AVE behavioral class) |
 | AST09 | No Governance | Medium | 3 | AVE-2026-00019, AVE-2026-00027, AVE-2026-00031 |
@@ -72,6 +78,48 @@ new records.
 
 ---
 
+## The 5 new records (2026-07-10 batch) — where they landed and why
+
+Two map cleanly. Three do not, and are recorded as gaps rather than forced.
+
+### AVE-2026-00054 — Code-Execution Sandbox Escape → AST06
+
+AST06's description ("Skills run in the agent's full security context — with no sandbox")
+assumes no isolation boundary exists at all. AVE-2026-00054 is different in premise — a
+sandbox exists and is *supposed* to constrain the code — but a JavaScript prototype-chain
+traversal payload breaks that boundary, producing the identical outcome AST06 describes:
+full-system compromise, no effective isolation. Same reasoning already applied to
+AVE-2026-00046 and AVE-2026-00050.
+
+### AVE-2026-00055 — MCP STDIO Launch Configuration Injection → AST02
+
+A near-exact match to AST02's own description ("Registries without provenance let
+attackers mass-upload... and poison distribution channels"): the primary source (OX
+Security's disclosure) found 9 of 11 tested MCP registries accepted a malicious
+proof-of-concept submission with no review at all.
+
+### AVE-2026-00052 and AVE-2026-00053 — do not fit; new gap
+
+AVE-2026-00052 (Tool Implementation Command Injection) and AVE-2026-00053 (Resource Path
+Traversal) are both accidental code-level bugs (CWE-78 and CWE-22 respectively) in an
+otherwise-legitimate tool's own parameter-handling logic, triggered by a tool-call
+parameter *after* the tool is already loaded and running. Neither existing category fits:
+AST01 assumes intentional malice ("hide credential stealers"); AST05 assumes payload
+execution "at skill-load time — before any user action," which is a parse-time framing
+these two records don't match (both fire at runtime, via a normal tool call). Both records
+trace to real, disclosed CVEs in legitimate MCP tool packages (gemini-mcp-tool, Zen MCP
+Server, tumf mcp-text-editor, Google's own MCP Toolbox for Databases) — none malicious by
+design. Recorded in the gaps table below rather than squeezed into AST01 or AST05.
+
+### AVE-2026-00056 — does not fit; new gap
+
+Zero-click exfiltration via rendered-content auto-fetch (the EchoLeak mechanism) is a data
+exfiltration class, and none of AST10's 10 categories address exfiltration specifically —
+the same reason 16 of AVE's original 51 records were already unmapped. Recorded in the
+gaps table rather than forced into an adjacent category.
+
+---
+
 ## Where AVE adds the most granularity
 
 **AST01 — Malicious Skills** now maps to 10 distinct AVE records, the largest single
@@ -85,7 +133,7 @@ prompt injection as the exploit mechanism for excess access — AVE-2026-00016 (
 injection), AVE-2026-00020 (A2A injection), and AVE-2026-00044 (async task poisoning) are
 each a distinct injection technique that specifically exploits over-broad access.
 
-**AST06 — Weak Isolation** now maps to 3 records including AVE's only CRITICAL-severity
+**AST06 — Weak Isolation** now maps to 4 records including AVE's only CRITICAL-severity
 record (AVE-2026-00046, AIVSS 9.2).
 
 **AST05 — Unsafe Deserialization**, under its corrected definition, maps to only 2 AVE
@@ -103,7 +151,9 @@ records — a narrow, exact-fit category rather than a catch-all.
 | HTTP Host header injection (BadHost) | AVE-2026-00049 | No AST category specifically names header-level request tampering as a distinct mechanism. AST01's general 'hidden capability' framing covers it but doesn't name the transport-layer vector. |
 | Parasitic toolchain / silent tool registration | AVE-2026-00050 | AST06 covers the general isolation failure; AVE-2026-00050 isolates the specific mechanism of runtime tool registration outside the declared manifest, distinct from AVE-2026-00046's external-callback hijacking. |
 | OAuth discovery rebinding | AVE-2026-00051 | AST04 covers metadata validation generally; AVE-2026-00051 isolates the specific RFC 8414 / OIDC discovery document poisoning pattern, which is protocol-specific and not named in AST04's description. |
-| AIVSS v0.8 quantitative scoring | all 51 records | AST10 risks carry a qualitative severity label (Critical/High/Medium) per category. Every AVE record carries a full AIVSS v0.8 score (cvss_base, AARF ten-factor breakdown, aars, thm, mitigation_factor) at the individual-class level -- a finer-grained quantitative layer AST10 does not currently have per-record. |
+| Tool/server implementation vulnerabilities | AVE-2026-00052, AVE-2026-00053 | Accidental CWE-78/CWE-22 code bugs in a legitimate tool's own runtime parameter handling, distinct from AST01's intentional-malice framing and AST05's parse-time-deserialization framing. Both trace to real disclosed CVEs in legitimate MCP tool packages. |
+| Zero-click rendered-content exfiltration | AVE-2026-00056 | No AST10 category addresses data exfiltration specifically. Traces to CVE-2025-32711 (EchoLeak), the first documented real-world zero-click prompt injection exploit in a production system. |
+| AIVSS v0.8 quantitative scoring | all 56 records | AST10 risks carry a qualitative severity label (Critical/High/Medium) per category. Every AVE record carries a full AIVSS v0.8 score (cvss_base, AARF ten-factor breakdown, aars, thm, mitigation_factor) at the individual-class level -- a finer-grained quantitative layer AST10 does not currently have per-record. |
 
 ---
 
@@ -121,10 +171,10 @@ records — a narrow, exact-fit category rather than a catch-all.
 | | |
 |---|---|
 | AST categories with an AVE mapping | 8 of 10 |
-| AVE records referenced | 35 of 51 |
-| AVE records unmapped to AST10 | 16 |
+| AVE records referenced | 37 of 56 |
+| AVE records unmapped to AST10 | 19 |
 
-The 16 unmapped AVE records are mostly data-exfiltration, information-disclosure, and standalone prompt-injection classes (PII theft, covert channels, credential theft via instruction, system prompt leak, vision injection, MCP App UI injection) that sit closer to OWASP LLM Top 10 / Agentic AI Top 10 territory, or that AST10's current 10 categories do not yet have a dedicated slot for.
+The 19 unmapped AVE records are mostly data-exfiltration, information-disclosure, and standalone prompt-injection classes (PII theft, covert channels, credential theft via instruction, system prompt leak, vision injection, MCP App UI injection, rendered-content auto-fetch exfiltration), plus the two new tool-implementation-vulnerability records (AVE-2026-00052, AVE-2026-00053) that don't cleanly fit any existing AST10 category — see "What AVE has that AST10 does not yet have" above.
 
 ---
 

--- a/crosswalks/ave-to-owasp-mcp.md
+++ b/crosswalks/ave-to-owasp-mcp.md
@@ -1,8 +1,8 @@
 # AVE → OWASP MCP Top 10 crosswalk
 
-All 48 AVE records mapped to OWASP MCP Top 10 categories.
+All 56 AVE records mapped to OWASP MCP Top 10 categories.
 
-**AVE records:** 48
+**AVE records:** 56
 **OWASP MCP Top 10:** Beta 2025 (MCP01:2025 – MCP10:2025)
 **AIVSS spec:** v0.8
 **Reference:** https://owasp.org/www-project-mcp-top-10/
@@ -31,105 +31,121 @@ category, gap analysis against existing controls, and audit reporting.
 
 ## Full mapping
 
+Generated directly from each record's `owasp_mcp` field -- do not hand-edit this
+table; regenerate it if records change.
+
 | AVE ID | Title | AIVSS | Severity | Primary | Secondary |
 |---|---|---|---|---|---|
-| AVE-2026-00001 | External instruction fetch (metamorphic payload) | 8.0 | HIGH | MCP04 | MCP06 |
-| AVE-2026-00002 | MCP tool description injection | 7.3 | HIGH | MCP03 | MCP10 |
+| AVE-2026-00001 | Metamorphic payload via external config fetch | 8 | HIGH | MCP04 | MCP06 |
+| AVE-2026-00002 | MCP tool description behavioral injection | 7.3 | HIGH | MCP03 | MCP10 |
 | AVE-2026-00003 | Credential exfiltration via agent instruction | 6.8 | MEDIUM | MCP01 | MCP05 |
-| AVE-2026-00004 | Shell pipe injection pattern | 5.9 | MEDIUM | MCP05 | MCP06 |
-| AVE-2026-00005 | Destructive command execution | 5.6 | MEDIUM | MCP05 | |
-| AVE-2026-00006 | Cryptocurrency drain attack | 7.5 | HIGH | MCP05 | MCP02 |
-| AVE-2026-00007 | Goal override instruction | 6.1 | MEDIUM | MCP06 | |
-| AVE-2026-00008 | Persistence and self-replication | 6.3 | MEDIUM | MCP05 | MCP04 |
-| AVE-2026-00009 | Jailbreak instruction | 5.5 | MEDIUM | MCP06 | |
-| AVE-2026-00010 | Hidden instruction concealment | 5.6 | MEDIUM | MCP06 | MCP08 |
-| AVE-2026-00011 | Dynamic tool call injection | 5.7 | MEDIUM | MCP03 | MCP05 |
-| AVE-2026-00012 | Permission escalation via false claim | 4.5 | MEDIUM | MCP02 | MCP07 |
-| AVE-2026-00013 | PII exfiltration pattern | 6.5 | MEDIUM | MCP01 | MCP05 |
-| AVE-2026-00014 | Trust escalation — false authority claim | 3.7 | LOW | MCP07 | MCP09 |
-| AVE-2026-00015 | System prompt extraction | 4.9 | MEDIUM | MCP10 | MCP08 |
-| AVE-2026-00016 | Indirect RAG prompt injection | 6.4 | MEDIUM | MCP10 | MCP03 |
-| AVE-2026-00017 | MCP server impersonation | 5.7 | MEDIUM | MCP09 | MCP07 |
-| AVE-2026-00018 | Tool result manipulation | 4.4 | MEDIUM | MCP03 | MCP08 |
-| AVE-2026-00019 | Agent memory poisoning | 5.6 | MEDIUM | MCP10 | MCP06 |
-| AVE-2026-00020 | Cross-agent A2A injection | 5.9 | MEDIUM | MCP10 | MCP06 |
-| AVE-2026-00021 | Autonomous action without confirmation | 4.5 | MEDIUM | MCP02 | MCP08 |
-| AVE-2026-00022 | Scope creep — undeclared resource access | 6.0 | MEDIUM | MCP02 | |
-| AVE-2026-00023 | Context window manipulation | 5.8 | MEDIUM | MCP10 | MCP06 |
-| AVE-2026-00024 | Content type mismatch — supply chain | 6.8 | MEDIUM | MCP04 | |
-| AVE-2026-00025 | Conversation history injection | 4.5 | MEDIUM | MCP10 | MCP06 |
-| AVE-2026-00026 | Tool output exfiltration encoding | 6.8 | MEDIUM | MCP01 | MCP08 |
-| AVE-2026-00027 | Multi-turn attack persistence | 5.6 | MEDIUM | MCP06 | MCP10 |
-| AVE-2026-00028 | File prompt injection | 5.9 | MEDIUM | MCP10 | MCP03 |
-| AVE-2026-00029 | Homoglyph and Unicode obfuscation | 4.8 | MEDIUM | MCP03 | MCP04 |
-| AVE-2026-00030 | Role claim privilege escalation | 4.3 | MEDIUM | MCP07 | MCP02 |
-| AVE-2026-00031 | Feedback and training loop poisoning | 5.4 | MEDIUM | MCP06 | MCP04 |
-| AVE-2026-00032 | Network reconnaissance instruction | 4.0 | MEDIUM | MCP05 | MCP02 |
-| AVE-2026-00033 | Unsafe deserialization and eval | 4.2 | MEDIUM | MCP05 | MCP04 |
-| AVE-2026-00034 | Supply chain skill import | 6.6 | MEDIUM | MCP04 | MCP03 |
-| AVE-2026-00035 | Environment and sensor data manipulation | 4.2 | MEDIUM | MCP03 | MCP08 |
-| AVE-2026-00036 | Lateral movement — pivot to other systems | 5.9 | MEDIUM | MCP05 | MCP02 |
-| AVE-2026-00037 | Vision prompt injection via image | 5.1 | MEDIUM | MCP10 | MCP03 |
-| AVE-2026-00038 | Excessive agency — unbounded tool use | 5.9 | MEDIUM | MCP02 | MCP08 |
-| AVE-2026-00039 | Covert channel — steganographic exfil | 4.9 | MEDIUM | MCP01 | MCP08 |
-| AVE-2026-00040 | Insecure output injection | 5.4 | MEDIUM | MCP05 | MCP10 |
-| AVE-2026-00041 | MCP server-card injection | 8.2 | HIGH | MCP03 | MCP09 |
-| AVE-2026-00042 | REPL code mode payload injection | 4.7 | MEDIUM | MCP05 | MCP10 |
-| AVE-2026-00043 | MCP app UI injection | 4.7 | MEDIUM | MCP03 | MCP10 |
-| AVE-2026-00044 | Async task result poisoning | 6.1 | MEDIUM | MCP06 | MCP10 |
-| AVE-2026-00045 | Cross-app-access escalation | 6.4 | MEDIUM | MCP02 | MCP07 |
-| AVE-2026-00046 | MCP tool hook hijacking | 9.1 | CRITICAL | MCP03 | MCP07 |
-| AVE-2026-00047 | Hardcoded credentials in agent component | 7.8 | HIGH | MCP01 | MCP07 |
-| AVE-2026-00048 | Unsafe agent delegation chain | 8.2 | HIGH | MCP03 | MCP07 |
+| AVE-2026-00004 | Arbitrary code execution via shell pipe injection in agentic c... | 5.9 | MEDIUM | MCP01 | MCP03 |
+| AVE-2026-00005 | Recursive file system destruction via destructive command inje... | 5.6 | MEDIUM | MCP02 | MCP07 |
+| AVE-2026-00006 | Cryptocurrency wallet drain via malicious fund transfer instru... | 7.5 | HIGH | MCP01 |  |
+| AVE-2026-00007 | Agent goal hijack via direct instruction override in agentic c... | 6.1 | MEDIUM | MCP01 | MCP03 |
+| AVE-2026-00008 | Agent persistence via self-replication instruction in agentic ... | 6.3 | MEDIUM | MCP04 | MCP08 |
+| AVE-2026-00009 | AI identity jailbreak via role-play or persona override in age... | 5.5 | MEDIUM | MCP01 | MCP03 |
+| AVE-2026-00010 | Covert instruction concealment via secrecy directive in agenti... | 5.6 | MEDIUM | MCP01 | MCP03 |
+| AVE-2026-00011 | Arbitrary tool invocation via dynamic tool call injection in a... | 5.7 | MEDIUM | MCP01 |  |
+| AVE-2026-00012 | Capability escalation via false permission grant in agentic co... | 4.5 | MEDIUM | MCP09 | MCP10 |
+| AVE-2026-00013 | Personal data exfiltration via PII collection and transmission... | 6.5 | MEDIUM | MCP05 | MCP06 |
+| AVE-2026-00014 | False authority claim via trust escalation impersonation in ag... | 3.7 | LOW | MCP09 | MCP10 |
+| AVE-2026-00015 | System prompt extraction via direct interrogation instruction ... | 4.9 | MEDIUM | MCP06 |  |
+| AVE-2026-00016 | Indirect Prompt Injection via RAG Retrieval | 6.4 | MEDIUM | MCP10 | MCP03 |
+| AVE-2026-00017 | MCP Server Impersonation or Spoofing | 5.7 | MEDIUM | MCP09 | MCP07 |
+| AVE-2026-00018 | Tool Result Manipulation or Output Poisoning | 4.4 | MEDIUM | MCP03 | MCP08 |
+| AVE-2026-00019 | Agent Memory Poisoning | 5.6 | MEDIUM | MCP10 | MCP06 |
+| AVE-2026-00020 | Cross-Agent Prompt Injection (A2A) | 5.9 | MEDIUM | MCP10 | MCP06 |
+| AVE-2026-00021 | Autonomous Action Without User Confirmation | 4.5 | MEDIUM | MCP02 | MCP08 |
+| AVE-2026-00022 | Scope Creep - Accessing Undeclared Resources | 6 | MEDIUM | MCP02 |  |
+| AVE-2026-00023 | Model Context Window Manipulation | 5.8 | MEDIUM | MCP10 | MCP06 |
+| AVE-2026-00024 | Supply Chain - Content Type Mismatch (Magika) | 6.8 | MEDIUM | MCP04 |  |
+| AVE-2026-00025 | Conversation History Injection | 4.5 | MEDIUM | MCP10 | MCP06 |
+| AVE-2026-00026 | Exfiltration via Tool Output Encoding | 6.8 | MEDIUM | MCP01 | MCP08 |
+| AVE-2026-00027 | Multi-Turn Attack - Instruction Persistence Across Conversations | 5.6 | MEDIUM | MCP06 | MCP10 |
+| AVE-2026-00028 | Prompt Injection via File or Document Content | 5.9 | MEDIUM | MCP10 | MCP03 |
+| AVE-2026-00029 | Homoglyph or Unicode Obfuscation Attack | 4.8 | MEDIUM | MCP03 | MCP04 |
+| AVE-2026-00030 | Privilege Escalation via False Role Claim | 4.3 | MEDIUM | MCP07 | MCP02 |
+| AVE-2026-00031 | Training Data or Feedback Loop Poisoning | 5.4 | MEDIUM | MCP06 | MCP04 |
+| AVE-2026-00032 | Network Reconnaissance Instruction | 4 | MEDIUM | MCP05 | MCP02 |
+| AVE-2026-00033 | Unsafe Deserialization or Eval Instruction | 4.2 | MEDIUM | MCP05 | MCP04 |
+| AVE-2026-00034 | Supply Chain - Dynamic Third-Party Skill Import | 6.6 | MEDIUM | MCP04 | MCP03 |
+| AVE-2026-00035 | Environment or Sensor Data Manipulation | 4.2 | MEDIUM | MCP03 | MCP08 |
+| AVE-2026-00036 | Lateral Movement - Pivot to Other Systems | 5.9 | MEDIUM | MCP05 | MCP02 |
+| AVE-2026-00037 | Prompt Injection via Image or Vision Input | 5.1 | MEDIUM | MCP10 | MCP03 |
+| AVE-2026-00038 | Excessive Agency - Unbounded Tool Use or Sub-Agent Spawning | 5.9 | MEDIUM | MCP02 | MCP08 |
+| AVE-2026-00039 | Covert Channel - Steganographic Data Exfiltration | 4.9 | MEDIUM | MCP01 | MCP08 |
+| AVE-2026-00040 | Insecure Output - Unescaped Injection into Downstream System | 5.4 | MEDIUM | MCP05 | MCP10 |
+| AVE-2026-00041 | Prompt injection via MCP server-card tool descriptions before ... | 8.2 | HIGH | MCP03 | MCP09 |
+| AVE-2026-00042 | Payload injection into agent-generated orchestration code via ... | 4.7 | MEDIUM | MCP05 | MCP10 |
+| AVE-2026-00043 | Prompt injection via rich UI payload (canvas, artifact, form) ... | 4.7 | MEDIUM | MCP03 | MCP10 |
+| AVE-2026-00044 | Prompt injection via poisoned async task result injected into ... | 6.1 | MEDIUM | MCP06 | MCP10 |
+| AVE-2026-00045 | Privilege escalation via cross-app-access - pivot from low-tru... | 6.4 | MEDIUM | MCP02 | MCP07 |
+| AVE-2026-00046 | MCP tool hook hijacking - redirect tool execution to attacker-... | 9.2 | CRITICAL | MCP03 | MCP06 |
+| AVE-2026-00047 | Hardcoded credentials in agent component - API keys and secret... | 7.6 | HIGH | MCP02 | MCP09 |
+| AVE-2026-00048 | Unsafe agent delegation chain - sub-agent spawned with inherit... | 7.7 | HIGH | MCP03 | MCP07 |
+| AVE-2026-00049 | HTTP Host Header Injection via Agent-Initiated Request (BadHost) | 7.2 | HIGH | MCP04 | MCP05 |
+| AVE-2026-00050 | Parasitic Toolchain — Silent Tool Registration and Persistent ... | 7.2 | HIGH | MCP04 | MCP07 |
+| AVE-2026-00051 | OAuth Discovery Rebinding — Authorization Endpoint Redirected ... | 7.2 | HIGH | MCP01 | MCP07 |
+| AVE-2026-00052 | Command injection via unsanitized tool-call parameter in MCP s... | 7.5 | HIGH | MCP05 | MCP04 |
+| AVE-2026-00053 | Path traversal via unsanitized path parameter in MCP resource/... | 6.3 | MEDIUM | MCP02 | MCP07 |
+| AVE-2026-00054 | Code-execution sandbox escape via JavaScript prototype-chain t... | 6.7 | MEDIUM | MCP05 | MCP07 |
+| AVE-2026-00055 | Command execution via untrusted MCP server launch configuratio... | 7.7 | HIGH | MCP05 | MCP04 |
+| AVE-2026-00056 | Zero-click data exfiltration via markdown image auto-fetch in ... | 5.8 | MEDIUM | MCP10 | MCP08 |
 
 ---
 
 ## By OWASP MCP category
 
 ### MCP01 — Token Mismanagement and Secret Exposure
-AVE-2026-00003, AVE-2026-00013, AVE-2026-00026, AVE-2026-00039,
-AVE-2026-00047
+AVE-2026-00003, AVE-2026-00004, AVE-2026-00006, AVE-2026-00007,
+AVE-2026-00009, AVE-2026-00010, AVE-2026-00011, AVE-2026-00026,
+AVE-2026-00039, AVE-2026-00051
 
 ### MCP02 — Privilege Escalation via Scope Creep
-AVE-2026-00006, AVE-2026-00008, AVE-2026-00012, AVE-2026-00021,
-AVE-2026-00022, AVE-2026-00030, AVE-2026-00032, AVE-2026-00036,
-AVE-2026-00038, AVE-2026-00045
+AVE-2026-00005, AVE-2026-00021, AVE-2026-00022, AVE-2026-00030,
+AVE-2026-00032, AVE-2026-00036, AVE-2026-00038, AVE-2026-00045,
+AVE-2026-00047, AVE-2026-00053
 
 ### MCP03 — Tool Poisoning
-AVE-2026-00002, AVE-2026-00011, AVE-2026-00016, AVE-2026-00018,
+AVE-2026-00002, AVE-2026-00004, AVE-2026-00007, AVE-2026-00009,
+AVE-2026-00010, AVE-2026-00016, AVE-2026-00018, AVE-2026-00028,
 AVE-2026-00029, AVE-2026-00034, AVE-2026-00035, AVE-2026-00037,
 AVE-2026-00041, AVE-2026-00043, AVE-2026-00046, AVE-2026-00048
 
 ### MCP04 — Software Supply Chain Attacks
 AVE-2026-00001, AVE-2026-00008, AVE-2026-00024, AVE-2026-00029,
-AVE-2026-00031, AVE-2026-00033, AVE-2026-00034
+AVE-2026-00031, AVE-2026-00033, AVE-2026-00034, AVE-2026-00049,
+AVE-2026-00050, AVE-2026-00052, AVE-2026-00055
 
 ### MCP05 — Command Injection and Execution
-AVE-2026-00003, AVE-2026-00004, AVE-2026-00005, AVE-2026-00006,
-AVE-2026-00008, AVE-2026-00011, AVE-2026-00013, AVE-2026-00032,
-AVE-2026-00033, AVE-2026-00036, AVE-2026-00040, AVE-2026-00042
+AVE-2026-00003, AVE-2026-00013, AVE-2026-00032, AVE-2026-00033,
+AVE-2026-00036, AVE-2026-00040, AVE-2026-00042, AVE-2026-00049,
+AVE-2026-00052, AVE-2026-00054, AVE-2026-00055
 
 ### MCP06 — Intent Flow Subversion
-AVE-2026-00001, AVE-2026-00004, AVE-2026-00007, AVE-2026-00009,
-AVE-2026-00010, AVE-2026-00019, AVE-2026-00020, AVE-2026-00023,
-AVE-2026-00025, AVE-2026-00027, AVE-2026-00031, AVE-2026-00044
+AVE-2026-00001, AVE-2026-00013, AVE-2026-00015, AVE-2026-00019,
+AVE-2026-00020, AVE-2026-00023, AVE-2026-00025, AVE-2026-00027,
+AVE-2026-00031, AVE-2026-00044, AVE-2026-00046
 
 ### MCP07 — Insufficient Authentication and Authorization
-AVE-2026-00012, AVE-2026-00014, AVE-2026-00017, AVE-2026-00030,
-AVE-2026-00045, AVE-2026-00046, AVE-2026-00047, AVE-2026-00048
+AVE-2026-00005, AVE-2026-00017, AVE-2026-00030, AVE-2026-00045,
+AVE-2026-00048, AVE-2026-00050, AVE-2026-00051, AVE-2026-00053,
+AVE-2026-00054
 
 ### MCP08 — Lack of Audit and Telemetry
-AVE-2026-00010, AVE-2026-00015, AVE-2026-00018, AVE-2026-00021,
-AVE-2026-00026, AVE-2026-00035, AVE-2026-00038, AVE-2026-00039
+AVE-2026-00008, AVE-2026-00018, AVE-2026-00021, AVE-2026-00026,
+AVE-2026-00035, AVE-2026-00038, AVE-2026-00039, AVE-2026-00056
 
 ### MCP09 — Shadow MCP Servers
-AVE-2026-00014, AVE-2026-00017, AVE-2026-00041
+AVE-2026-00012, AVE-2026-00014, AVE-2026-00017, AVE-2026-00041,
+AVE-2026-00047
 
 ### MCP10 — Context Injection and Over-sharing
-AVE-2026-00002, AVE-2026-00015, AVE-2026-00016, AVE-2026-00019,
-AVE-2026-00020, AVE-2026-00023, AVE-2026-00025, AVE-2026-00027,
-AVE-2026-00028, AVE-2026-00037, AVE-2026-00040, AVE-2026-00042,
-AVE-2026-00043, AVE-2026-00044
+AVE-2026-00002, AVE-2026-00012, AVE-2026-00014, AVE-2026-00016,
+AVE-2026-00019, AVE-2026-00020, AVE-2026-00023, AVE-2026-00025,
+AVE-2026-00027, AVE-2026-00028, AVE-2026-00037, AVE-2026-00040,
+AVE-2026-00042, AVE-2026-00043, AVE-2026-00044, AVE-2026-00056
 
 ---
 
@@ -138,9 +154,9 @@ AVE-2026-00043, AVE-2026-00044
 | Severity | AIVSS | Count |
 |---|---|---|
 | CRITICAL | >= 9.0 | 1 |
-| HIGH | 7.0–8.9 | 6 |
-| MEDIUM | 4.0–6.9 | 39 |
-| LOW | < 4.0 | 2 |
+| HIGH | 7.0–8.9 | 11 |
+| MEDIUM | 4.0–6.9 | 43 |
+| LOW | < 4.0 | 1 |
 
 ---
 

--- a/crosswalks/clawscan-to-ave.json
+++ b/crosswalks/clawscan-to-ave.json
@@ -10,12 +10,12 @@
   },
   "target": {
     "standard": "AVE",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "url": "https://ave.bawbel.io",
-    "record_count": 51
+    "record_count": 56
   },
-  "generated": "2026-06-21",
-  "note": "Crosswalk from ClawScan's 7 analyzer modules and their rule IDs to AVE behavioral class ids. Updated for the 51-record set (v1.1 migration added AVE-2026-00049, 00050, 00051). Rule IDs sourced from ClawScan live scan output and documentation at clawscan.dev. Gaps indicate behavioral classes covered by ClawScan that AVE does not yet enumerate.",
+  "generated": "2026-07-12",
+  "note": "Crosswalk from ClawScan's 7 analyzer modules and their rule IDs to AVE behavioral class ids. Rule-level mappings below were last checked against ClawScan's live scan output and documentation on 2026-06-21 and reflect the 51-record set current at that time. AVE-2026-00052 through 00056 (added 2026-07-10) are not yet reflected in the mappings or gaps below -- that requires re-checking ClawScan's actual rule catalog, which this repo does not have live access to; the AVE side of that recheck (target.record_count) is updated, the ClawScan side is not. Gaps indicate behavioral classes covered by ClawScan that AVE does not yet enumerate.",
   "mappings": [
     {
       "clawscan_module": "prompt-injection",

--- a/crosswalks/skillspector-to-ave.json
+++ b/crosswalks/skillspector-to-ave.json
@@ -11,12 +11,12 @@
   },
   "target": {
     "standard": "AVE",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "url": "https://ave.bawbel.io",
-    "record_count": 51
+    "record_count": 56
   },
-  "generated": "2026-06-21",
-  "note": "Crosswalk from SkillSpector's 16 scanner categories to AVE behavioral class ids. Updated for the 51-record set (v1.1 migration added AVE-2026-00049, 00050, 00051). SkillSpector organises detection as an internal scanner taxonomy; AVE is a behavioral standard. Some SkillSpector categories are scanner mechanics (YARA signatures, taint tracking, AST analysis) rather than vulnerability classes -- these are marked as no_ave_class with an explanation. Gaps indicate behavioral classes that AVE does not yet enumerate.",
+  "generated": "2026-07-12",
+  "note": "Crosswalk from SkillSpector's 16 scanner categories to AVE behavioral class ids. Rule-level mappings below were last checked against SkillSpector 2.0.0's category/pattern documentation on 2026-06-21 and reflect the 51-record set current at that time. AVE-2026-00052 through 00056 (added 2026-07-10) are not yet reflected in the mappings or gaps below -- that requires re-checking SkillSpector's actual category catalog, which this repo does not have live access to; the AVE side of that recheck (target.record_count) is updated, the SkillSpector side is not. SkillSpector organises detection as an internal scanner taxonomy; AVE is a behavioral standard. Some SkillSpector categories are scanner mechanics (YARA signatures, taint tracking, AST analysis) rather than vulnerability classes -- these are marked as no_ave_class with an explanation. Gaps indicate behavioral classes that AVE does not yet enumerate.",
   "mappings": [
     {
       "skillspector_category": "prompt_injection",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "bawbel-ave"
@@ -11,8 +11,23 @@ requires-python = ">=3.11"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "pytest-cov>=5.0",
     "jsonschema>=4.23",
 ]
 
+# Not a Python library -- nothing here imports "bawbel_ave" as a package.
+# scripts/ are run directly (python scripts/foo.py) and tests/ load rule
+# files dynamically. This pyproject.toml exists for dependency and pytest
+# config only, so tell setuptools there's no package to discover/build.
+[tool.setuptools]
+packages = []
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.coverage.run]
+# Scoped to rules/ deliberately: that's the code pytest's fixture-driven tests
+# actually exercise (CLAUDE.md's TDD loop). scripts/ holds one-time migration
+# and validation tooling that isn't meant to carry unit-test coverage in the
+# same sense -- validate_records.py's "test" is that it validates every record.
+source = ["rules"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bawbel-ave"
-version = "1.1.0"
+version = "1.2.0"
 description = "AVE — Agentic Vulnerability Enumeration standard"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
## Summary

Phase 0 (verifiable hygiene) from `TRUST_STRATEGY.md`, plus crosswalk updates for the 5 records merged in #37.

**CI / security scanning** (none of this existed before):
- `.github/workflows/tests.yml` -- runs the full validate/fixtures/rule-coverage/pytest sequence with coverage (`--cov=rules --cov-fail-under=95`) on every PR/push to main/develop. Previously nothing in CI actually ran the test suite.
- `.github/workflows/codeql.yml` -- CodeQL for Python and JavaScript, on PRs plus a weekly schedule
- `.github/dependabot.yml` + `.github/workflows/dependency-review.yml` -- Dependabot files version-update PRs; `dependency-review-action` is what actually blocks a PR introducing a moderate+ severity vulnerable dependency
- `.github/workflows/secret-scan.yml` + `.gitleaks.toml` -- gitleaks on every PR/push, with an allowlist for `tests/fixtures/` (AVE's positive fixtures intentionally contain credential-shaped strings as detection-rule test data, e.g. AVE-2026-00047 -- without the allowlist this would false-positive on every PR touching that record)
- `.github/workflows/scorecard.yml` -- OpenSSF Scorecard, publishes results automatically once merged to `main`
- Enabled natively via the GitHub API (repo settings, not files): secret scanning, secret scanning push protection, Dependabot security updates -- all were disabled
- README: 8 new badges (Tests, Coverage, CodeQL, Dependency Review, Secret Scan, Scorecard, Security Policy, Code of Conduct), records badge corrected 51 → 56

**Two pre-existing packaging bugs found and fixed** while building the tests workflow (verified against a genuinely clean venv, not just my dev environment):
1. `build-backend = "setuptools.backends.legacy:build"` is not a valid backend -- fixed to `setuptools.build_meta`
2. With that fixed, setuptools' automatic package discovery then failed outright, because this repo isn't a Python library (nothing imports `bawbel_ave`; scripts run directly, tests load rule files dynamically). Added `[tool.setuptools] packages = []`.

Both bugs meant `pip install -e ".[dev]"` -- the exact command CONTRIBUTING.md and CLAUDE.md tell contributors to run -- was already broken on a clean machine, independent of anything added in this PR.

**Crosswalk updates:**
- `ave-to-owasp-mcp.md`: was stale (missing AVE-2026-00049-00051 *and* 00052-00056) and, on closer inspection, had drifted from the records themselves for several existing entries (e.g. AVE-2026-00004 was hand-listed under the wrong categories). Regenerated the whole file programmatically from each record's actual `owasp_mcp` field rather than patching it, added a note saying so.
- `ave-to-ast10.json` / `.md`: classified each of the 5 new records (AVE-2026-00052-00056) against AST10's actual category descriptions, not just titles. Two map cleanly -- AVE-2026-00054 (Sandbox Escape) → AST06, AVE-2026-00055 (STDIO Launch Config Injection) → AST02. Three do **not** fit any existing category and are recorded as new gaps rather than forced: AVE-2026-00052/00053 are accidental code-level bugs (CWE-78/CWE-22), which matches neither AST01's intentional-malice framing nor AST05's parse-time-deserialization framing; AVE-2026-00056 is data exfiltration, which none of AST10's 10 categories address. Coverage recomputed and cross-checked between the JSON and MD files (37/56 records referenced, was 35/51).
- `clawscan-to-ave.json` / `skillspector-to-ave.json` checked and left untouched -- these key off the external tools' own rule catalogs, which aren't visible to this repo; adding entries would mean inventing facts about tools this repo doesn't control.

## Not done, needs a human

OpenSSF Best Practices Badge (bestpractices.dev) requires interactive account signup and ~40 self-certification questions -- can't be completed via API/CLI. Most of the underlying criteria are already satisfied by what's in this repo (LICENSE, SECURITY.md, CONTRIBUTING.md, tests, HTTPS delivery).

## Test plan

- [x] `python scripts/validate_records.py` -- all 56 records valid
- [x] `pytest tests/ -x -q` -- 112 passed
- [x] `.gitleaks.toml` verified: no false-positives on `tests/fixtures/`, still catches real secret patterns elsewhere
- [x] `pip install -e ".[dev]"` verified end-to-end in a from-scratch virtualenv (not just the dev environment that already had things cached)
- [x] JSON/MD crosswalk numbers cross-checked to agree exactly
- [ ] First live run of each new workflow, once this PR is open against `develop` (can't fully verify GitHub Actions execution from local `gh`/git alone)