### PR TITLE
fix: remove bawbel-scanner install boilerplate from AVE-2026-00024

### DIFF
--- a/records/AVE-2026-00024.json
+++ b/records/AVE-2026-00024.json
@@ -4,7 +4,7 @@
   "component_type": "mcp_server",
   "title": "Supply Chain - Content Type Mismatch (Magika)",
   "attack_class": "Supply Chain - Content Type Mismatch",
-  "description": "This record covers supply chain attacks where an executable payload is disguised as a skill file (`.md`, `.yaml`, `.json`, `.txt`). Unlike all other AVE records which are detected by text pattern matching, this record is detected exclusively by the **Magika engine (Stage 0)** - Google's ML-based file type classifier - because the file contains no readable text instructions to match against. Detection requires a Magika-integrated scanning tool (bawbel-scanner is one implementation: `pip install \"bawbel-scanner[magika]\"`).",
+  "description": "This record covers supply chain attacks where an executable payload is disguised as a skill file (`.md`, `.yaml`, `.json`, `.txt`). Unlike all other AVE records which are detected by text pattern matching, this record is detected exclusively by the **Magika engine (Stage 0)** - Google's ML-based file type classifier - because the file contains no readable text instructions to match against. Detection requires a scanning tool integrated with Magika or an equivalent ML-based file type classifier.",
   "affected_platforms": [
     "any-mcp-client",
     "claude-desktop"
@@ -81,13 +81,13 @@
     "spec_version": "0.8",
     "notes": "AARF scores based on typical deployment of mcp components in agentic workflows."
   },
-  "remediation": "- Install a Magika-integrated scanning tool (bawbel-scanner is one implementation: `pip install \"bawbel-scanner[magika]\"`).\n- Verify content type of all skill files before loading\n- Reject any file where content type does not match declared extension\n- Use a file type allowlist for skill loading - only accept known-safe types",
+  "remediation": "- Install a scanning tool integrated with Magika or an equivalent ML-based file type classifier.\n- Verify content type of all skill files before loading\n- Reject any file where content type does not match declared extension\n- Use a file type allowlist for skill loading - only accept known-safe types",
   "status": "active",
   "kill_switch_active": false,
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-05-12T00:00:00Z",
+  "last_updated": "2026-07-17T00:00:00Z",
   "references": [
     {
       "tag": "CWE-434",


### PR DESCRIPTION
## Summary
- AVE-2026-00024's `description` and `remediation` both contained a literal `pip install "bawbel-scanner[magika]"` command naming one company's package as the standard's own example implementation
- Same class of finding as the corpus-wide bawbel-scanner boilerplate fix in `AVE_V1.1.0_MIGRATION_BRIEF.md` Section 4.5, missed on this record because it named a specific install command rather than the generic "using bawbel-scanner" phrasing that sweep targeted
- Replaced with vendor-neutral phrasing describing the required capability (a Magika-integrated or equivalent ML-based file type classifier), not a specific package
- `last_updated` bumped to today

## Test plan
- [x] `python3 scripts/validate_records.py` -- all 59 records still valid
- [x] `python3 -m pytest tests/ -q -k "00024"` -- this record's existing rule/fixtures unaffected
- [x] Re-swept the full corpus for `bawbel scan\b|bawbel-scanner|bawbel-gate|bawbel pin` -- this was the only remaining match outside the legitimate `researcher`/`researcher_url` attribution fields present on every record