### PR TITLE
docs: add AVE-2026-00057/58/59 to README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 
 ---
 
+## [1.3.0] - 2026-07-17
+
+### Summary
+
+- 3 new records: AVE-2026-00057 through AVE-2026-00059 — record set now at 59,
+  118 tests passing.
+  - AVE-2026-00057: obfuscated/encoded skill payload designed to evade static
+    scanners (base64/hex/marshal decode fed directly into eval/exec)
+  - AVE-2026-00058: deceptive skill trigger or activation-scope manipulation
+    via misleading manifest description
+  - AVE-2026-00059: fragmented cross-tool-description prompt injection
+    reassembled at a planted trigger (ShareLock-class), citing the original
+    research plus Microsoft's 2026 MCP security checkpoint
+- `owasp_mcp` corrected against `crosswalks/ave-to-owasp-mcp.md` during review,
+  not just pattern-validated against the schema: AVE-2026-00057 was missing
+  `MCP03` (Tool Poisoning) alongside `MCP04`; AVE-2026-00058's draft `MCP09`
+  (Shadow MCP Servers) was a flat mismatch, corrected to `MCP03` + `MCP06`
+  (Tool Poisoning, Intent Flow Subversion). `mitre_atlas: AML.T0051` on
+  AVE-2026-00059 verified against MITRE's own published technique name (LLM
+  Prompt Injection), not assumed from existing corpus convention.
+
+---
+
 ## [1.2.0] - 2026-07-12
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Stable IDs, AIVSS scores, and behavioral fingerprints for every way a skill file
 MCP server, system prompt, or agent plugin can be weaponized — scored consistently,
 mapped to the frameworks security teams already report against.
 
-[![Records](https://img.shields.io/badge/records-56-0f6e56?style=flat-square)](records/)
+[![Records](https://img.shields.io/badge/records-59-0f6e56?style=flat-square)](records/)
 [![Schema](https://img.shields.io/badge/schema-v1.1.0-0a3024?style=flat-square)](schema/ave-record-1.1.0.schema.json)
 [![AIVSS](https://img.shields.io/badge/AIVSS-v0.8-d4a017?style=flat-square)](https://aivss.owasp.org)
 [![OWASP MCP](https://img.shields.io/badge/OWASP-MCP%20Top%2010-0a3024?style=flat-square)](https://owasp.org)
@@ -95,13 +95,13 @@ skill file          ->   in CI / pre-commit   ->  before deploy
 
 | | |
 |---|---|
-| Total records | 56 |
+| Total records | 59 |
 | Schema version | 1.1.0 |
 | AIVSS spec | v0.8 |
 | CRITICAL (>= 9.0) | 1 |
-| HIGH (7.0-8.9) | 11 |
-| MEDIUM (4.0-6.9) | 43 |
-| LOW (< 4.0) | 1 |
+| HIGH (7.0-8.9) | 12 |
+| MEDIUM (4.0-6.9) | 44 |
+| LOW (< 4.0) | 2 |
 | Framework: OWASP MCP Top 10 | all records |
 | Framework: MITRE ATLAS | where applicable |
 | Framework: OWASP Agentic AI Top 10 | where applicable |
@@ -220,6 +220,9 @@ AIVSS = ((8.5 + 7.5) / 2) x 1.0 x 1 = 8.0  ->  HIGH
 | [AVE-2026-00054](records/AVE-2026-00054.json) | Code-Execution Sandbox Escape | 6.7 | MEDIUM |
 | [AVE-2026-00055](records/AVE-2026-00055.json) | MCP STDIO Launch Configuration Injection | 7.7 | HIGH |
 | [AVE-2026-00056](records/AVE-2026-00056.json) | Zero-Click Exfiltration via Rendered Content Auto-Fetch | 5.8 | MEDIUM |
+| [AVE-2026-00057](records/AVE-2026-00057.json) | Obfuscated Payload — Static Scanner Evasion | 4.4 | MEDIUM |
+| [AVE-2026-00058](records/AVE-2026-00058.json) | Deceptive Trigger — Activation-Scope Manipulation | 3.1 | LOW |
+| [AVE-2026-00059](records/AVE-2026-00059.json) | Fragmented Cross-Description Reassembly (ShareLock) | 7.1 | HIGH |
 
 ---
 


### PR DESCRIPTION
## Summary
This was originally pushed to `add-3-records` (PR #50), but landed after that PR was already merged, so it never made it into `develop`. Re-applying the same commit on top of current `develop`.

- README: badge count (56 -> 59), Stats table severity breakdown (CRITICAL 1, HIGH 12, MEDIUM 44, LOW 2), and a table row for each of AVE-2026-00057/58/59
- CHANGELOG: new `[1.3.0]` entry documenting the three records and the owasp_mcp/mitre_atlas corrections made during review

## Test plan
- [x] `python3 scripts/validate_records.py` -- all 59 records still valid
- [x] Confirmed `develop` already has all 3 new record files and the AVE-2026-00024 fix (PR #50, #51) merged; this PR only adds the docs that got stranded