### PR TITLE
fix: remove bawbel CLI names and stale counts from LANGUAGE.md

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -77,7 +77,7 @@ The false-positive guard. A rule without a negative fixture is incomplete.
 The five values of `detection_layer` define where evidence surfaces and what scanner reaches it.
 
 **content** — Evidence is in the text body of the skill file, prompt file, or MCP tool description
-field. Detectable by a static scanner reading the file before the agent runs. 33 of the 48 records
+field. Detectable by a static scanner reading the file before the agent runs. 37 of the 59 records
 are at this layer.
 
 **server_card** — Evidence is in the MCP server manifest: `.well-known/mcp.json`, tool schemas, or
@@ -89,7 +89,7 @@ registry before installation.
 
 **runtime** — Evidence only appears during live agent execution: injected via tool results, memory
 writes, A2A messages, rendered UI payloads, image pixels, or async task payloads. A static scanner
-cannot catch these. Requires a behavioral sandbox or runtime monitoring. 12 of the 48 records are
+cannot catch these. Requires a behavioral sandbox or runtime monitoring. 15 of the 59 records are
 at this layer.
 
 **transport** — Evidence is in the network layer: HTTP headers, OAuth discovery endpoints, webhook
@@ -99,8 +99,8 @@ The layer determines what detection stage is reachable:
 
 | detection_layer | detection_stage | Scanner type needed |
 |---|---|---|
-| content | static_detection | File-level static scanner (bawbel scan) |
-| server_card | static_detection | Server-card scanner (bawbel scan-server-card) |
+| content | static_detection | File-level static scanner |
+| server_card | static_detection | Server-card scanner |
 | registry_metadata | static_detection | Registry audit tool |
 | runtime | runtime_observed | Behavioral sandbox or runtime monitor |
 | transport | runtime_observed | Network proxy or monitor |


### PR DESCRIPTION
## Summary

Task D4 from the neutrality-audit-phase-2 brief. Confirmed clean on the specific concern the brief flagged (\`LANGUAGE.md\` being a misplaced \`bawbel-gate\` style-guide file, verbatim or adapted -- no "grant"/permission glossary language found; it's genuinely AVE-specific domain vocabulary). \`CLAUDE.md\`'s side of D4 was already fixed in #53.

Independently found and fixed while auditing this file:

- The detection_stage table named literal bawbel CLI commands ("bawbel scan", "bawbel scan-server-card") in the standard's own domain-language glossary -- same class of finding as the corpus-wide bawbel-scanner boilerplate fix elsewhere in this repo's history, missed because this file isn't a record and the earlier sweep only checked \`records/*.json\`
- Stale record-count figures in prose ("33 of the 48", "12 of the 48") -- corpus was 48 records when written, is 59 now. Recounted against the live corpus: content 37/59, runtime 15/59

## Test plan
- [x] \`python3 scripts/validate_records.py\` -- all 59 records still valid (this PR only touches LANGUAGE.md)
- [x] Repo-wide grep for \`bawbel scan\b\` and the stale "of the 48" figures in LANGUAGE.md -- zero remaining matches