### PR TITLE
fix: replace stale bawbel.io@gmail.com contact email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-bawbel.io@gmail.com.
+aveproject.org@gmail.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,4 +236,4 @@ name. Records are immutable once published — your attribution stays forever.
 ## Questions
 
 Open a [GitHub Discussion](https://github.com/aveproject/ave/discussions) or
-email [bawbel.io@gmail.com](mailto:bawbel.io@gmail.com).
+email [aveproject.org@gmail.com](mailto:aveproject.org@gmail.com).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 **Do not open a public GitHub issue for security vulnerabilities in Bawbel
 software (scanner, PiranhaDB, ave-site).**
 
-Email: **bawbel.io@gmail.com**
+Email: **aveproject.org@gmail.com**
 Subject: `SECURITY: [component] [brief description]`
 
 We will acknowledge within 48 hours and work with you on coordinated
@@ -22,7 +22,7 @@ record, not a Bawbel security report.
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full submission process.
 
 For critical or pre-disclosure submissions:
-Email **bawbel.io@gmail.com** subject: `AVE CRITICAL: [brief description]`
+Email **aveproject.org@gmail.com** subject: `AVE CRITICAL: [brief description]`
 
 ---
 

--- a/docs/specs/ave-implementer-guide.md
+++ b/docs/specs/ave-implementer-guide.md
@@ -158,6 +158,6 @@ cross-tool deduplication and links to the full behavioral record.
 ## Contact
 
 Open an issue at [github.com/aveproject/ave](https://github.com/aveproject/ave) or email
-bawbel.io@gmail.com.
+aveproject.org@gmail.com.
 
 Maintaining a scanner? Submit a crosswalk PR — we will help with the mapping.


### PR DESCRIPTION
## Summary
Discovery (\`grep -rln "bawbel.io@gmail.com" .\`) found 4 files, not the 6 the original brief guessed -- \`GOVERNANCE.md\`, \`README.md\`, and \`package.json\` don't contain it.

- \`SECURITY.md\` (2 occurrences), \`CODE_OF_CONDUCT.md\`, \`CONTRIBUTING.md\`, \`docs/specs/ave-implementer-guide.md\` swept to \`aveproject.org@gmail.com\`

\`SECURITY.md\` needed a judgment call: it uses the address in two genuinely different contexts -- one for reporting vulnerabilities in Bawbel's own tooling (scanner, PiranhaDB, ave-site), one for the AVE standard's own critical/pre-disclosure record-submission contact, explicitly distinguished in the file's own prose ("not a Bawbel security report"). Confirmed with the maintainer that both should move to the new address.

No Bawbel-attributed language needed rewriting beyond the address itself -- all 4 occurrences were plain "email X" phrasing, not "Contact Bawbel at X."

## Test plan
- [x] \`grep -rln "bawbel.io@gmail.com" .\` -- zero results
- [x] \`grep -rln "aveproject.org@gmail.com" .\` -- 4 files (5 occurrences, SECURITY.md has 2)
- [x] \`python3 scripts/validate_records.py\` -- all 59 records still valid (this PR touches no records)