### PR TITLE
Update cfgaudit crosswalk for cfgaudit 1.10.0 (add CFG091, CFG092)

### DIFF
--- a/crosswalks/cfgaudit-to-ave.json
+++ b/crosswalks/cfgaudit-to-ave.json
@@ -3,12 +3,12 @@
   "source": {
     "tool": "cfgaudit",
     "vendor": "cfgaudit",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "url": "https://github.com/cfgaudit/cfgaudit",
     "license": "Apache-2.0",
     "tool_class": "static configuration auditor",
-    "rules_total": 90,
-    "rules_mapped": 33
+    "rules_total": 92,
+    "rules_mapped": 35
   },
   "target": {
     "standard": "AVE",
@@ -17,8 +17,8 @@
     "record_count": 59,
     "static_record_count": 44
   },
-  "generated": "2026-07-22",
-  "note": "cfgaudit is a static auditor of committable AI-agent CONFIGURATION files. It does not connect to running servers or observe runtime, so it maps only to AVE's static_detection records. Each cfgaudit rule emits its primary AVE id in JSON/SARIF output (see github.com/cfgaudit/cfgaudit/blob/main/docs/cfgaudit-to-ave.md). Mappings are class-level behavioral equivalence, not asserted identity. cfgaudit maps 33 config-surface rules onto 19 AVE behavioral classes (many-to-one: several rules per class, since cfgaudit slices threats by config surface where AVE slices by behavior). AVE-2026-00036 (lateral movement) was implemented and then reverted after a false-positive analysis; see gaps.",
+  "generated": "2026-07-25",
+  "note": "cfgaudit is a static auditor of committable AI-agent CONFIGURATION files. It does not connect to running servers or observe runtime, so it maps only to AVE's static_detection records. Each cfgaudit rule emits its primary AVE id in JSON/SARIF output (see github.com/cfgaudit/cfgaudit/blob/main/docs/cfgaudit-to-ave.md). Mappings are class-level behavioral equivalence, not asserted identity. cfgaudit maps 35 config-surface rules onto 19 AVE behavioral classes (many-to-one: several rules per class, since cfgaudit slices threats by config surface where AVE slices by behavior). AVE-2026-00036 (lateral movement) was implemented and then reverted after a false-positive analysis; see gaps.",
   "mappings": [
     {
       "ave_id": "AVE-2026-00003",
@@ -49,7 +49,8 @@
       "ave_id": "AVE-2026-00007",
       "title": "prompt-injection goal hijack",
       "cfgaudit_rules": [
-        "CFG026"
+        "CFG026",
+        "CFG092"
       ]
     },
     {
@@ -86,7 +87,8 @@
       "ave_id": "AVE-2026-00021",
       "title": "autonomous action without confirmation",
       "cfgaudit_rules": [
-        "CFG029"
+        "CFG029",
+        "CFG091"
       ]
     },
     {
@@ -175,7 +177,7 @@
     },
     {
       "ave_id": "AVE-2026-00036",
-      "note": "lateral movement. cfgaudit implemented and then reverted this rule. The vocabulary ('lateral movement', 'pivot to other systems') is intent-ambiguous, appearing in security-tool self-description and defensive contexts a static linter cannot distinguish from a directive."
+      "note": "lateral movement. cfgaudit implemented and then reverted this rule. The vocabulary ('lateral movement', 'pivot to other systems') is intent-ambiguous, appearing in security-tool self-description and defensive contexts a static linter cannot distinguish from a directive. The reverted rule used the CFG091 id, which cfgaudit has since reused for the qwen approval-mode rule (mapped to AVE-2026-00021)."
     },
     {
       "ave_id": "AVE-2026-00059",
@@ -184,8 +186,8 @@
   ],
   "coverage": {
     "ave_static_records": 44,
-    "cfgaudit_rules_total": 90,
-    "cfgaudit_rules_mapped": 33,
+    "cfgaudit_rules_total": 92,
+    "cfgaudit_rules_mapped": 35,
     "ave_classes_covered": 19,
     "cfgaudit_rules_unmapped": 57
   },

--- a/crosswalks/cfgaudit-to-ave.md
+++ b/crosswalks/cfgaudit-to-ave.md
@@ -8,13 +8,13 @@ cfgaudit emits each rule's primary AVE id in its JSON and SARIF output (`AVEID` 
 
 | | Version |
 |---|---|
-| cfgaudit | 1.9.0 |
+| cfgaudit | 1.10.0 |
 | AVE record set | 1.1.0 |
 | Bawbel Scanner (validation, below) | 1.3.0 |
 
 ## Coverage
 
-cfgaudit has **90 rules** in total. **33 of them map onto 19 AVE behavioral classes.** It is a many-to-one mapping: several cfgaudit rules land on the same AVE class, because cfgaudit slices threats by config surface where AVE slices by behavior. For example, cfgaudit has five distinct secret-detection rules (a secret in `settings.json` env, in an MCP `env`/`headers` block, an entropy fallback, a Continue inline `apiKey`, a crypto signing key), and all five map to the single AVE class `AVE-2026-00047` (hardcoded credentials in component).
+cfgaudit has **92 rules** in total. **35 of them map onto 19 AVE behavioral classes.** It is a many-to-one mapping: several cfgaudit rules land on the same AVE class, because cfgaudit slices threats by config surface where AVE slices by behavior. For example, cfgaudit has five distinct secret-detection rules (a secret in `settings.json` env, in an MCP `env`/`headers` block, an entropy fallback, a Continue inline `apiKey`, a crypto signing key), and all five map to the single AVE class `AVE-2026-00047` (hardcoded credentials in component).
 
 The other 57 rules have no AVE class: they check config surfaces AVE's skill and MCP-server records do not enumerate (see "Config surfaces beyond AVE's model" below).
 
@@ -24,7 +24,9 @@ The other 57 rules have no AVE class: they check config surfaces AVE's skill and
 |---|---|---|---|
 | CFG024 | AVE-2026-00029 | homoglyph / Unicode obfuscation | hidden Unicode control chars in instruction text |
 | CFG026 | AVE-2026-00007 | goal hijack | override / persona / authority instruction |
+| CFG092 | AVE-2026-00007 | goal hijack | Kimi agent file `override: true` replaces the whole system prompt |
 | CFG029 | AVE-2026-00021 | autonomous action without confirmation | instruction to bypass permission prompts |
+| CFG091 | AVE-2026-00021 | autonomous action without confirmation | qwen `approvalMode: yolo` auto-approves every tool call |
 | CFG030 | AVE-2026-00010 | covert instruction concealment | "don't tell the user" / secrecy directive |
 | CFG032 | AVE-2026-00025 | conversation-history / role injection | pseudo-system tags, turn-boundary injection |
 | CFG035 | AVE-2026-00011 | dynamic tool-call injection | instruction to configure or trust an MCP server |
@@ -91,5 +93,5 @@ Static `static_detection` classes cfgaudit does not map, with the reason:
 | AVE id | Gap |
 |---|---|
 | AVE-2026-00015 | system-prompt extraction. Maps to OWASP LLM07, which cfgaudit treats as runtime; the instruction is static, but the scope boundary is undecided. |
-| AVE-2026-00036 | lateral movement. cfgaudit implemented and then reverted this rule after a false-positive analysis over 422 real instruction files: the vocabulary (`lateral movement`, `pivot to other systems`) is statically indistinguishable from security-tool self-description and defensive contexts. |
+| AVE-2026-00036 | lateral movement. cfgaudit implemented and then reverted this rule after a false-positive analysis over 422 real instruction files: the vocabulary (`lateral movement`, `pivot to other systems`) is statically indistinguishable from security-tool self-description and defensive contexts. The reverted rule used the CFG091 id, which cfgaudit has since reused for the qwen approval-mode rule (mapped to AVE-2026-00021). |
 | AVE-2026-00059 | fragmented cross-description injection. Needs multi-source correlation; cfgaudit checks each file in isolation, which is the exact property this attack defeats. |


### PR DESCRIPTION
Follow-up to #67 (merged). cfgaudit shipped two new rules since that crosswalk was submitted (at cfgaudit 1.9.0), and both map cleanly onto existing AVE classes.

## New mappings

- **CFG091** (qwen `approvalMode: yolo`, which auto-approves every tool call with no confirmation) maps to **AVE-2026-00021** (autonomous action without confirmation), joining CFG029.
- **CFG092** (Kimi agent file `override: true`, which replaces the built-in agent's whole system prompt) maps to **AVE-2026-00007** (goal hijack), joining CFG026.

## Counts

Both new rules land on existing AVE classes, so `ave_classes_covered` stays 19. `rules_mapped` 33 to 35, `rules_total` 90 to 92; `cfgaudit_rules_unmapped` stays 57. The AVE record set is unchanged (still up to AVE-2026-00059), so nothing changes on the `target` side.

## Housekeeping

The `AVE-2026-00036` (lateral movement) gap entry now notes that the reverted rule's `CFG091` id has since been reused for the qwen approval-mode rule, so the id no longer points at the deferred class.

Both files (`.json` and `.md`) updated in lockstep. Source of truth: https://github.com/cfgaudit/cfgaudit/blob/main/docs/cfgaudit-to-ave.md