### PR TITLE
docs: cross-reference scaling-and-governance.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,9 @@ the mapping.
 See [GOVERNANCE.md](GOVERNANCE.md) for the decision-making process, how records
 are proposed and reviewed, and the path toward neutral governance.
 
+See [docs/specs/scaling-and-governance.md](docs/specs/scaling-and-governance.md)
+for record-growth discipline, schema versioning, and deprecation policy.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor-facing process.
 
 See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.


### PR DESCRIPTION
Adds a pointer to docs/specs/scaling-and-governance.md in the Governance and contributing section, alongside the existing GOVERNANCE.md/CONTRIBUTING.md/CODE_OF_CONDUCT.md links. Part of the cross-reference sweep following #80.