### PR TITLE
docs: cross-reference scaling-and-governance.md in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,13 @@ contribution makes AI agents safer for everyone.
 
 ## Submitting a new AVE record
 
+Before opening a PR that adds a new record, read
+`docs/specs/scaling-and-governance.md` Section 1. A record needs a
+genuinely distinct behavioral mechanism; PRs that mirror another
+framework's category without describing a real, evidenced mechanism will
+be asked to either strengthen the evidence or fold into an existing
+record's `mutation_count` instead.
+
 ### Step 1 -- Open an issue
 
 Use the **New AVE Record** issue template. Include:


### PR DESCRIPTION
Adds a direct statement at the top of the 'Submitting a new AVE record' section pointing contributors at docs/specs/scaling-and-governance.md Section 1 before they open a PR, rather than a link buried at the bottom of the file. Part of the cross-reference sweep following #80.