### PR TITLE
docs: cross-reference scaling-and-governance.md in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,6 +22,9 @@ Minor additions (new optional fields) are non-breaking and can ship in a patch r
 **Crosswalk updates:** maintainer or contributors may update crosswalk JSON files to
 add new tool mappings. No record changes required.
 
+Record-growth, schema-versioning, and deprecation policy specifically are
+covered in `docs/specs/scaling-and-governance.md`, not restated here.
+
 ---
 
 ## Contribution process


### PR DESCRIPTION
Adds a cross-reference to docs/specs/scaling-and-governance.md at the end of the Decision making section, which already covers new records, schema changes, deprecation, and crosswalks at a high level -- the detailed policy now lives in the linked doc instead of being restated here. Part of the cross-reference sweep following #80.