### PR TITLE
docs: add status glossary entry, cross-referencing scaling-and-governance.md

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -29,6 +29,13 @@ Authored once. Immutable ave_id. Lives in records/AVE-YYYY-NNNNN.json.
 **ave_id** — unique identifier. Format AVE-YYYY-NNNNN. Never renumbered.
 Immutable once published. Deprecated via status, never deleted.
 
+**status** — `active` is the default. The only valid non-`active` values
+are `deprecated`, `merged`, `rejected`, per
+`docs/specs/scaling-and-governance.md` Section 3. Don't use synonyms
+("retired," "duplicate," "invalid") in prose describing a record's
+status, even informally. These names mean something specific and
+consistent everywhere they appear.
+
 **attack_class** — the behavioral category. NOT "vulnerability type".
 Examples: external_instruction_fetch, tool_description_injection,
 rug_pull, cross_app_escalation. Use snake_case.


### PR DESCRIPTION
LANGUAGE.md had no dedicated glossary entry for the status field (only a passing mention under ave_id). Adds one naming deprecated/merged/rejected as the only valid non-active values, per docs/specs/scaling-and-governance.md Section 3, and bans informal synonyms (retired, duplicate, invalid) in prose. Part of the cross-reference sweep following #80.