### PR TITLE
docs: CHANGELOG entry for scaling-and-governance.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 
 ---
 
+## [Unreleased]
+
+### Added
+- `docs/specs/scaling-and-governance.md`: record-growth discipline
+  (citing MITRE CWE 4.19 as a documented cautionary precedent), schema
+  versioning policy (formalizing the existing alias/frozen-snapshot
+  pattern), and deprecation policy (modeled on CVE's rejected-but-permanent
+  approach). The deprecation policy's schema implementation
+  (`merged_into`, `rejection_reason` fields) is tracked separately for a
+  future version bump, not yet implemented.
+
+---
+
 ## [1.3.0] - 2026-07-17
 
 ### Summary


### PR DESCRIPTION
No Unreleased section existed yet (top entry was the versioned 1.3.0); adds one recording the addition of docs/specs/scaling-and-governance.md, since this is a docs-only change with no schema/record version bump attached. Part of the cross-reference sweep following #80.