### PR TITLE
docs: cross-reference scaling-and-governance.md in ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,10 @@ crosswalks/            Mappings from other scanners and frameworks to AVE ids
 docs/                  ADRs, guides, research reports
 ```
 
+The alias/versioned-snapshot pattern shown above is described informally
+here; `docs/specs/scaling-and-governance.md` Section 2 is the canonical
+policy (bump rules, freeze guarantees) this file tree implements.
+
 There is no `rules/` directory in this repo. Detection rule implementations
 (pattern matching, YARA, semgrep, or anything else) are implementation
 artifacts, not standard artifacts, and live in whichever tool implements


### PR DESCRIPTION
ARCHITECTURE.md's file-tree block already informally documents the alias/frozen-snapshot schema versioning pattern (ave-record.schema.json vs ave-record-1.1.0.schema.json/1.0.0.schema.json). Points it at docs/specs/scaling-and-governance.md Section 2 as the canonical policy rather than letting a second, informal description drift out of sync. Part of the cross-reference sweep following #80.