### PR TITLE
fix: stale piranha.bawbel.io reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Three patterns depending on your environment:
 **Pattern 1 — Runtime API** (cloud CI/CD, always-on internet)
 ```python
 import httpx
-resp = httpx.get("https://api.piranha.bawbel.io/ave/AVE-2026-00002")
+resp = httpx.get("https://api.aveproject.org/records/AVE-2026-00002")
 record = resp.json()  # full record: fingerprint, IOCs, remediation, frameworks
 ```
 


### PR DESCRIPTION
README's Pattern 1 example still referenced the old vendor-specific endpoint instead of the neutral reference API. Confirmed isolated to this one occurrence via full document read-through. Corrected host and path; verified the new endpoint returns 200 before committing.