### PR TITLE
fix: GOVERNANCE.md deprecation_reason field claim

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,8 +16,8 @@ and having positive + negative detection fixtures.
 removal, required field addition) require a new schema version and a migration script.
 Minor additions (new optional fields) are non-breaking and can ship in a patch release.
 
-**Deprecation:** a record is deprecated by setting `status` to `"deprecated"` with a
-`deprecation_reason`. `ave_id` values are never reused or deleted.
+**Deprecation:** a record is deprecated by setting `status` to `"deprecated"`, with a
+note explaining why. `ave_id` values are never reused or deleted.
 
 **Crosswalk updates:** maintainer or contributors may update crosswalk JSON files to
 add new tool mappings. No record changes required.


### PR DESCRIPTION
GOVERNANCE.md claimed deprecation requires setting a `deprecation_reason` field, which doesn't exist anywhere: not in the schema, not on any record, and not named by scaling-and-governance.md Section 3 (the newer policy doc), which only ever says 'a note explains why.' Corrected the wording to match reality rather than adding the field, which would be a separate schema decision. Found while verifying claims for the v1.2.0 roadmap issues (#103, #104, #105).