### PR TITLE
docs: link AVE-2026-00046 writeup from its own record

### DIFF
--- a/records/AVE-2026-00046.json
+++ b/records/AVE-2026-00046.json
@@ -109,6 +109,11 @@
       "tag": "AVE Registry",
       "text": "AVE-2026-00046 \u2014 AVE behavioral vulnerability registry",
       "url": "https://github.com/aveproject/ave/blob/main/records/AVE-2026-00046.json"
+    },
+    {
+      "tag": "AVE Technical Writeup",
+      "text": "Full technical breakdown of this record: the mechanism, why detection is genuinely hard, and what a real defense looks like",
+      "url": "https://aveproject.org/writeups/AVE-2026-00046.html"
     }
   ],
   "owasp_mcp": [


### PR DESCRIPTION
Adds a references entry pointing to the existing ave-site writeup. No content duplicated into this repo; the record just becomes discoverable as pointing somewhere that already exists.

Note: the URL 404'd on first check (likely a deploy-in-progress timing issue), confirmed live with real content (title/description matching the writeup, not a soft-404) on a second check before proceeding.