### PR TITLE
docs: collapsible record index

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ AIVSS = ((8.5 + 7.5) / 2) x 1.0 x 1 = 8.0  ->  HIGH
 
 ## Record index
 
+<details>
+<summary><strong>70 records, click to expand</strong></summary>
+
 | AVE ID | Title | AIVSS | Severity |
 |---|---|---|---|
 | [AVE-2026-00001](records/AVE-2026-00001.json) | Metamorphic Payload via External Config Fetch | 8.0 | HIGH |
@@ -238,6 +241,8 @@ AIVSS = ((8.5 + 7.5) / 2) x 1.0 x 1 = 8.0  ->  HIGH
 | [AVE-2026-00068](records/AVE-2026-00068.json) | CLI Command Composition Risk (MOSAIC) | 5.1 | MEDIUM |
 | [AVE-2026-00069](records/AVE-2026-00069.json) | Multimodal Image-Hidden Instructions (SkillCamo) | 4.8 | MEDIUM |
 | [AVE-2026-00070](records/AVE-2026-00070.json) | Distributed Cross-Agent Backdoor Fragments | 6.4 | MEDIUM |
+
+</details>
 
 ---
 

--- a/docs/specs/researcher-process.md
+++ b/docs/specs/researcher-process.md
@@ -181,9 +181,12 @@ guard and deserves real effort, an easy negative fixture tests nothing.
 - `dist/ave-records-latest.json`: add or replace this record's entry,
   keep the array sorted by `ave_id`.
 - `CHANGELOG.md`: one line under Unreleased/Added.
-- `README.md`: update the record count if it references one, find the
-  actual line first (`grep -n "[0-9]\+ records" README.md`), don't
-  assume its current wording.
+- `README.md`: the record count lives in three separate places that
+  don't share a common text pattern, a single grep won't catch all of
+  them, update each explicitly:
+  - the badge (`grep -n "records-[0-9]\+-" README.md`)
+  - the Stats table (`grep -n "Total records" README.md`)
+  - the collapsible record index's summary label (`grep -n "records, click to expand" README.md`)
 
 Don't bump `schema_version` or create a new versioned dist snapshot as a
 side effect of adding one record, that's a separate, deliberate decision.


### PR DESCRIPTION
Wraps the record index table in a details/summary block, collapsed by default. Chose details over a CSS-scrollable div since GitHub sanitizes inline styles on divs in README rendering; details is native HTML5 and actually works. Verified against GitHub's real rendered HTML (not just source inspection): the details/summary/table structure parses correctly, the table renders as a proper table inside the collapsed block, and the closing tag lands in the right place.