### PR TITLE
crosswalks: refresh cfgaudit to v1.11.0 (53 rules onto 23 classes)

### DIFF
--- a/crosswalks/cfgaudit-to-ave.json
+++ b/crosswalks/cfgaudit-to-ave.json
@@ -3,26 +3,26 @@
   "source": {
     "tool": "cfgaudit",
     "vendor": "cfgaudit",
-    "version": "1.10.0",
+    "version": "1.11.0",
     "url": "https://github.com/cfgaudit/cfgaudit",
     "license": "Apache-2.0",
     "tool_class": "static configuration auditor",
-    "rules_total": 92,
-    "rules_mapped": 35
+    "rules_total": 97,
+    "rules_mapped": 53
   },
   "target": {
     "standard": "AVE",
     "version": "1.1.0",
     "url": "https://aveproject.org",
-    "record_count": 59,
-    "static_record_count": 44
+    "record_count": 70,
+    "static_record_count": 51
   },
-  "generated": "2026-07-25",
-  "note": "cfgaudit is a static auditor of committable AI-agent CONFIGURATION files. It does not connect to running servers or observe runtime, so it maps only to AVE's static_detection records. Each cfgaudit rule emits its primary AVE id in JSON/SARIF output (see github.com/cfgaudit/cfgaudit/blob/main/docs/cfgaudit-to-ave.md). Mappings are class-level behavioral equivalence, not asserted identity. cfgaudit maps 35 config-surface rules onto 19 AVE behavioral classes (many-to-one: several rules per class, since cfgaudit slices threats by config surface where AVE slices by behavior). AVE-2026-00036 (lateral movement) was implemented and then reverted after a false-positive analysis; see gaps.",
+  "generated": "2026-08-05",
+  "note": "cfgaudit is a static auditor of committable AI-agent CONFIGURATION files. It does not connect to running servers or observe runtime, so it maps only to AVE's static_detection records. Each cfgaudit rule emits its primary AVE id in JSON/SARIF output (see github.com/cfgaudit/cfgaudit/blob/main/docs/cfgaudit-to-ave.md). Mappings are class-level behavioral equivalence, not asserted identity. cfgaudit now maps 53 config-surface rules onto 23 AVE behavioral classes, up from 35 onto 19 at v1.10.0. Most of that growth is not new cfgaudit rules: it is previously unmapped rules finding a home in AVE-2026-00061 through AVE-2026-00064, the four config classes AVE added from this crosswalk's own gap list (aveproject/ave#68). CFG091 moved from AVE-2026-00021 to AVE-2026-00063: 00021 describes a component that explicitly INSTRUCTS the agent to bypass confirmation, while qwen's tools.approvalMode is a setting, which is what 00063 covers 'independent of any instruction text'.",
   "mappings": [
     {
       "ave_id": "AVE-2026-00003",
-      "title": "credential exfiltration",
+      "title": "Credential exfiltration via agent instruction",
       "cfgaudit_rules": [
         "CFG031",
         "CFG036",
@@ -32,7 +32,7 @@
     },
     {
       "ave_id": "AVE-2026-00004",
-      "title": "shell-pipe code execution",
+      "title": "Arbitrary code execution via shell pipe injection in agentic component",
       "cfgaudit_rules": [
         "CFG008",
         "CFG014"
@@ -40,14 +40,14 @@
     },
     {
       "ave_id": "AVE-2026-00005",
-      "title": "recursive filesystem destruction",
+      "title": "Recursive file system destruction via destructive command injection in agentic component",
       "cfgaudit_rules": [
         "CFG039"
       ]
     },
     {
       "ave_id": "AVE-2026-00007",
-      "title": "prompt-injection goal hijack",
+      "title": "Agent goal hijack via direct instruction override in agentic component",
       "cfgaudit_rules": [
         "CFG026",
         "CFG092"
@@ -55,7 +55,7 @@
     },
     {
       "ave_id": "AVE-2026-00008",
-      "title": "persistence / self-replication",
+      "title": "Agent persistence via self-replication instruction in agentic component",
       "cfgaudit_rules": [
         "CFG027",
         "CFG028"
@@ -63,21 +63,21 @@
     },
     {
       "ave_id": "AVE-2026-00010",
-      "title": "covert instruction concealment",
+      "title": "Covert instruction concealment via secrecy directive in agentic component",
       "cfgaudit_rules": [
         "CFG030"
       ]
     },
     {
       "ave_id": "AVE-2026-00011",
-      "title": "dynamic tool-call injection",
+      "title": "Arbitrary tool invocation via dynamic tool call injection in agentic component",
       "cfgaudit_rules": [
         "CFG035"
       ]
     },
     {
       "ave_id": "AVE-2026-00017",
-      "title": "server impersonation / spoofing",
+      "title": "MCP Server Impersonation or Spoofing",
       "cfgaudit_rules": [
         "CFG052",
         "CFG059"
@@ -85,43 +85,42 @@
     },
     {
       "ave_id": "AVE-2026-00021",
-      "title": "autonomous action without confirmation",
+      "title": "Autonomous Action Without User Confirmation",
       "cfgaudit_rules": [
-        "CFG029",
-        "CFG091"
+        "CFG029"
       ]
     },
     {
       "ave_id": "AVE-2026-00025",
-      "title": "conversation-history / role injection",
+      "title": "Conversation History Injection",
       "cfgaudit_rules": [
         "CFG032"
       ]
     },
     {
       "ave_id": "AVE-2026-00027",
-      "title": "multi-turn instruction persistence",
+      "title": "Multi-Turn Attack - Instruction Persistence Across Conversations",
       "cfgaudit_rules": [
         "CFG081"
       ]
     },
     {
       "ave_id": "AVE-2026-00029",
-      "title": "homoglyph / Unicode obfuscation",
+      "title": "Homoglyph or Unicode Obfuscation Attack",
       "cfgaudit_rules": [
         "CFG024"
       ]
     },
     {
       "ave_id": "AVE-2026-00032",
-      "title": "network reconnaissance instruction",
+      "title": "Network Reconnaissance Instruction",
       "cfgaudit_rules": [
         "CFG090"
       ]
     },
     {
       "ave_id": "AVE-2026-00039",
-      "title": "covert-channel exfiltration",
+      "title": "Covert Channel - Steganographic Data Exfiltration",
       "cfgaudit_rules": [
         "CFG033",
         "CFG072"
@@ -129,18 +128,19 @@
     },
     {
       "ave_id": "AVE-2026-00047",
-      "title": "hardcoded credentials in component",
+      "title": "Hardcoded credentials in agent component - API keys and secrets exposed in skill files",
       "cfgaudit_rules": [
         "CFG007",
         "CFG050",
         "CFG054",
         "CFG065",
-        "CFG073"
+        "CFG073",
+        "CFG097"
       ]
     },
     {
       "ave_id": "AVE-2026-00048",
-      "title": "unsafe agent delegation chain",
+      "title": "Unsafe agent delegation chain - sub-agent spawned with inherited permissions and no trust boundary",
       "cfgaudit_rules": [
         "CFG051",
         "CFG085"
@@ -148,7 +148,7 @@
     },
     {
       "ave_id": "AVE-2026-00055",
-      "title": "command exec via untrusted MCP launch config",
+      "title": "Command execution via untrusted MCP server launch configuration (STDIO)",
       "cfgaudit_rules": [
         "CFG019",
         "CFG020",
@@ -157,16 +157,58 @@
     },
     {
       "ave_id": "AVE-2026-00057",
-      "title": "obfuscated/encoded payload",
+      "title": "Obfuscated or encoded skill payload designed to evade static scanners",
       "cfgaudit_rules": [
         "CFG057"
       ]
     },
     {
       "ave_id": "AVE-2026-00058",
-      "title": "deceptive trigger / activation-scope",
+      "title": "Deceptive skill trigger or activation-scope manipulation via misleading manifest description",
       "cfgaudit_rules": [
         "CFG056"
+      ]
+    },
+    {
+      "ave_id": "AVE-2026-00061",
+      "title": "TLS certificate verification disabled in agent component configuration",
+      "cfgaudit_rules": [
+        "CFG075"
+      ]
+    },
+    {
+      "ave_id": "AVE-2026-00062",
+      "title": "Unpinned dependency version allowing supply chain substitution",
+      "cfgaudit_rules": [
+        "CFG010",
+        "CFG055",
+        "CFG074",
+        "CFG089"
+      ]
+    },
+    {
+      "ave_id": "AVE-2026-00063",
+      "title": "Human approval gate bypassed via declarative configuration, distinct from AVE-2026-00048",
+      "cfgaudit_rules": [
+        "CFG003",
+        "CFG004",
+        "CFG048",
+        "CFG053",
+        "CFG063",
+        "CFG079",
+        "CFG087",
+        "CFG091",
+        "CFG093",
+        "CFG096"
+      ]
+    },
+    {
+      "ave_id": "AVE-2026-00064",
+      "title": "Zero-click code execution via project-load auto-run configuration",
+      "cfgaudit_rules": [
+        "CFG047",
+        "CFG067",
+        "CFG086"
       ]
     }
   ],
@@ -177,19 +219,31 @@
     },
     {
       "ave_id": "AVE-2026-00036",
-      "note": "lateral movement. cfgaudit implemented and then reverted this rule. The vocabulary ('lateral movement', 'pivot to other systems') is intent-ambiguous, appearing in security-tool self-description and defensive contexts a static linter cannot distinguish from a directive. The reverted rule used the CFG091 id, which cfgaudit has since reused for the qwen approval-mode rule (mapped to AVE-2026-00021)."
+      "note": "lateral movement. cfgaudit implemented and then reverted this rule. The vocabulary ('lateral movement', 'pivot') appears in ordinary security tooling and infrastructure docs, so the false-positive rate was unacceptable for a static config check."
     },
     {
       "ave_id": "AVE-2026-00059",
-      "note": "fragmented cross-description injection. Needs multi-source correlation; cfgaudit checks each file in isolation."
+      "note": "fragmented cross-description injection. Needs multi-source correlation; cfgaudit checks each file independently."
+    },
+    {
+      "ave_id": "AVE-2026-00065",
+      "note": "A2A agent card poisoning. cfgaudit reaches the committed pointer but not the card. A .gemini/agents/*.md may carry an inline agent_card_json, which cfgaudit recognises well enough to classify the file as a remote agent, but it does not audit the card's contents. It does flag a cleartext agent_card_url and a credential literal in the same file's auth block (CFG097)."
+    },
+    {
+      "ave_id": "AVE-2026-00060",
+      "note": "STDIO transport shell injection. Server-side implementation flaw, requires SAST of the MCP server source rather than reading its launch configuration. Same layer as AVE-2026-00052 and AVE-2026-00053; see the static_detection note below."
+    },
+    {
+      "ave_id": "AVE-2026-00069",
+      "note": "image-hidden instructions in a skill package. Requires binary content analysis of a bundled image; cfgaudit reads text configuration only. Same layer as AVE-2026-00024."
     }
   ],
   "coverage": {
-    "ave_static_records": 44,
-    "cfgaudit_rules_total": 92,
-    "cfgaudit_rules_mapped": 35,
-    "ave_classes_covered": 19,
-    "cfgaudit_rules_unmapped": 57
+    "ave_static_records": 51,
+    "cfgaudit_rules_total": 97,
+    "cfgaudit_rules_mapped": 53,
+    "ave_classes_covered": 23,
+    "cfgaudit_rules_unmapped": 44
   },
   "validation": {
     "against": {
@@ -199,57 +253,37 @@
     "method": "same SKILL.md per rule, cfgaudit canonical triggers unmodified, static engines only (pattern+yara+semgrep, no LLM), both reading ave_id from JSON",
     "shared_surface_rules": 10,
     "agreements": 5,
-    "note": "5 of the 10 instruction-content rules that share a scan surface with Bawbel: both scanners independently emit the same ave_id. The 5 divergences are detection-pattern differences, not mapping errors."
+    "note": "5 of the 10 instruction-content rules that share a scan surface with Bawbel: both scanners independently emit the same ave_id. The 5 divergences are detection-pattern differences, not mapping errors. Re-checked at cfgaudit v1.11.0 against AVE record set 1.1.0 (70 records). A false-positive pass over 432 real repositories preceded this release and changed two rules, neither of them mapped: CFG015 and CFG009 stopped firing on hook idioms, and a Cursor build-cache warning was withdrawn."
   },
   "config_surfaces_beyond_ave": [
-    {
-      "surface": "permission / approval config",
-      "example_rules": [
-        "CFG001",
-        "CFG003",
-        "CFG004",
-        "CFG048",
-        "CFG079"
-      ]
-    },
-    {
-      "surface": "zero-click IDE / workspace auto-run",
-      "example_rules": [
-        "CFG047",
-        "CFG067",
-        "CFG086",
-        "CFG087"
-      ]
-    },
     {
       "surface": "telemetry / endpoint redirect",
       "example_rules": [
         "CFG005",
         "CFG046",
         "CFG071"
-      ]
+      ],
+      "note": "Still open. Distinct from AVE-2026-00002: nothing is injected into the model's context. A committed key/value changes where the process sends data, and the model never sees it, so detection is a value comparison rather than content analysis. OTEL_EXPORTER_OTLP_*ENDPOINT to a non-local collector, ANTHROPIC_BASE_URL off Anthropic (CVE-2026-21852), a model or provider base URL over cleartext http."
     },
     {
       "surface": "sandbox weakening in config",
       "example_rules": [
         "CFG022",
         "CFG061",
-        "CFG064"
-      ]
-    },
-    {
-      "surface": "TLS verification disabled",
-      "example_rules": [
-        "CFG075"
-      ]
+        "CFG064",
+        "CFG079",
+        "CFG095"
+      ],
+      "note": "Still open. sandbox.excludedCommands with a wildcard or shell, bwrapPath/socatPath helper substitution, network.allowUnixSockets naming docker.sock, filesystem.allowWrite on $PATH or a shell rc; Gemini tools.sandboxAllowedPaths exposing / or ~; Codex sandbox_mode danger-full-access and [sandbox_workspace_write] network_access; Cursor .cursor/sandbox.json type insecure_none and an inverted networkPolicy."
     },
     {
       "surface": "container / daemon posture",
       "example_rules": [
         "CFG082",
-        "CFG083",
-        "CFG084"
-      ]
+        "CFG084",
+        "CFG083"
+      ],
+      "note": "Still open, and it is THREE mechanisms with no shared detection logic, not one class. (1) daemon redirected off-host: DOCKER_HOST or a -H/--host flag pointing at a remote tcp:// or ssh:// daemon. (2) image trust verification disabled: DOCKER_CONTENT_TRUST=0, --disable-content-trust, --insecure-registry. (3) browser subprocess replaced: an MCP server's args carrying --utility-cmd-prefix, --renderer-cmd-prefix, --gpu-launcher or --browser-subprocess-path. The first is the highest-value single record."
     },
     {
       "surface": "MCP network / transport posture",
@@ -259,16 +293,24 @@
         "CFG058",
         "CFG021",
         "CFG069"
-      ]
+      ],
+      "note": "Still open, and likewise a surface rather than a class: FIVE mechanisms. Bind address 0.0.0.0 or [::] (NeighborJack); a wildcard CORS origin in env, escalating when auth is disabled in the same env (CVE-2026-33010); type sse, the deprecated transport; HTTP_PROXY/HTTPS_PROXY/ALL_PROXY resolving off loopback; HTTP transport enabled without log redaction, so request bodies with bearer tokens reach the logs (CVE-2026-42282, CVE-2026-41495). The bind-all case is the highest-value single record."
     },
     {
-      "surface": "supply-chain pinning / plugin auto-install",
+      "surface": "cleartext endpoint, distinct from TLS verification disabled",
       "example_rules": [
-        "CFG010",
-        "CFG055",
-        "CFG074",
-        "CFG089"
-      ]
+        "CFG049",
+        "CFG071",
+        "CFG097"
+      ],
+      "note": "New in this revision, and it has no class in either direction. AVE-2026-00061 covers verification being switched off; this is the case where there is no TLS at all. A committed http:// MCP server URL, model base URL, or A2A agent_card_url."
+    },
+    {
+      "surface": "natural-language steering of an approval classifier",
+      "example_rules": [
+        "CFG094"
+      ],
+      "note": "New in this revision. Cursor's .cursor/permissions.json autoRun.allow_instructions is prose the repository feeds to the classifier that decides, in Auto-review mode, whether a tool call runs without asking. It falls between AVE-2026-00063, which is explicitly 'independent of any instruction text', and AVE-2026-00021, which is an instruction to the agent rather than to a gatekeeper."
     }
   ]
 }

--- a/crosswalks/cfgaudit-to-ave.md
+++ b/crosswalks/cfgaudit-to-ave.md
@@ -8,58 +8,68 @@ cfgaudit emits each rule's primary AVE id in its JSON and SARIF output (`AVEID` 
 
 | | Version |
 |---|---|
-| cfgaudit | 1.10.0 |
-| AVE record set | 1.1.0 |
+| cfgaudit | 1.11.0 |
+| AVE record set | 1.1.0 (70 records) |
 | Bawbel Scanner (validation, below) | 1.3.0 |
 
 ## Coverage
 
-cfgaudit has **92 rules** in total. **35 of them map onto 19 AVE behavioral classes.** It is a many-to-one mapping: several cfgaudit rules land on the same AVE class, because cfgaudit slices threats by config surface where AVE slices by behavior. For example, cfgaudit has five distinct secret-detection rules (a secret in `settings.json` env, in an MCP `env`/`headers` block, an entropy fallback, a Continue inline `apiKey`, a crypto signing key), and all five map to the single AVE class `AVE-2026-00047` (hardcoded credentials in component).
+cfgaudit has **97 rules** in total. **53 of them map onto 23 AVE behavioral classes**, up from 35 onto 19 at v1.10.0. It is a many-to-one mapping: several cfgaudit rules land on the same AVE class, because cfgaudit slices threats by config surface where AVE slices by behavior. For example, cfgaudit has five distinct secret-detection rules (a secret in `settings.json` env, in an MCP `env`/`headers` block, an entropy fallback, a Continue inline `apiKey`, a crypto signing key), and all five map to the single AVE class `AVE-2026-00047` (hardcoded credentials in component).
 
-The other 57 rules have no AVE class: they check config surfaces AVE's skill and MCP-server records do not enumerate (see "Config surfaces beyond AVE's model" below).
+The other 44 rules have no AVE class: they check config surfaces AVE's skill and MCP-server records do not enumerate (see "Config surfaces beyond AVE's model" below).
+
+**Most of that growth is not new cfgaudit rules.** Five rules were added in v1.11.0 and three of them map. The other fifteen new mappings are rules that existed all along and finally have a home, in `AVE-2026-00061` through `AVE-2026-00064`, the four config classes AVE added from this crosswalk's own gap list ([#68](https://github.com/aveproject/ave/issues/68)). Four of the eight surfaces listed below at v1.10.0 are therefore now closed.
+
+**One mapping moved.** `CFG091` (qwen `tools.approvalMode: "yolo"`) was mapped to `AVE-2026-00021`, whose text describes *"a component that explicitly **instructs** the agent to bypass this confirmation step"*. It is a setting, not an instruction, and `AVE-2026-00063` is explicit that it covers the declarative case *"independent of any instruction text"*. `AVE-2026-00021` keeps the instruction-driven rule (`CFG029`).
 
 ## Rule mapping
 
-| cfgaudit rule(s) | AVE id | Class | Notes |
+| cfgaudit rule(s) | AVE id | AVE class | what cfgaudit reads |
 |---|---|---|---|
-| CFG024 | AVE-2026-00029 | homoglyph / Unicode obfuscation | hidden Unicode control chars in instruction text |
-| CFG026 | AVE-2026-00007 | goal hijack | override / persona / authority instruction |
-| CFG092 | AVE-2026-00007 | goal hijack | Kimi agent file `override: true` replaces the whole system prompt |
-| CFG029 | AVE-2026-00021 | autonomous action without confirmation | instruction to bypass permission prompts |
-| CFG091 | AVE-2026-00021 | autonomous action without confirmation | qwen `approvalMode: yolo` auto-approves every tool call |
-| CFG030 | AVE-2026-00010 | covert instruction concealment | "don't tell the user" / secrecy directive |
-| CFG032 | AVE-2026-00025 | conversation-history / role injection | pseudo-system tags, turn-boundary injection |
-| CFG035 | AVE-2026-00011 | dynamic tool-call injection | instruction to configure or trust an MCP server |
-| CFG031, CFG036, CFG037, CFG038 | AVE-2026-00003 | credential exfiltration | sensitive-path read, env dump, embedded exfil shell |
-| CFG033, CFG072 | AVE-2026-00039 | covert-channel exfiltration | markdown-image sink, DNS-name exfil |
-| CFG056 | AVE-2026-00058 | deceptive trigger / activation-scope | broad always-on skill trigger |
-| CFG057 | AVE-2026-00057 | obfuscated / encoded payload | base64 or data-URI encoded injection |
-| CFG081 | AVE-2026-00027 | multi-turn instruction persistence | "survive context compaction" directive |
-| CFG051, CFG085 | AVE-2026-00048 | unsafe agent delegation chain | over-broad tool grant in agent frontmatter |
-| CFG090 | AVE-2026-00032 | network reconnaissance instruction | scan or enumerate an internal network (see gaps re: precision) |
-| CFG008, CFG014 | AVE-2026-00004 | shell-pipe code execution | reverse shell, `curl \| sh` |
-| CFG039 | AVE-2026-00005 | recursive filesystem destruction | `rm -rf` |
-| CFG027, CFG028 | AVE-2026-00008 | persistence / self-replication | cron/startup persistence, writing trust files |
-| CFG007, CFG050, CFG054, CFG065, CFG073 | AVE-2026-00047 | hardcoded credentials in component | secrets in settings or MCP env/headers |
-| CFG052, CFG059 | AVE-2026-00017 | server impersonation / spoofing | MCP name shadowing, typosquat |
-| CFG019, CFG020, CFG070 | AVE-2026-00055 | command exec via untrusted MCP launch config | inline-script, env-code, repo-relative launcher |
+| CFG031, CFG036, CFG037, CFG038 | AVE-2026-00003 | Credential exfiltration via agent instruction |  |
+| CFG008, CFG014 | AVE-2026-00004 | Arbitrary code execution via shell pipe injection in agentic component |  |
+| CFG039 | AVE-2026-00005 | Recursive file system destruction via destructive command injection in agentic component |  |
+| CFG026, CFG092 | AVE-2026-00007 | Agent goal hijack via direct instruction override in agentic component |  |
+| CFG027, CFG028 | AVE-2026-00008 | Agent persistence via self-replication instruction in agentic component |  |
+| CFG030 | AVE-2026-00010 | Covert instruction concealment via secrecy directive in agentic component |  |
+| CFG035 | AVE-2026-00011 | Arbitrary tool invocation via dynamic tool call injection in agentic component |  |
+| CFG052, CFG059 | AVE-2026-00017 | MCP Server Impersonation or Spoofing |  |
+| CFG029 | AVE-2026-00021 | Autonomous Action Without User Confirmation |  |
+| CFG032 | AVE-2026-00025 | Conversation History Injection |  |
+| CFG081 | AVE-2026-00027 | Multi-Turn Attack - Instruction Persistence Across Conversations |  |
+| CFG024 | AVE-2026-00029 | Homoglyph or Unicode Obfuscation Attack |  |
+| CFG090 | AVE-2026-00032 | Network Reconnaissance Instruction |  |
+| CFG033, CFG072 | AVE-2026-00039 | Covert Channel - Steganographic Data Exfiltration |  |
+| CFG007, CFG050, CFG054, CFG065, CFG073, CFG097 | AVE-2026-00047 | Hardcoded credentials in agent component - API keys and secrets exposed in skill files |  |
+| CFG051, CFG085 | AVE-2026-00048 | Unsafe agent delegation chain - sub-agent spawned with inherited permissions and no trust boundary |  |
+| CFG019, CFG020, CFG070 | AVE-2026-00055 | Command execution via untrusted MCP server launch configuration (STDIO) |  |
+| CFG057 | AVE-2026-00057 | Obfuscated or encoded skill payload designed to evade static scanners |  |
+| CFG056 | AVE-2026-00058 | Deceptive skill trigger or activation-scope manipulation via misleading manifest description |  |
+| CFG075 | AVE-2026-00061 | TLS certificate verification disabled in agent component configuration | MCP `env`/`args` TLS-verify killswitch |
+| CFG010, CFG055, CFG074, CFG089 | AVE-2026-00062 | Unpinned dependency version allowing supply chain substitution | unpinned `@latest`/`:latest`, lock file with no integrity pin, unpinned marketplace source |
+| CFG003, CFG004, CFG048, CFG053, CFG063, CFG079, CFG087, CFG091, CFG093, CFG096 | AVE-2026-00063 | Human approval gate bypassed via declarative configuration, distinct from AVE-2026-00048 | a config flag that removes the approval step, across seven agents |
+| CFG047, CFG067, CFG086 | AVE-2026-00064 | Zero-click code execution via project-load auto-run configuration | `.vscode/tasks.json` `folderOpen`, Zed `create_worktree` hook task, zero-click hook events |
 
 Mappings are class-level behavioral equivalence, not asserted identity. Where a cfgaudit rule covers more than one AVE class, only the canonical primary is emitted (matching AVE's one-`ruleId`-per-class SARIF model); the full multi-mapping is in cfgaudit's own crosswalk doc.
 
 ## Config surfaces beyond AVE's model
 
-AVE's records enumerate behavior in skills and MCP servers. cfgaudit additionally audits config-file classes that carry no corresponding AVE behavioral class today. The 57 unmapped rules cluster into these surfaces:
+AVE's records enumerate behavior in skills and MCP servers. cfgaudit additionally audits config-file classes that carry no corresponding AVE behavioral class today.
+
+Four of the eight surfaces listed here at v1.10.0 have since been closed by AVE records: permission/approval config and the committed-hook auto-approve case by `AVE-2026-00063`, zero-click auto-run by `AVE-2026-00064`, TLS verification disabled by `AVE-2026-00061`, and supply-chain pinning by `AVE-2026-00062`. What remains:
 
 | Config surface | Example files / keys | Example rules |
 |---|---|---|
-| Permission / approval config | `permissions.allow`, `defaultMode: bypassPermissions`, `enableAllProjectMcpServers`, `.vscode` `chat.tools.autoApprove` | CFG001, CFG003, CFG004, CFG048, CFG079 |
-| Zero-click IDE / workspace auto-run | `.vscode/tasks.json` `runOn: folderOpen`, committed `.claude`/Cursor/Copilot hooks | CFG047, CFG067, CFG086, CFG087 |
-| Telemetry / endpoint redirect | `OTEL_EXPORTER_OTLP_*`, `ANTHROPIC_BASE_URL`, model `base_url` | CFG005, CFG046, CFG071 |
-| Sandbox weakening in config | `sandbox` excludes/paths, Gemini/Codex sandbox modes | CFG022, CFG061, CFG064 |
-| TLS verification disabled | `NODE_TLS_REJECT_UNAUTHORIZED=0`, `GIT_SSL_NO_VERIFY`, `--insecure` in MCP `env`/`args` | CFG075 |
-| Container / daemon posture | `DOCKER_HOST` off-host, `DOCKER_CONTENT_TRUST=0`, Chromium launcher args | CFG082, CFG083, CFG084 |
-| MCP network / transport posture | bind-all `0.0.0.0`, wildcard CORS, deprecated `sse`, proxy env, log redaction | CFG018, CFG066, CFG058, CFG021, CFG069 |
-| Supply-chain pinning / plugin auto-install | unpinned MCP package, `enabledPlugins`/`extraKnownMarketplaces`, `skills-lock.json` | CFG010, CFG055, CFG074, CFG089 |
+| Telemetry / endpoint redirect | `OTEL_EXPORTER_OTLP_*ENDPOINT` to a non-local collector, `ANTHROPIC_BASE_URL` off Anthropic, model or provider `base_url` over cleartext | CFG005, CFG046, CFG071 |
+| Sandbox weakening in config | `sandbox.excludedCommands` wildcard/shell, `bwrapPath`/`socatPath`, `allowUnixSockets` naming `docker.sock`; Gemini `tools.sandboxAllowedPaths` exposing `/`; Codex `danger-full-access` and `[sandbox_workspace_write] network_access`; Cursor `type: insecure_none` | CFG022, CFG061, CFG064, CFG079, CFG095 |
+| Container / daemon posture | `DOCKER_HOST` or `-H` at a remote `tcp://`/`ssh://` daemon; `DOCKER_CONTENT_TRUST=0`, `--disable-content-trust`, `--insecure-registry`; Chromium `--utility-cmd-prefix`, `--renderer-cmd-prefix`, `--gpu-launcher`, `--browser-subprocess-path` in MCP `args` | CFG082, CFG084, CFG083 |
+| MCP network / transport posture | bind `0.0.0.0`/`[::]`; wildcard CORS origin, escalating when auth is disabled in the same `env`; `type: sse`; `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` off loopback; HTTP transport without log redaction | CFG018, CFG066, CFG058, CFG021, CFG069 |
+| Cleartext endpoint, distinct from TLS verification disabled | a committed `http://` MCP server URL, model base URL, or A2A `agent_card_url` | CFG049, CFG071, CFG097 |
+| Natural-language steering of an approval classifier | Cursor `.cursor/permissions.json` `autoRun.allow_instructions` | CFG094 |
+
+The last two are new in this revision.
+
+**Container posture and MCP network posture are each several mechanisms, not one class.** Container posture is three with no shared detection logic: the daemon redirect, image-trust verification being off, and a launcher flag replacing the browser subprocess. MCP network posture is five. If either becomes a record, the daemon redirect and the bind-all case are the highest-value single ones. This was the specific question in [#68](https://github.com/aveproject/ave/issues/68), answered there at field level.
 
 These are not gaps in this crosswalk; they are config classes outside AVE's current skill/MCP-behavioral scope. They are listed here so the taxonomy's coverage against a config-auditor is visible.
 
@@ -95,3 +105,6 @@ Static `static_detection` classes cfgaudit does not map, with the reason:
 | AVE-2026-00015 | system-prompt extraction. Maps to OWASP LLM07, which cfgaudit treats as runtime; the instruction is static, but the scope boundary is undecided. |
 | AVE-2026-00036 | lateral movement. cfgaudit implemented and then reverted this rule after a false-positive analysis over 422 real instruction files: the vocabulary (`lateral movement`, `pivot to other systems`) is statically indistinguishable from security-tool self-description and defensive contexts. The reverted rule used the CFG091 id, which cfgaudit has since reused for the qwen approval-mode rule (mapped to AVE-2026-00021). |
 | AVE-2026-00059 | fragmented cross-description injection. Needs multi-source correlation; cfgaudit checks each file in isolation, which is the exact property this attack defeats. |
+| AVE-2026-00060 | STDIO transport shell injection. A server-side implementation flaw: it needs SAST of the MCP server's source, not a read of its launch configuration. Same layer as AVE-2026-00052 and AVE-2026-00053. |
+| AVE-2026-00065 | A2A agent card poisoning. cfgaudit reaches the committed pointer but not the card. A `.gemini/agents/*.md` may carry an inline `agent_card_json`, which cfgaudit recognises well enough to classify the file as a remote agent, but it does not audit the card's contents. It does flag a cleartext `agent_card_url` and a credential literal in the same file's `auth` block (CFG097). |
+| AVE-2026-00069 | Image-hidden instructions in a skill package. Needs binary content analysis of a bundled image; cfgaudit reads text configuration only. Same layer as AVE-2026-00024. |

--- a/crosswalks/cfgaudit-to-ave.md
+++ b/crosswalks/cfgaudit-to-ave.md
@@ -24,31 +24,32 @@ The other 44 rules have no AVE class: they check config surfaces AVE's skill and
 
 ## Rule mapping
 
-| cfgaudit rule(s) | AVE id | AVE class | what cfgaudit reads |
+| cfgaudit rule(s) | AVE id | Class | Notes |
 |---|---|---|---|
-| CFG031, CFG036, CFG037, CFG038 | AVE-2026-00003 | Credential exfiltration via agent instruction |  |
-| CFG008, CFG014 | AVE-2026-00004 | Arbitrary code execution via shell pipe injection in agentic component |  |
-| CFG039 | AVE-2026-00005 | Recursive file system destruction via destructive command injection in agentic component |  |
-| CFG026, CFG092 | AVE-2026-00007 | Agent goal hijack via direct instruction override in agentic component |  |
-| CFG027, CFG028 | AVE-2026-00008 | Agent persistence via self-replication instruction in agentic component |  |
-| CFG030 | AVE-2026-00010 | Covert instruction concealment via secrecy directive in agentic component |  |
-| CFG035 | AVE-2026-00011 | Arbitrary tool invocation via dynamic tool call injection in agentic component |  |
-| CFG052, CFG059 | AVE-2026-00017 | MCP Server Impersonation or Spoofing |  |
-| CFG029 | AVE-2026-00021 | Autonomous Action Without User Confirmation |  |
-| CFG032 | AVE-2026-00025 | Conversation History Injection |  |
-| CFG081 | AVE-2026-00027 | Multi-Turn Attack - Instruction Persistence Across Conversations |  |
-| CFG024 | AVE-2026-00029 | Homoglyph or Unicode Obfuscation Attack |  |
-| CFG090 | AVE-2026-00032 | Network Reconnaissance Instruction |  |
-| CFG033, CFG072 | AVE-2026-00039 | Covert Channel - Steganographic Data Exfiltration |  |
-| CFG007, CFG050, CFG054, CFG065, CFG073, CFG097 | AVE-2026-00047 | Hardcoded credentials in agent component - API keys and secrets exposed in skill files |  |
-| CFG051, CFG085 | AVE-2026-00048 | Unsafe agent delegation chain - sub-agent spawned with inherited permissions and no trust boundary |  |
-| CFG019, CFG020, CFG070 | AVE-2026-00055 | Command execution via untrusted MCP server launch configuration (STDIO) |  |
-| CFG057 | AVE-2026-00057 | Obfuscated or encoded skill payload designed to evade static scanners |  |
-| CFG056 | AVE-2026-00058 | Deceptive skill trigger or activation-scope manipulation via misleading manifest description |  |
-| CFG075 | AVE-2026-00061 | TLS certificate verification disabled in agent component configuration | MCP `env`/`args` TLS-verify killswitch |
-| CFG010, CFG055, CFG074, CFG089 | AVE-2026-00062 | Unpinned dependency version allowing supply chain substitution | unpinned `@latest`/`:latest`, lock file with no integrity pin, unpinned marketplace source |
-| CFG003, CFG004, CFG048, CFG053, CFG063, CFG079, CFG087, CFG091, CFG093, CFG096 | AVE-2026-00063 | Human approval gate bypassed via declarative configuration, distinct from AVE-2026-00048 | a config flag that removes the approval step, across seven agents |
-| CFG047, CFG067, CFG086 | AVE-2026-00064 | Zero-click code execution via project-load auto-run configuration | `.vscode/tasks.json` `folderOpen`, Zed `create_worktree` hook task, zero-click hook events |
+| CFG024 | AVE-2026-00029 | homoglyph / Unicode obfuscation | hidden Unicode control chars in instruction text |
+| CFG026 | AVE-2026-00007 | goal hijack | override / persona / authority instruction |
+| CFG092 | AVE-2026-00007 | goal hijack | Kimi agent file `override: true` replaces the whole system prompt |
+| CFG029 | AVE-2026-00021 | autonomous action without confirmation | instruction to bypass permission prompts |
+| CFG030 | AVE-2026-00010 | covert instruction concealment | "don't tell the user" / secrecy directive |
+| CFG032 | AVE-2026-00025 | conversation-history / role injection | pseudo-system tags, turn-boundary injection |
+| CFG035 | AVE-2026-00011 | dynamic tool-call injection | instruction to configure or trust an MCP server |
+| CFG031, CFG036, CFG037, CFG038 | AVE-2026-00003 | credential exfiltration | sensitive-path read, env dump, embedded exfil shell |
+| CFG033, CFG072 | AVE-2026-00039 | covert-channel exfiltration | markdown-image sink, DNS-name exfil |
+| CFG056 | AVE-2026-00058 | deceptive trigger / activation-scope | broad always-on skill trigger |
+| CFG057 | AVE-2026-00057 | obfuscated / encoded payload | base64 or data-URI encoded injection |
+| CFG081 | AVE-2026-00027 | multi-turn instruction persistence | "survive context compaction" directive |
+| CFG051, CFG085 | AVE-2026-00048 | unsafe agent delegation chain | over-broad tool grant in agent frontmatter |
+| CFG090 | AVE-2026-00032 | network reconnaissance instruction | scan or enumerate an internal network (see gaps re: precision) |
+| CFG008, CFG014 | AVE-2026-00004 | shell-pipe code execution | reverse shell, `curl \| sh` |
+| CFG039 | AVE-2026-00005 | recursive filesystem destruction | `rm -rf` |
+| CFG027, CFG028 | AVE-2026-00008 | persistence / self-replication | cron/startup persistence, writing trust files |
+| CFG007, CFG050, CFG054, CFG065, CFG073, CFG097 | AVE-2026-00047 | hardcoded credentials in component | secrets in settings or MCP env/headers; CFG097 adds a literal in a Gemini remote agent's `auth` block |
+| CFG052, CFG059 | AVE-2026-00017 | server impersonation / spoofing | MCP name shadowing, typosquat |
+| CFG019, CFG020, CFG070 | AVE-2026-00055 | command exec via untrusted MCP launch config | inline-script, env-code, repo-relative launcher |
+| CFG075 | AVE-2026-00061 | TLS verification disabled in config | `NODE_TLS_REJECT_UNAUTHORIZED=0`, `GIT_SSL_NO_VERIFY`, `--insecure` in MCP `env`/`args` |
+| CFG010, CFG055, CFG074, CFG089 | AVE-2026-00062 | unpinned dependency / supply-chain substitution | unpinned `@latest`/`:latest`, `skills-lock.json` with no integrity pin, marketplace source without a full-SHA pin |
+| CFG003, CFG004, CFG048, CFG053, CFG063, CFG079, CFG087, CFG091, CFG093, CFG096 | AVE-2026-00063 | approval gate bypassed by declarative config | `enableAllProjectMcpServers`, `defaultMode: bypassPermissions`, VS Code `chat.permissions.default`, blanket MCP-trust keys, Codex `approval_policy`/`approvals_reviewer`, `autoMode` classifier, a hook answering a permission gate, qwen `approvalMode: yolo`, Cursor allowlists, Gemini MCP `trust` |
+| CFG047, CFG067, CFG086 | AVE-2026-00064 | zero-click project-load auto-run | `.vscode/tasks.json` `runOn: folderOpen` and Zed `create_worktree` hook tasks, committed project hooks, zero-click hook events |
 
 Mappings are class-level behavioral equivalence, not asserted identity. Where a cfgaudit rule covers more than one AVE class, only the canonical primary is emitted (matching AVE's one-`ruleId`-per-class SARIF model); the full multi-mapping is in cfgaudit's own crosswalk doc.
 


### PR DESCRIPTION
Follow-up to #67, and it closes most of what #68 was tracking.

## Coverage

35 rules onto 19 classes → **53 onto 23**.

Most of that is not new cfgaudit rules. Five were added in v1.11.0 and three of them map. The other fifteen new mappings are rules that existed all along and now have a home in the four config classes you added from this crosswalk's own gap list:

| Record | cfgaudit rules |
|---|---|
| `AVE-2026-00061` TLS verification disabled | CFG075 |
| `AVE-2026-00062` unpinned dependency | CFG010, CFG074, CFG055, CFG089 |
| `AVE-2026-00063` approval gate bypassed by config | CFG003, CFG004, CFG048, CFG053, CFG063, CFG079, CFG087, CFG091, CFG093, CFG096 |
| `AVE-2026-00064` zero-click project-load auto-run | CFG047, CFG067, CFG086 |

`00063` is doing a lot of work, which I take as a sign it was the right class to add.

## One mapping moved, on your wording

`CFG091` (qwen `tools.approvalMode: "yolo"`) was on `AVE-2026-00021`, whose text is *"a component that explicitly **instructs** the agent to bypass this confirmation step"*. It is a setting, not an instruction, and `00063` says it covers the declarative case *"independent of any instruction text"*. Moved. `00021` keeps the instruction-driven rule, `CFG029`.

## The two surfaces you were blocked on

Both are now at mechanism level rather than a topic label, matching what I posted in #68.

**Container posture is three mechanisms** with no shared detection logic: the daemon redirected off-host (`DOCKER_HOST`, `-H`), image trust verification disabled (`DOCKER_CONTENT_TRUST=0`, `--disable-content-trust`, `--insecure-registry`), and a Chromium launcher flag replacing the browser subprocess.

**MCP network posture is five**: bind-all, wildcard CORS escalating when auth is off in the same env, deprecated `sse`, a non-loopback proxy, and HTTP transport without log redaction.

Neither is one class. If you pick either up, the daemon redirect and the bind-all case are the highest-value single records.

## Two shapes with no class in either direction

Added to the surfaces table because they are the honest leftovers:

- **A cleartext endpoint**, distinct from TLS verification being disabled. `00061` covers verification switched off; this is no TLS at all. A committed `http://` MCP server URL, model base URL, or `agent_card_url`.
- **Natural-language steering of an approval classifier.** Cursor's `autoRun.allow_instructions` is prose the repository feeds to the classifier that decides whether a tool call runs unattended. It falls between `00063` (explicitly not instruction text) and `00021` (an instruction to the agent, not to a gatekeeper).

## Three gaps added going the other way

Classes cfgaudit does **not** cover, recorded so the crosswalk is honest in both directions:

- `00060` and `00069` need server source and binary image analysis respectively, the same layer as `00052`, `00053` and `00024`.
- `00065` (A2A agent card poisoning) is reachable only as far as the committed pointer. A `.gemini/agents/*.md` may carry an inline `agent_card_json`, which cfgaudit recognises well enough to classify the file as a remote agent, but it does not audit the card's contents. It does flag a cleartext `agent_card_url` and a credential literal in the same file's `auth` block.

## Validation

- `crosswalks/cfgaudit-to-ave.json` validates against `schema/crosswalk-1.0.0.schema.json`
- All 29 referenced AVE ids resolve to records in this repo
- All 53 rule-to-class pairs match cfgaudit's `cmd/cfgaudit/avemap.go` exactly, which is itself drift-guarded on our side by a test that fails if the map and the crosswalk diverge
- Counts taken from `dist/ave-records-latest.manifest.json` (70 records) and a `detection_stage` tally (51 static)

One note on cfgaudit's side, since it affects nothing here but is the reason the version moved: v1.11.0 shipped after a false-positive pass over 432 real repositories, which changed two rules. Neither is mapped.
