### PR TITLE
feat: AVE-2026-00072 -- MCP server bound to all interfaces (NeighborJack)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 ## [Unreleased]
 
 ### Added
+- AVE-2026-00072: MCP server bound to all interfaces with no
+  authentication (NeighborJack) — a wildcard bind address (0.0.0.0 or
+  [::]) makes an MCP server reachable by anyone on the local network
+  with no credential required; the config difference from a safe
+  deployment is a single token. Second of three records drafted from
+  predictor2718's detailed cfgaudit gap breakdown on issue #68 (MEDIUM,
+  AIVSS 5.0)
 - AVE-2026-00070: distributed cross-agent backdoor fragments
   (Collaborative Shadows) — a poisoned tool spreads encrypted, dormant
   attack primitives across multiple distinct agents' own memories

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Stable IDs, AIVSS scores, and behavioral fingerprints for every way a skill file
 MCP server, system prompt, or agent plugin can be weaponized — scored consistently,
 mapped to the frameworks security teams already report against.
 
-[![Records](https://img.shields.io/badge/records-70-0f6e56?style=flat-square)](records/)
+[![Records](https://img.shields.io/badge/records-71-0f6e56?style=flat-square)](records/)
 [![Schema](https://img.shields.io/badge/schema-v1.1.0-0a3024?style=flat-square)](schema/ave-record-1.1.0.schema.json)
 [![AIVSS](https://img.shields.io/badge/AIVSS-v0.8-d4a017?style=flat-square)](https://aivss.owasp.org)
 [![OWASP MCP](https://img.shields.io/badge/OWASP-MCP%20Top%2010-0a3024?style=flat-square)](https://owasp.org)
@@ -99,12 +99,12 @@ skill file          ->   in CI / pre-commit   ->  before deploy
 
 | | |
 |---|---|
-| Total records | 70 |
+| Total records | 71 |
 | Schema version | 1.1.0 |
 | AIVSS spec | v0.8 |
 | CRITICAL (>= 9.0) | 1 |
 | HIGH (7.0-8.9) | 14 |
-| MEDIUM (4.0-6.9) | 53 |
+| MEDIUM (4.0-6.9) | 54 |
 | LOW (< 4.0) | 2 |
 | Framework: OWASP MCP Top 10 | all records |
 | Framework: MITRE ATLAS | where applicable |
@@ -167,7 +167,7 @@ AIVSS = ((8.5 + 7.5) / 2) x 1.0 x 1 = 8.0  ->  HIGH
 ## Record index
 
 <details>
-<summary><strong>70 records, click to expand</strong></summary>
+<summary><strong>71 records, click to expand</strong></summary>
 
 | AVE ID | Title | AIVSS | Severity |
 |---|---|---|---|
@@ -241,6 +241,7 @@ AIVSS = ((8.5 + 7.5) / 2) x 1.0 x 1 = 8.0  ->  HIGH
 | [AVE-2026-00068](records/AVE-2026-00068.json) | CLI Command Composition Risk (MOSAIC) | 5.1 | MEDIUM |
 | [AVE-2026-00069](records/AVE-2026-00069.json) | Multimodal Image-Hidden Instructions (SkillCamo) | 4.8 | MEDIUM |
 | [AVE-2026-00070](records/AVE-2026-00070.json) | Distributed Cross-Agent Backdoor Fragments | 6.4 | MEDIUM |
+| [AVE-2026-00072](records/AVE-2026-00072.json) | MCP Server Bound to All Interfaces (NeighborJack) | 5.0 | MEDIUM |
 
 </details>
 

--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -8748,6 +8748,121 @@
     ]
   },
   {
+    "ave_id": "AVE-2026-00072",
+    "schema_version": "1.1.0",
+    "status": "active",
+    "component_type": "mcp_server",
+    "title": "MCP server bound to all network interfaces with no authentication step (NeighborJack)",
+    "attack_class": "Insecure Configuration - Network Bind Exposure",
+    "severity": "MEDIUM",
+    "description": "An MCP server's declared args or env set its bind address to 0.0.0.0 or [::], the wildcard address, rather than a loopback or explicitly scoped interface. Once bound this way, the server is reachable by anyone on the local network, not just the local machine, and no authentication step separates a local, trusted caller from a remote, untrusted one on the same LAN. The configuration difference from a safe deployment is a single token in the server's args or env; nothing about the server's declared tools or capabilities changes, only who can reach them. predictor2718's own name for this pattern is NeighborJack: a server bound this way grants any device on the same network segment the same tool access a legitimate local client would have, with no credential, token, or prompt required.",
+    "affected_platforms": [
+      "any-mcp-server-with-configurable-bind-address"
+    ],
+    "affected_registries": [
+      "clawhub.io",
+      "smithery.ai",
+      "agentskills.io"
+    ],
+    "aivss_score": 5,
+    "cvss_base_vector": "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+    "owasp_mcp": [
+      "MCP07"
+    ],
+    "mitre_atlas": [],
+    "nist_ai_rmf": [],
+    "behavioral_fingerprint": "An MCP server's declared args or env set its bind address to the wildcard 0.0.0.0 or [::] rather than a loopback address or an explicitly scoped, narrower interface, with no accompanying authentication requirement for incoming connections.",
+    "behavioral_vector": [
+      "network-bind-exposure",
+      "neighborjack",
+      "unauthenticated-lan-reachability"
+    ],
+    "provenance_vector": {
+      "entry_class": "registry_metadata",
+      "payload_surface": "MCP server args or env declaring a bind address of 0.0.0.0 or [::]",
+      "escalation": "instruction_to_capability"
+    },
+    "trifecta_profile": {
+      "requires": [
+        "external_comms"
+      ]
+    },
+    "mitigation": {
+      "strategy": [
+        "deny_by_default",
+        "verify_identity"
+      ],
+      "enforcement_point": "static_scan",
+      "trifecta_control": "break_external_comms"
+    },
+    "example_patterns": [
+      "{\"args\": [\"--host\", \"0.0.0.0\", \"--port\", \"8080\"]}",
+      "{\"env\": {\"BIND_ADDRESS\": \"[::]\"}}"
+    ],
+    "mutation_count": 0,
+    "detection_methodology": "1. Static scan of MCP server args and env for a declared bind address. 2. Flag any value that is the IPv4 wildcard (0.0.0.0) or IPv6 wildcard ([::]) rather than a loopback address (127.0.0.1, ::1) or an explicitly scoped, non-wildcard interface. 3. Cross-reference against any declared authentication configuration for the same server; a wildcard bind with no authentication requirement is the maximal-severity form of this class, though the bind address alone is sufficient to flag regardless of auth state, since auth configuration can itself be misconfigured or absent by default.",
+    "indicators_of_compromise": [
+      "MCP server args or env declaring a bind address of 0.0.0.0 or [::]",
+      "Successful connections to the server's port originating from hosts other than localhost",
+      "Tool invocations against the server with no accompanying authentication credential, token, or session establishment step"
+    ],
+    "remediation": "Bind MCP servers to a loopback address (127.0.0.1 or ::1) by default; require an explicit, separately-reviewed opt-in before binding to a wildcard or LAN-reachable address. Where LAN or remote reachability is genuinely required, pair it with a mandatory authentication step, never rely on network position alone as an implicit trust boundary.",
+    "kill_switch_active": false,
+    "researcher": "Saray Chak",
+    "researcher_url": "https://bawbel.io",
+    "published": "2026-08-06T00:00:00Z",
+    "last_updated": "2026-08-06T00:00:00Z",
+    "references": [
+      {
+        "tag": "cfgaudit crosswalk gap detail",
+        "text": "predictor2718 (cfgaudit maintainer), detailed mechanism breakdown on issue #68: MCP server wildcard bind exposure (CFG018), the NeighborJack pattern, his own recommendation for the single highest-value record if one is drawn from the broader network-posture group.",
+        "url": "https://github.com/aveproject/ave/issues/68"
+      },
+      {
+        "tag": "CWE-1327",
+        "text": "CWE-1327: Binding to an Unrestricted IP Address - MITRE Common Weakness Enumeration",
+        "url": "https://cwe.mitre.org/data/definitions/1327.html"
+      },
+      {
+        "tag": "AVE Registry",
+        "text": "AVE-2026-00072 - AVE behavioral vulnerability registry",
+        "url": "https://github.com/aveproject/ave/blob/main/records/AVE-2026-00072.json"
+      }
+    ],
+    "aivss": {
+      "cvss_base": 8.7,
+      "aarf": {
+        "autonomy": 1,
+        "tool_use": 1,
+        "multi_agent": 0,
+        "non_determinism": 0,
+        "self_modification": 0,
+        "dynamic_identity": 0,
+        "persistent_memory": 0,
+        "natural_language_input": 0,
+        "data_access": 0.5,
+        "external_dependencies": 0
+      },
+      "aars": 2.5,
+      "thm": 0.9,
+      "mitigation_factor": 1,
+      "aivss_score": 5,
+      "aivss_severity": "MEDIUM",
+      "spec_version": "0.8",
+      "notes": "AV:A (adjacent network) rather than AV:N in the CVSS vector: exploitation requires LAN adjacency, not full internet reachability, reflected in a lower external_dependencies AARF score than a remotely-triggerable class would carry. thm set to 0.90 (PoC exists) rather than 1.0: predictor2718 did not cite a specific CVE for CFG018 the way he did for the CORS/logging rules in the same network-posture bucket (CFG066/CFG069), but cfgaudit actively detects this pattern in real deployed configs. MEDIUM severity despite a near-maximum cvss_base (8.7, full unauthenticated tool access to any LAN party) reflects AARF's narrow amplification profile: single-component, no multi-agent, no natural-language surface. owasp_asi intentionally omitted rather than force-fit: this is a network access-control gap, not a match for any of the ten agent-behavior-focused ASI categories, same omission discipline already applied to AVE-2026-00061. Scoped specifically to the wildcard-bind mechanism (CFG018) per predictor2718's own recommendation; CORS wildcard (CFG066, escalates to CVE-2026-33010 combined with disabled auth), deprecated SSE transport (CFG058), non-local proxy routing (CFG021), and unredacted HTTP logging (CFG069, CVE-2026-42282/CVE-2026-41495) are real, separate mechanisms he documented individually, deliberately not folded in here."
+    },
+    "evidence_kind_default": "config_schema",
+    "detection_stage": "static_detection",
+    "detection_layer": "registry_metadata",
+    "confidence_baseline": 0.8,
+    "evidence_basis_engines": [
+      "pattern"
+    ],
+    "derivable_into": [
+      "remote-control-chain"
+    ]
+  },
+  {
     "ave_id": "AVE-2026-00014",
     "schema_version": "1.1.0",
     "component_type": "skill",

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
-  "record_count": 70,
-  "generated_at": "2026-08-03T15:59:54.482Z",
+  "record_count": 71,
+  "generated_at": "2026-08-06T15:14:26.389Z",
   "source": "https://github.com/aveproject/ave"
 }

--- a/records/AVE-2026-00072.json
+++ b/records/AVE-2026-00072.json
@@ -1,0 +1,95 @@
+{
+  "ave_id": "AVE-2026-00072",
+  "schema_version": "1.1.0",
+  "status": "active",
+  "component_type": "mcp_server",
+  "title": "MCP server bound to all network interfaces with no authentication step (NeighborJack)",
+  "attack_class": "Insecure Configuration - Network Bind Exposure",
+  "severity": "MEDIUM",
+  "description": "An MCP server's declared args or env set its bind address to 0.0.0.0 or [::], the wildcard address, rather than a loopback or explicitly scoped interface. Once bound this way, the server is reachable by anyone on the local network, not just the local machine, and no authentication step separates a local, trusted caller from a remote, untrusted one on the same LAN. The configuration difference from a safe deployment is a single token in the server's args or env; nothing about the server's declared tools or capabilities changes, only who can reach them. predictor2718's own name for this pattern is NeighborJack: a server bound this way grants any device on the same network segment the same tool access a legitimate local client would have, with no credential, token, or prompt required.",
+  "affected_platforms": [
+    "any-mcp-server-with-configurable-bind-address"
+  ],
+  "affected_registries": [
+    "clawhub.io", "smithery.ai", "agentskills.io"
+  ],
+  "aivss_score": 5.0,
+  "cvss_base_vector": "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
+  "owasp_mcp": ["MCP07"],
+  "mitre_atlas": [],
+  "nist_ai_rmf": [],
+  "behavioral_fingerprint": "An MCP server's declared args or env set its bind address to the wildcard 0.0.0.0 or [::] rather than a loopback address or an explicitly scoped, narrower interface, with no accompanying authentication requirement for incoming connections.",
+  "behavioral_vector": [
+    "network-bind-exposure",
+    "neighborjack",
+    "unauthenticated-lan-reachability"
+  ],
+  "provenance_vector": {
+    "entry_class": "registry_metadata",
+    "payload_surface": "MCP server args or env declaring a bind address of 0.0.0.0 or [::]",
+    "escalation": "instruction_to_capability"
+  },
+  "trifecta_profile": {
+    "requires": ["external_comms"]
+  },
+  "mitigation": {
+    "strategy": ["deny_by_default", "verify_identity"],
+    "enforcement_point": "static_scan",
+    "trifecta_control": "break_external_comms"
+  },
+  "example_patterns": [
+    "{\"args\": [\"--host\", \"0.0.0.0\", \"--port\", \"8080\"]}",
+    "{\"env\": {\"BIND_ADDRESS\": \"[::]\"}}"
+  ],
+  "mutation_count": 0,
+  "detection_methodology": "1. Static scan of MCP server args and env for a declared bind address. 2. Flag any value that is the IPv4 wildcard (0.0.0.0) or IPv6 wildcard ([::]) rather than a loopback address (127.0.0.1, ::1) or an explicitly scoped, non-wildcard interface. 3. Cross-reference against any declared authentication configuration for the same server; a wildcard bind with no authentication requirement is the maximal-severity form of this class, though the bind address alone is sufficient to flag regardless of auth state, since auth configuration can itself be misconfigured or absent by default.",
+  "indicators_of_compromise": [
+    "MCP server args or env declaring a bind address of 0.0.0.0 or [::]",
+    "Successful connections to the server's port originating from hosts other than localhost",
+    "Tool invocations against the server with no accompanying authentication credential, token, or session establishment step"
+  ],
+  "remediation": "Bind MCP servers to a loopback address (127.0.0.1 or ::1) by default; require an explicit, separately-reviewed opt-in before binding to a wildcard or LAN-reachable address. Where LAN or remote reachability is genuinely required, pair it with a mandatory authentication step, never rely on network position alone as an implicit trust boundary.",
+  "kill_switch_active": false,
+  "researcher": "Saray Chak",
+  "researcher_url": "https://bawbel.io",
+  "published": "2026-08-06T00:00:00Z",
+  "last_updated": "2026-08-06T00:00:00Z",
+  "references": [
+    {
+      "tag": "cfgaudit crosswalk gap detail",
+      "text": "predictor2718 (cfgaudit maintainer), detailed mechanism breakdown on issue #68: MCP server wildcard bind exposure (CFG018), the NeighborJack pattern, his own recommendation for the single highest-value record if one is drawn from the broader network-posture group.",
+      "url": "https://github.com/aveproject/ave/issues/68"
+    },
+    {
+      "tag": "CWE-1327",
+      "text": "CWE-1327: Binding to an Unrestricted IP Address - MITRE Common Weakness Enumeration",
+      "url": "https://cwe.mitre.org/data/definitions/1327.html"
+    },
+    {
+      "tag": "AVE Registry",
+      "text": "AVE-2026-00072 - AVE behavioral vulnerability registry",
+      "url": "https://github.com/aveproject/ave/blob/main/records/AVE-2026-00072.json"
+    }
+  ],
+  "aivss": {
+    "cvss_base": 8.7,
+    "aarf": {
+      "autonomy": 1, "tool_use": 1, "multi_agent": 0, "non_determinism": 0,
+      "self_modification": 0, "dynamic_identity": 0, "persistent_memory": 0,
+      "natural_language_input": 0, "data_access": 0.5, "external_dependencies": 0
+    },
+    "aars": 2.5,
+    "thm": 0.9,
+    "mitigation_factor": 1.0,
+    "aivss_score": 5.0,
+    "aivss_severity": "MEDIUM",
+    "spec_version": "0.8",
+    "notes": "AV:A (adjacent network) rather than AV:N in the CVSS vector: exploitation requires LAN adjacency, not full internet reachability, reflected in a lower external_dependencies AARF score than a remotely-triggerable class would carry. thm set to 0.90 (PoC exists) rather than 1.0: predictor2718 did not cite a specific CVE for CFG018 the way he did for the CORS/logging rules in the same network-posture bucket (CFG066/CFG069), but cfgaudit actively detects this pattern in real deployed configs. MEDIUM severity despite a near-maximum cvss_base (8.7, full unauthenticated tool access to any LAN party) reflects AARF's narrow amplification profile: single-component, no multi-agent, no natural-language surface. owasp_asi intentionally omitted rather than force-fit: this is a network access-control gap, not a match for any of the ten agent-behavior-focused ASI categories, same omission discipline already applied to AVE-2026-00061. Scoped specifically to the wildcard-bind mechanism (CFG018) per predictor2718's own recommendation; CORS wildcard (CFG066, escalates to CVE-2026-33010 combined with disabled auth), deprecated SSE transport (CFG058), non-local proxy routing (CFG021), and unredacted HTTP logging (CFG069, CVE-2026-42282/CVE-2026-41495) are real, separate mechanisms he documented individually, deliberately not folded in here."
+  },
+  "evidence_kind_default": "config_schema",
+  "detection_stage": "static_detection",
+  "detection_layer": "registry_metadata",
+  "confidence_baseline": 0.8,
+  "evidence_basis_engines": ["pattern"],
+  "derivable_into": ["remote-control-chain"]
+}

--- a/tests/fixtures/AVE-2026-00072_negative.md
+++ b/tests/fixtures/AVE-2026-00072_negative.md
@@ -1,0 +1,19 @@
+# MCP server config: internal-notes-server (clean)
+
+```json
+{
+  "mcpServers": {
+    "internal-notes-server": {
+      "command": "notes-mcp",
+      "args": ["--host", "127.0.0.1", "--port", "9421"],
+      "env": {}
+    }
+  }
+}
+```
+
+The server binds to the loopback address only. Only processes running
+on the same machine as the server itself can connect to port 9421; no
+device elsewhere on the local network can reach it regardless of
+whether authentication is configured. The bind address itself is the
+containment boundary here.

--- a/tests/fixtures/AVE-2026-00072_positive.md
+++ b/tests/fixtures/AVE-2026-00072_positive.md
@@ -1,0 +1,22 @@
+# MCP server config: internal-notes-server
+
+```json
+{
+  "mcpServers": {
+    "internal-notes-server": {
+      "command": "notes-mcp",
+      "args": ["--host", "0.0.0.0", "--port", "9421"],
+      "env": {}
+    }
+  }
+}
+```
+
+No authentication configuration is declared anywhere for this server.
+Any device on the same local network segment, not just the machine
+running the MCP client, can connect to port 9421 and invoke every tool
+this server exposes (reading notes, creating notes, deleting notes) with
+no credential, token, or session-establishment step. The bind address
+is the entire difference between this configuration and a safe one; the
+tools, arguments, and everything else about the server declaration are
+ordinary.


### PR DESCRIPTION
## Summary

AVE-2026-00072: MCP server bound to all interfaces with no authentication, "NeighborJack" (MEDIUM, AIVSS 5.0). Second of three records drafted from predictor2718's detailed mechanism breakdown on [issue #68](https://github.com/aveproject/ave/issues/68).

## Mechanism, and why exactly this one from the bucket

MCP network posture was originally a topic label covering five distinct mechanisms with no shared detection logic. This record covers only the wildcard bind (CFG018), predictor2718's own recommendation for the single highest-value record if one is drawn from the group: a server bound to `0.0.0.0`/`[::]` is reachable by anyone on the LAN with no authentication step, and the config difference from a safe deployment is a single token.

**Explicitly excluded**, all real, distinct future record candidates per predictor2718's own breakdown:
- Wildcard CORS (CFG066, escalates to CVE-2026-33010 combined with disabled auth)
- Deprecated SSE transport (CFG058)
- Non-local proxy routing (CFG021)
- Unredacted HTTP logging (CFG069, CVE-2026-42282 and CVE-2026-41495)

## Framework mappings, researched not assumed

- `owasp_mcp: ["MCP07"]` (Insufficient Authentication & Authorization) verified against OWASP's own published category list.
- `mitre_atlas: []`: researched. Independent research confirms "MCP server compromise as a pivot point" is an explicitly documented current gap in ATLAS's own coverage, not yet a defined technique -- not a research shortfall, a genuine absence.
- `owasp_asi` intentionally omitted, same discipline already applied to AVE-2026-00061: this is a network access-control gap, not a fit for any of the ten agent-behavior-focused ASI categories.
- `CWE-1327` (Binding to an Unrestricted IP Address) confirmed as a precise match.

## AIVSS notes

`AV:A` (adjacent network) rather than `AV:N`: exploitation requires LAN adjacency, not full internet reachability. MEDIUM despite a near-maximum `cvss_base` (8.7, full unauthenticated tool access to any LAN party) reflects AARF's narrow amplification profile.

## Validation

- `python3 scripts/validate_records.py`: all 71 records valid.
- `python3 scripts/check_fixtures.py`: all 71 records have positive + negative fixtures.
- `pytest tests/ -x -q`: 284 passed.
- `python3 scripts/validate_crosswalks.py`: 4/4 crosswalks valid.
- No vendor boilerplate.
- `node scripts/build-records.js`: dist regenerated; frozen v1.1.0 snapshot untouched.
- README badge/stats/index (all three record-count locations) and CHANGELOG updated in this commit.

## Scope notes

No detection-rule PR in bawbel/scanner -- separate tracker. One more record from the same issue #68 breakdown to follow (telemetry redirect); a fourth (sandbox-config weakening) is explicitly held per predictor2718's own two flagged reasons.