### PR TITLE
Validate AVE record string formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dev = [
     # GPL, and over the [format-nongpl] extra, which pulls in thirteen
     # distributions to reach the same two checkers.
     "rfc3986-validator>=0.1.1",
+    # Registers the "date-time" format checker used by AVE record metadata.
+    "rfc3339-validator>=0.1.4",
 ]
 
 # Not a Python library -- nothing here imports "bawbel_ave" as a package.

--- a/scripts/validate_records.py
+++ b/scripts/validate_records.py
@@ -12,10 +12,11 @@
 #       consumer of the corpus. A stray vendor product name is a neutrality
 #       violation this project enforces everywhere else; records shouldn't be
 #       the one place it's unchecked.
-# How:  jsonschema.Draft202012Validator against schema/ave-record-1.1.0.schema.json
-#       (handles the draft-vs-active conditional required set natively), plus a
-#       handful of checks the schema's additionalProperties:false already implies
-#       but which deserve a readable, named failure message of their own
+# How:  jsonschema.Draft202012Validator with format checking enabled against
+#       schema/ave-record-1.1.0.schema.json (handles the draft-vs-active
+#       conditional required set natively and enforces date-time / uri metadata),
+#       plus a handful of checks the schema's additionalProperties:false already
+#       implies but which deserve a readable, named failure message of their own
 import json
 import re
 import sys
@@ -53,6 +54,12 @@ VENDOR_BOILERPLATE_PATTERNS = [
 def check_schema(record: dict, validator: jsonschema.Draft202012Validator) -> list[str]:
     return [f"schema: {e.message} (at {'/'.join(str(p) for p in e.path) or '<root>'})"
             for e in validator.iter_errors(record)]
+
+
+def build_validator(schema: dict) -> jsonschema.Draft202012Validator:
+    return jsonschema.Draft202012Validator(
+        schema, format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER
+    )
 
 
 def check_no_old_field_names(record: dict) -> list[str]:
@@ -136,7 +143,7 @@ def check_no_vendor_boilerplate(raw_text: str) -> list[str]:
 def main() -> int:
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.Draft202012Validator.check_schema(schema)
-    validator = jsonschema.Draft202012Validator(schema)
+    validator = build_validator(schema)
 
     paths = sorted(RECORDS_DIR.glob("AVE-*.json"))
     if not paths:

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -1,0 +1,23 @@
+import json
+
+from scripts import validate_records
+
+
+def test_record_validator_rejects_invalid_date_time_format():
+    schema = json.loads(validate_records.SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = validate_records.build_validator(schema)
+    record = {
+        "ave_id": "AVE-2026-99999",
+        "schema_version": "1.1.0",
+        "status": "draft",
+        "title": "Invalid date-time fixture",
+        "description": "A minimal draft record with malformed published metadata.",
+        "attack_class": "test",
+        "behavioral_fingerprint": "test",
+        "references": [{"title": "Example", "url": "https://example.com"}],
+        "published": "not-a-date-time",
+    }
+
+    errors = validate_records.check_schema(record, validator)
+
+    assert any("not-a-date-time" in error for error in errors)


### PR DESCRIPTION
﻿## Summary

- enable `Draft202012Validator` format checking in `scripts/validate_records.py`
- add `rfc3339-validator` as a dev dependency so `date-time` formats are actually enforced
- add regression coverage for malformed record `published` metadata

## Root cause

`validate_records.py` built `Draft202012Validator(schema)` without a format checker. Adding `FORMAT_CHECKER` alone registers `uri` because `rfc3986-validator` is already present, but this environment showed `date-time` was still not registered until `rfc3339-validator` was installed.

Closes #125.

## Verification

- `python -m pytest -q` -> 281 passed
- `python scripts/validate_records.py` -> all 70 records valid
- `python scripts/validate_crosswalks.py` -> 4/4 crosswalks valid
- `python -m py_compile scripts/validate_records.py tests/test_validate_data.py` -> passed
