### PR TITLE
fix: use scoped PAT for dist/ regenerate auto-PR, not default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/regenerate-records-json.yml
+++ b/.github/workflows/regenerate-records-json.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Open PR if dist/ changed
         uses: peter-evans/create-pull-request@v8
         with:
+          # The default GITHUB_TOKEN can't open PRs unless "Allow GitHub
+          # Actions to create and approve pull requests" is on repo-wide --
+          # off by default, and left off here deliberately so no other
+          # workflow in this repo picks up that ability. DIST_SYNC_PR_TOKEN
+          # is a fine-grained PAT scoped to this repo only (contents +
+          # pull-requests: read/write, nothing else), used only by this step.
+          token: ${{ secrets.DIST_SYNC_PR_TOKEN }}
           commit-message: "chore: regenerate consolidated records JSON"
           title: "chore: regenerate consolidated records JSON"
           body: |


### PR DESCRIPTION
## Problem

The `regenerate-records-json` workflow has failed on every single run
since at least 2026-07-28 (11 consecutive failures) at its "Open PR if
dist/ changed" step:

```
##[error]GitHub Actions is not permitted to create or approve pull requests.
```

`peter-evans/create-pull-request@v8` had no `token:` input, so it fell
back to the default `GITHUB_TOKEN`. This repo has "Allow GitHub Actions
to create and approve pull requests" off (confirmed via
`gh api repos/aveproject/ave/actions/permissions/workflow` ->
`can_approve_pull_request_reviews: false`), which hard-gates PR creation
regardless of the `permissions:` block declared in the workflow YAML.

## Fix

Point only the PR-creation step at `DIST_SYNC_PR_TOKEN`, a fine-grained
PAT scoped to `aveproject/ave` only (`contents` + `pull requests`:
read/write, real expiration set, nothing else). This is narrower than
flipping the repo-wide toggle, which would hand every workflow in this
repo PR-creation rights it doesn't need. Earlier steps (checkout,
`npm ci`, `build-records.js`) are untouched and keep using the default
`GITHUB_TOKEN`.

## Verification

Can't fully verify until this merges to `develop` -- the workflow only
triggers on push to `develop` touching `records/`. Once merged, the next
`records/` change landing on `develop` (e.g. the pending AVE-2026-00075
PR) will be the real end-to-end trigger. Flagging that as the follow-up
check rather than claiming it's proven green here.