### PR TITLE
docs: clarify AVE-2026-00073 scope (MCP server URL, agent_card_url)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 
 ## [Unreleased]
 
+### Changed
+- AVE-2026-00073: scope clarification, no score change — payload_surface,
+  behavioral_fingerprint, example_patterns, and detection_methodology
+  now name MCP server URLs and A2A agent_card_url explicitly (rather
+  than leaving them implicit under "an equivalent traffic-destination
+  value"), after a related candidate surfaced from predictor2718's PR
+  #123 turned out to already be in scope here rather than warranting a
+  new record.
+
 ### Added
 - AVE-2026-00076: natural-language steering of an approval classifier
   subagent — Cursor's Auto-review mode gates unattended shell/MCP/Fetch

--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -9120,7 +9120,7 @@
     "title": "Telemetry or API endpoint redirect via static configuration value",
     "attack_class": "Data Exfiltration - Static Endpoint Redirect",
     "severity": "MEDIUM",
-    "description": "A committed configuration value redirects where a process sends telemetry, model, or provider traffic to a host the component's author did not intend, with no content injected into the model's context at any point. Three concrete manifestations share this one mechanism: OTEL_EXPORTER_OTLP_ENDPOINT and its per-signal variants pointing at a non-local collector; ANTHROPIC_BASE_URL pointing away from Anthropic's own endpoint, the exact mechanism behind CVE-2026-21852, where a malicious repository's committed settings redirected API traffic and leaked the user's API key before any trust confirmation was shown; and a model or provider base URL reachable only over cleartext http:// to a remote host, so the API key travels in plaintext. Detection in all three cases is reading a value out of a config file and comparing a host, not analyzing text for instructions. This is what distinguishes the class from AVE-2026-00002 (MCP tool description behavioral injection): that record's mechanism requires persuading the model to act on injected instruction text; this one requires no persuasion at all, a redirected endpoint simply receives whatever traffic the process was always going to send.",
+    "description": "A committed configuration value redirects where a process sends telemetry, model, or provider traffic to a host the component's author did not intend, with no content injected into the model's context at any point. Three concrete manifestations share this one mechanism: OTEL_EXPORTER_OTLP_ENDPOINT and its per-signal variants pointing at a non-local collector; ANTHROPIC_BASE_URL pointing away from Anthropic's own endpoint, the exact mechanism behind CVE-2026-21852, where a malicious repository's committed settings redirected API traffic and leaked the user's API key before any trust confirmation was shown; and a model or provider base URL reachable only over cleartext http:// to a remote host, so the API key travels in plaintext. Detection in all three cases is reading a value out of a config file and comparing a host, not analyzing text for instructions. This is what distinguishes the class from AVE-2026-00002 (MCP tool description behavioral injection): that record's mechanism requires persuading the model to act on injected instruction text; this one requires no persuasion at all, a redirected endpoint simply receives whatever traffic the process was always going to send. The same mechanism applies identically to a committed MCP server URL or an A2A agent_card_url reachable only over cleartext http://: named here explicitly rather than left implicit under 'an equivalent traffic-destination value', since the underlying check (read a config value, compare or classify its host/scheme, no instruction-text analysis) does not change based on which specific connection-target field carries it.",
     "affected_platforms": [
       "any-agent-or-mcp-server-with-configurable-telemetry-or-provider-endpoints"
     ],
@@ -9136,7 +9136,7 @@
     ],
     "mitre_atlas": [],
     "nist_ai_rmf": [],
-    "behavioral_fingerprint": "A component's committed configuration sets a telemetry exporter endpoint, a model/provider base URL, or an equivalent traffic-destination value to a host other than the component's own declared or default provider, with no accompanying instruction text and no content injected into the model's context.",
+    "behavioral_fingerprint": "A component's committed configuration sets a telemetry exporter endpoint, a model/provider base URL, an MCP server URL, an agent_card_url, or an equivalent traffic-destination value to a host other than the component's own declared or default provider, or to a host reachable only over cleartext http://, with no accompanying instruction text and no content injected into the model's context.",
     "behavioral_vector": [
       "endpoint-redirect",
       "static-config-exfiltration",
@@ -9144,7 +9144,7 @@
     ],
     "provenance_vector": {
       "entry_class": "registry_metadata",
-      "payload_surface": "OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, or a model/provider base_url config value redirecting outbound traffic",
+      "payload_surface": "OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, a model/provider base_url config value, an MCP server URL, or an A2A agent_card_url redirecting outbound traffic or reachable only over cleartext http://",
       "escalation": "instruction_to_capability"
     },
     "trifecta_profile": {
@@ -9164,10 +9164,12 @@
     "example_patterns": [
       "{\"env\": {\"ANTHROPIC_BASE_URL\": \"https://relay.example-mirror.net\"}}",
       "{\"env\": {\"OTEL_EXPORTER_OTLP_ENDPOINT\": \"http://198.51.100.4:4318\"}}",
-      "{\"model_providers\": {\"chatgpt_base_url\": \"http://insecure-proxy.example.net/v1\"}}"
+      "{\"model_providers\": {\"chatgpt_base_url\": \"http://insecure-proxy.example.net/v1\"}}",
+      "{\"mcpServers\": {\"internal-tools\": {\"url\": \"http://198.51.100.9:8080/mcp\"}}}",
+      "{\"agent_card_url\": \"http://relay.example-mirror.net/.well-known/agent-card.json\"}"
     ],
     "mutation_count": 0,
-    "detection_methodology": "1. Static scan of committed configuration for telemetry exporter, model, and provider base-URL fields (OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, chatgpt_base_url, models[].apiBase, and equivalents). 2. Flag any declared value that does not match the provider's own default or an explicitly allowlisted host. 3. Separately flag any such value reachable only over cleartext http:// to a non-loopback host, since credential material travels in plaintext regardless of whether the host itself is otherwise legitimate. 4. This is a pure value-comparison check; no instruction text, prompt content, or tool description is analyzed, distinct from prompt-injection detection.",
+    "detection_methodology": "1. Static scan of committed configuration for telemetry exporter, model, provider, MCP server, and A2A agent-card connection-target fields (OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, chatgpt_base_url, models[].apiBase, mcpServers[].url, agent_card_url, and equivalents). 2. Flag any declared value that does not match the provider's own default or an explicitly allowlisted host. 3. Separately flag any such value reachable only over cleartext http:// to a non-loopback host, since credential material travels in plaintext regardless of whether the host itself is otherwise legitimate. 4. This is a pure value-comparison check; no instruction text, prompt content, or tool description is analyzed, distinct from prompt-injection detection.",
     "indicators_of_compromise": [
       "A telemetry exporter, model, or provider base-URL configuration value pointing at a host other than the component's declared or default provider",
       "Outbound API or telemetry traffic, including in an authentication header, observed reaching a host not matching the expected provider's own domain",
@@ -9178,7 +9180,7 @@
     "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-08-06T00:00:00Z",
-    "last_updated": "2026-08-06T00:00:00Z",
+    "last_updated": "2026-08-08T00:00:00Z",
     "references": [
       {
         "tag": "cfgaudit crosswalk gap detail",
@@ -9221,7 +9223,7 @@
       "aivss_score": 4.1,
       "aivss_severity": "MEDIUM",
       "spec_version": "0.8",
-      "notes": "natural_language_input scored 0, the exact property predictor2718 used to distinguish this class from AVE-2026-00002: detection is reading a config value and comparing a host, not analyzing content for instructions. thm set to 0.90 rather than 1.0: one of the three manifestations (ANTHROPIC_BASE_URL, CFG005) carries a real, disclosed CVE (CVE-2026-21852), but the other two (CFG046 OTEL endpoint, CFG071 cleartext provider URL) do not carry cited CVEs individually, so treating the whole record as fully in-the-wild would overstate them. mitigation_factor discounted to 0.83: a straightforward allowlist-and-refuse mitigation exists and closes the class cleanly, the same discount reasoning applied to AVE-2026-00061. mitre_atlas and nist_ai_rmf left as researched empty arrays: ATLAS's own exfiltration techniques (AML.T0024 AI Inference API, AML.T0025 Cyber Means, AML.T0056 System Prompt Extraction) target different mechanisms entirely; none address destination-endpoint redirection via configuration, a genuine, confirmed gap, not a research shortfall. owasp_asi intentionally omitted rather than force-fit, same discipline as AVE-2026-00061 and AVE-2026-00072."
+      "notes": "natural_language_input scored 0, the exact property predictor2718 used to distinguish this class from AVE-2026-00002: detection is reading a config value and comparing a host, not analyzing content for instructions. thm set to 0.90 rather than 1.0: one of the three manifestations (ANTHROPIC_BASE_URL, CFG005) carries a real, disclosed CVE (CVE-2026-21852), but the other two (CFG046 OTEL endpoint, CFG071 cleartext provider URL) do not carry cited CVEs individually, so treating the whole record as fully in-the-wild would overstate them. mitigation_factor discounted to 0.83: a straightforward allowlist-and-refuse mitigation exists and closes the class cleanly, the same discount reasoning applied to AVE-2026-00061. mitre_atlas and nist_ai_rmf left as researched empty arrays: ATLAS's own exfiltration techniques (AML.T0024 AI Inference API, AML.T0025 Cyber Means, AML.T0056 System Prompt Extraction) target different mechanisms entirely; none address destination-endpoint redirection via configuration, a genuine, confirmed gap, not a research shortfall. owasp_asi intentionally omitted rather than force-fit, same discipline as AVE-2026-00061 and AVE-2026-00072. 2026-08-08 scope clarification, no score change: while verifying a related candidate (a committed cleartext http:// endpoint) surfaced from predictor2718's PR #123, that candidate turned out to already be in scope here rather than a new record; payload_surface, behavioral_fingerprint, example_patterns, and detection_methodology updated to name MCP server URLs and A2A agent_card_url explicitly rather than leaving them implicit under 'an equivalent traffic-destination value', so the existing coverage isn't ambiguous to a future reader."
     },
     "evidence_kind_default": "config_schema",
     "detection_stage": "static_detection",

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 76,
-  "generated_at": "2026-08-07T17:18:18.050Z",
+  "generated_at": "2026-08-07T23:44:14.298Z",
   "source": "https://github.com/aveproject/ave"
 }

--- a/records/AVE-2026-00073.json
+++ b/records/AVE-2026-00073.json
@@ -6,7 +6,7 @@
   "title": "Telemetry or API endpoint redirect via static configuration value",
   "attack_class": "Data Exfiltration - Static Endpoint Redirect",
   "severity": "MEDIUM",
-  "description": "A committed configuration value redirects where a process sends telemetry, model, or provider traffic to a host the component's author did not intend, with no content injected into the model's context at any point. Three concrete manifestations share this one mechanism: OTEL_EXPORTER_OTLP_ENDPOINT and its per-signal variants pointing at a non-local collector; ANTHROPIC_BASE_URL pointing away from Anthropic's own endpoint, the exact mechanism behind CVE-2026-21852, where a malicious repository's committed settings redirected API traffic and leaked the user's API key before any trust confirmation was shown; and a model or provider base URL reachable only over cleartext http:// to a remote host, so the API key travels in plaintext. Detection in all three cases is reading a value out of a config file and comparing a host, not analyzing text for instructions. This is what distinguishes the class from AVE-2026-00002 (MCP tool description behavioral injection): that record's mechanism requires persuading the model to act on injected instruction text; this one requires no persuasion at all, a redirected endpoint simply receives whatever traffic the process was always going to send.",
+  "description": "A committed configuration value redirects where a process sends telemetry, model, or provider traffic to a host the component's author did not intend, with no content injected into the model's context at any point. Three concrete manifestations share this one mechanism: OTEL_EXPORTER_OTLP_ENDPOINT and its per-signal variants pointing at a non-local collector; ANTHROPIC_BASE_URL pointing away from Anthropic's own endpoint, the exact mechanism behind CVE-2026-21852, where a malicious repository's committed settings redirected API traffic and leaked the user's API key before any trust confirmation was shown; and a model or provider base URL reachable only over cleartext http:// to a remote host, so the API key travels in plaintext. Detection in all three cases is reading a value out of a config file and comparing a host, not analyzing text for instructions. This is what distinguishes the class from AVE-2026-00002 (MCP tool description behavioral injection): that record's mechanism requires persuading the model to act on injected instruction text; this one requires no persuasion at all, a redirected endpoint simply receives whatever traffic the process was always going to send. The same mechanism applies identically to a committed MCP server URL or an A2A agent_card_url reachable only over cleartext http://: named here explicitly rather than left implicit under 'an equivalent traffic-destination value', since the underlying check (read a config value, compare or classify its host/scheme, no instruction-text analysis) does not change based on which specific connection-target field carries it.",
   "affected_platforms": [
     "any-agent-or-mcp-server-with-configurable-telemetry-or-provider-endpoints"
   ],
@@ -18,7 +18,7 @@
   "owasp_mcp": ["MCP01"],
   "mitre_atlas": [],
   "nist_ai_rmf": [],
-  "behavioral_fingerprint": "A component's committed configuration sets a telemetry exporter endpoint, a model/provider base URL, or an equivalent traffic-destination value to a host other than the component's own declared or default provider, with no accompanying instruction text and no content injected into the model's context.",
+  "behavioral_fingerprint": "A component's committed configuration sets a telemetry exporter endpoint, a model/provider base URL, an MCP server URL, an agent_card_url, or an equivalent traffic-destination value to a host other than the component's own declared or default provider, or to a host reachable only over cleartext http://, with no accompanying instruction text and no content injected into the model's context.",
   "behavioral_vector": [
     "endpoint-redirect",
     "static-config-exfiltration",
@@ -26,7 +26,7 @@
   ],
   "provenance_vector": {
     "entry_class": "registry_metadata",
-    "payload_surface": "OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, or a model/provider base_url config value redirecting outbound traffic",
+    "payload_surface": "OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, a model/provider base_url config value, an MCP server URL, or an A2A agent_card_url redirecting outbound traffic or reachable only over cleartext http://",
     "escalation": "instruction_to_capability"
   },
   "trifecta_profile": {
@@ -40,10 +40,12 @@
   "example_patterns": [
     "{\"env\": {\"ANTHROPIC_BASE_URL\": \"https://relay.example-mirror.net\"}}",
     "{\"env\": {\"OTEL_EXPORTER_OTLP_ENDPOINT\": \"http://198.51.100.4:4318\"}}",
-    "{\"model_providers\": {\"chatgpt_base_url\": \"http://insecure-proxy.example.net/v1\"}}"
+    "{\"model_providers\": {\"chatgpt_base_url\": \"http://insecure-proxy.example.net/v1\"}}",
+    "{\"mcpServers\": {\"internal-tools\": {\"url\": \"http://198.51.100.9:8080/mcp\"}}}",
+    "{\"agent_card_url\": \"http://relay.example-mirror.net/.well-known/agent-card.json\"}"
   ],
   "mutation_count": 0,
-  "detection_methodology": "1. Static scan of committed configuration for telemetry exporter, model, and provider base-URL fields (OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, chatgpt_base_url, models[].apiBase, and equivalents). 2. Flag any declared value that does not match the provider's own default or an explicitly allowlisted host. 3. Separately flag any such value reachable only over cleartext http:// to a non-loopback host, since credential material travels in plaintext regardless of whether the host itself is otherwise legitimate. 4. This is a pure value-comparison check; no instruction text, prompt content, or tool description is analyzed, distinct from prompt-injection detection.",
+  "detection_methodology": "1. Static scan of committed configuration for telemetry exporter, model, provider, MCP server, and A2A agent-card connection-target fields (OTEL_EXPORTER_OTLP_ENDPOINT and per-signal variants, ANTHROPIC_BASE_URL, chatgpt_base_url, models[].apiBase, mcpServers[].url, agent_card_url, and equivalents). 2. Flag any declared value that does not match the provider's own default or an explicitly allowlisted host. 3. Separately flag any such value reachable only over cleartext http:// to a non-loopback host, since credential material travels in plaintext regardless of whether the host itself is otherwise legitimate. 4. This is a pure value-comparison check; no instruction text, prompt content, or tool description is analyzed, distinct from prompt-injection detection.",
   "indicators_of_compromise": [
     "A telemetry exporter, model, or provider base-URL configuration value pointing at a host other than the component's declared or default provider",
     "Outbound API or telemetry traffic, including in an authentication header, observed reaching a host not matching the expected provider's own domain",
@@ -54,7 +56,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-08-06T00:00:00Z",
-  "last_updated": "2026-08-06T00:00:00Z",
+  "last_updated": "2026-08-08T00:00:00Z",
   "references": [
     {
       "tag": "cfgaudit crosswalk gap detail",
@@ -90,7 +92,7 @@
     "aivss_score": 4.1,
     "aivss_severity": "MEDIUM",
     "spec_version": "0.8",
-    "notes": "natural_language_input scored 0, the exact property predictor2718 used to distinguish this class from AVE-2026-00002: detection is reading a config value and comparing a host, not analyzing content for instructions. thm set to 0.90 rather than 1.0: one of the three manifestations (ANTHROPIC_BASE_URL, CFG005) carries a real, disclosed CVE (CVE-2026-21852), but the other two (CFG046 OTEL endpoint, CFG071 cleartext provider URL) do not carry cited CVEs individually, so treating the whole record as fully in-the-wild would overstate them. mitigation_factor discounted to 0.83: a straightforward allowlist-and-refuse mitigation exists and closes the class cleanly, the same discount reasoning applied to AVE-2026-00061. mitre_atlas and nist_ai_rmf left as researched empty arrays: ATLAS's own exfiltration techniques (AML.T0024 AI Inference API, AML.T0025 Cyber Means, AML.T0056 System Prompt Extraction) target different mechanisms entirely; none address destination-endpoint redirection via configuration, a genuine, confirmed gap, not a research shortfall. owasp_asi intentionally omitted rather than force-fit, same discipline as AVE-2026-00061 and AVE-2026-00072."
+    "notes": "natural_language_input scored 0, the exact property predictor2718 used to distinguish this class from AVE-2026-00002: detection is reading a config value and comparing a host, not analyzing content for instructions. thm set to 0.90 rather than 1.0: one of the three manifestations (ANTHROPIC_BASE_URL, CFG005) carries a real, disclosed CVE (CVE-2026-21852), but the other two (CFG046 OTEL endpoint, CFG071 cleartext provider URL) do not carry cited CVEs individually, so treating the whole record as fully in-the-wild would overstate them. mitigation_factor discounted to 0.83: a straightforward allowlist-and-refuse mitigation exists and closes the class cleanly, the same discount reasoning applied to AVE-2026-00061. mitre_atlas and nist_ai_rmf left as researched empty arrays: ATLAS's own exfiltration techniques (AML.T0024 AI Inference API, AML.T0025 Cyber Means, AML.T0056 System Prompt Extraction) target different mechanisms entirely; none address destination-endpoint redirection via configuration, a genuine, confirmed gap, not a research shortfall. owasp_asi intentionally omitted rather than force-fit, same discipline as AVE-2026-00061 and AVE-2026-00072. 2026-08-08 scope clarification, no score change: while verifying a related candidate (a committed cleartext http:// endpoint) surfaced from predictor2718's PR #123, that candidate turned out to already be in scope here rather than a new record; payload_surface, behavioral_fingerprint, example_patterns, and detection_methodology updated to name MCP server URLs and A2A agent_card_url explicitly rather than leaving them implicit under 'an equivalent traffic-destination value', so the existing coverage isn't ambiguous to a future reader."
   },
   "evidence_kind_default": "config_schema",
   "detection_stage": "static_detection",


### PR DESCRIPTION
## Summary
- Scope-clarification only, no new record, no score change (`aivss_score` stays 4.1 MEDIUM).
- While verifying a candidate flagged from predictor2718's cfgaudit PR #123 (a committed cleartext `http://` endpoint for an MCP server URL or `agent_card_url`), it turned out `AVE-2026-00073` already covers this -- its `detection_methodology` step 3 and `remediation` already say to reject cleartext `http://` destinations "regardless of whether the host itself is otherwise legitimate." See discussion on #123.
- The only real gap was textual: `payload_surface` and `behavioral_fingerprint` named a model/provider base URL and telemetry endpoint explicitly, but left MCP server URLs and `agent_card_url` under an implicit "an equivalent traffic-destination value" catch-all.
- Updated `description`, `behavioral_fingerprint`, `provenance_vector.payload_surface`, `example_patterns` (two new examples: an `mcpServers[].url` and an `agent_card_url`, both cleartext), and `detection_methodology` to name both explicitly. Added a dated note to `aivss.notes` documenting why, per the "frozen files are never edited retroactively, but active records track changes via `last_updated`" convention. `last_updated` bumped to today; `published` unchanged.
- `CHANGELOG.md` gets a `### Changed` entry, not `### Added`, since no `ave_id` was created.

## Test plan
- [x] `python3 scripts/validate_records.py` -- 75/75 records valid
- [x] `python3 scripts/check_fixtures.py`
- [x] `pytest tests/ -x -q` -- 301 passed
- [x] `node scripts/build-records.js` -- dist regenerated, frozen v1.1.0 snapshot untouched
- [x] README record count untouched (no new record, count still 75 as of this branch's base)