### PR TITLE
fix: escape commit message in notify-ave-site client-payload

### DIFF
--- a/.github/workflows/notify-ave-site.yml
+++ b/.github/workflows/notify-ave-site.yml
@@ -35,5 +35,5 @@ jobs:
             {
               "ave_ref": "${{ github.sha }}",
               "pusher": "${{ github.actor }}",
-              "message": "${{ github.event.head_commit.message }}"
+              "message": ${{ toJSON(github.event.head_commit.message) }}
             }


### PR DESCRIPTION
## Summary
- Fixes the `Notify ave-site on records update` workflow, which has been failing on every trigger since at least 2026-07-13.
- Two independent bugs stacked here, found and fixed in sequence:
  1. `AVE_SITE_DEPLOY_TOKEN` didn't exist as a repo secret at all -- every run failed at token validation ("Parameter token or opts.auth is required") before ever reaching the payload. Now added (not part of this PR, done directly in repo settings).
  2. Once the token existed, re-running the last failed run surfaced a second, previously-masked bug: `client-payload` interpolates `github.event.head_commit.message` directly into a JSON string via `"${{ ... }}"`. Multi-line commit messages (i.e. any commit with a trailer -- most commits in this repo) contain raw newlines, invalid inside a JSON string literal unless escaped, so the dispatch failed with `Bad control character in string literal in JSON`.
- Fixed by switching to `${{ toJSON(github.event.head_commit.message) }}`, which properly escapes newlines/quotes and already returns a quoted string, so the surrounding literal quotes are removed for that field.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Once merged and synced to `main`, confirm the next `records/**` or `schema/**` push triggers a green run (previously reproduced the JSON error via `gh run rerun` against a real multi-line commit message on the current, unfixed workflow)