### PR TITLE
feat: ramparts-to-ave crosswalk + numbering-mismatch caution

### DIFF
--- a/crosswalks/ramparts-to-ave.json
+++ b/crosswalks/ramparts-to-ave.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://aveproject.org/schema/crosswalk-1.0.0.schema.json",
+  "source": {
+    "tool": "Ramparts",
+    "vendor": "Highflame Inc.",
+    "url": "https://github.com/highflame-ai/ramparts",
+    "license": "Apache-2.0",
+    "commit": "a62b320ae1f59da9937e721715bec54c9a5bc5c0"
+  },
+  "target": {
+    "standard": "AVE",
+    "version": "1.1.0",
+    "url": "https://aveproject.org",
+    "record_count": 76,
+    "static_record_count": 57
+  },
+  "generated": "2026-08-08",
+  "note": "Ramparts and AVE both draft their own reading of the still-unratified OWASP MCP Top 10, independently, and their MCP01-MCP10 numbering does not align category-for-category; Ramparts' MCP03 (Excessive Agency) and AVE's MCP03 (Tool Poisoning) are unrelated despite sharing a number. This crosswalk matches by verified mechanism, not by shared tag number, see AVE issue #138 for the full verification. One Ramparts rule, EnvironmentVariableLeakage, splits into two distinct AVE mappings depending on which internal condition fires, a literal-value branch and a theft-language branch, not one-to-one. Near-miss not included in mappings: Ramparts' CommandInjection is a signature match over dangerous syntax anywhere in content; AVE-2026-00052 specifically requires a taint path from a caller-supplied parameter to shell exec. Same subject, different rigor, the exact distinction between signature-based scanning and reachability analysis. Real gaps in both directions: Ramparts' cross-origin tool confusion detection and its MCPConfigChanged baseline-diff check (a previously-approved server's fingerprint changing after the fact) have no AVE analog today; AVE has nothing for session-memory or cross-agent-state poisoning, which Ramparts does not currently touch either.",
+  "mappings": [
+    {
+      "ramparts_finding": "SecretsLeakage",
+      "ave_id": "AVE-2026-00047",
+      "title": "Hardcoded credentials in agent component - API keys and secrets exposed in skill files",
+      "notes": "Both require a literal high-entropy credential value adjacent to a credential keyword. AVE's fingerprint explicitly excludes env-var references, matching Ramparts' literal-value requirement."
+    },
+    {
+      "ramparts_finding": "EnvironmentVariableLeakage ($named_assignment_with_value branch)",
+      "ave_id": "AVE-2026-00047",
+      "title": "Hardcoded credentials in agent component - API keys and secrets exposed in skill files",
+      "notes": "Same literal-value mechanism as SecretsLeakage, anchored to env-var-shaped names specifically."
+    },
+    {
+      "ramparts_finding": "EnvironmentVariableLeakage ($theft_language + $env_access branch)",
+      "ave_id": "AVE-2026-00003",
+      "title": "Credential exfiltration via agent instruction",
+      "notes": "The other half of the same Ramparts rule. Matches AVE's instructed-exfiltration mechanism, not the hardcoded-literal one. One rule name, two distinct AVE mechanisms depending on which internal condition fires."
+    },
+    {
+      "ramparts_finding": "MCPConfigRisk",
+      "ave_id": "AVE-2026-00055",
+      "title": "Command execution via untrusted MCP server launch configuration (STDIO)",
+      "notes": "Both: STDIO launch config (command/args) executes without a validation gate."
+    },
+    {
+      "ramparts_finding": "PathTraversalVulnerability",
+      "ave_id": "AVE-2026-00053",
+      "title": "Path traversal via unsanitized path parameter in MCP resource/file-handler implementation",
+      "notes": "Direct mechanism match."
+    },
+    {
+      "ramparts_finding": "SkillEmbeddedPayload",
+      "ave_id": "AVE-2026-00057",
+      "title": "Obfuscated or encoded skill payload designed to evade static scanners",
+      "notes": "Near-identical fingerprints: base64/hex blob decoding to executable content at runtime, evading static scanners."
+    },
+    {
+      "ramparts_finding": "OverbroadAllowedTools",
+      "ave_id": "AVE-2026-00038",
+      "title": "Excessive Agency - Unbounded Tool Use or Sub-Agent Spawning",
+      "notes": "Both: unrestricted grant of code-execution tool capability."
+    },
+    {
+      "ramparts_finding": "GenericSkillTrigger",
+      "ave_id": "AVE-2026-00058",
+      "title": "Deceptive skill trigger or activation-scope manipulation via misleading manifest description",
+      "notes": "Both: description misrepresents scope, causing over-broad or implicit invocation."
+    },
+    {
+      "ramparts_finding": "AutonomyAbuse ($skip_confirmation branch)",
+      "ave_id": "AVE-2026-00021",
+      "title": "Autonomous Action Without User Confirmation",
+      "notes": "Both: instruction to bypass human confirmation on a consequential action."
+    },
+    {
+      "ramparts_finding": "Jailbreak (SecurityIssueType)",
+      "ave_id": "AVE-2026-00009",
+      "title": "AI identity jailbreak via role-play or persona override in agentic component",
+      "notes": "Both: coercing an unrestricted persona or mode."
+    }
+  ],
+  "coverage": {
+    "ramparts_findings_mapped": 10,
+    "ave_classes_covered": 9,
+    "note_on_unmapped": "Ramparts' full finding list is broader than what's mapped here; only mechanism-verified matches are included. See note field for near-misses and known gaps in both directions."
+  }
+}

--- a/docs/specs/scaling-and-governance.md
+++ b/docs/specs/scaling-and-governance.md
@@ -85,3 +85,23 @@ separately as part of a future version bump (alongside `owasp_ast`, see
 `AVE_V1.1.0_MIGRATION_BRIEF.md` Section 7.0), not implied to already exist
 by this policy document. This section states the policy the schema change
 will implement, it does not implement it.
+
+## 4. Crosswalk numbering caution
+
+External frameworks still being drafted (OWASP's MCP Top 10 has not
+been formally ratified as of this writing) get independently
+interpreted by every project that adopts them early. Two projects can
+both number their own categories MCP01 through MCP10 and mean entirely
+different things by the same number, confirmed directly during the
+Ramparts crosswalk (issue #138): Ramparts' MCP03 is Excessive Agency,
+AVE's MCP03 is Tool Poisoning, unrelated categories sharing a number by
+coincidence, not agreement.
+
+**Any crosswalk to an external tool's own OWASP MCP Top 10 tagging
+must match by category meaning, not by tag number.** Matching by number
+alone will silently produce wrong pairings whenever the external
+project drafted its own reading independently, which is the common
+case for an unratified standard, not the exception. This applies
+symmetrically: if another project ever crosswalks to AVE's own
+`owasp_mcp` field by number rather than meaning, the same risk runs the
+other way.


### PR DESCRIPTION
Ten mechanism-verified matches from issue #138. Includes the near-miss (CommandInjection) and bidirectional gaps in the `note` field rather than as mappings, since they're not confirmed matches. Also adds a durable caution to `scaling-and-governance.md` about OWASP MCP Top 10 numbering not being stable across independently-drafted crosswalks, referencing #138 as the concrete case that surfaced it.

## Summary
- `crosswalks/ramparts-to-ave.json`: ten Ramparts findings mapped to nine AVE records (`EnvironmentVariableLeakage` splits across two AVE mechanisms depending on which internal condition fires). All titles, the record count (76), static_record_count (57), and ramparts' commit SHA pulled live, not typed from memory.
- `docs/specs/scaling-and-governance.md` Section 4 (new): the MCP01-MCP10 numbering-mismatch caution -- Ramparts' MCP03 (Excessive Agency) and AVE's MCP03 (Tool Poisoning) are unrelated despite sharing a number, since OWASP's MCP Top 10 isn't formally ratified yet and gets independently interpreted by early adopters. States the rule this crosswalk had to follow: match by category meaning, never by tag number.

## Test plan
- [x] `python3 scripts/validate_crosswalks.py` -- 5/5 valid, `ramparts-to-ave.json` resolves clean against `schema/crosswalk-1.0.0.schema.json`
- [x] `python3 scripts/validate_records.py` -- 76/76 records valid (unaffected, no record changes in this PR)
- [x] `pytest tests/ -x -q` -- 305 passed
- [x] No new em-dash occurrences in the governance doc addition