### PR TITLE
fix: researcher field attribution rule and worked example

### DIFF
--- a/.claude/skills/add-ave-record/SKILL.md
+++ b/.claude/skills/add-ave-record/SKILL.md
@@ -26,6 +26,17 @@ Include the evidence fields:
 - evidence_basis_engines
 - derivable_into
 
+**The `researcher` field, a common, real mistake, not a hypothetical
+one**: defaulting to the AVE maintainer's own name because it's the
+name most readily at hand while drafting. Check first: does this
+record trace to a real external CVE, paper, vendor disclosure, or
+existing tool implementation? If yes, and it almost always is yes,
+that source's own name or organization belongs in `researcher`, not
+the person writing the AVE record. This exact mistake shipped on two
+published records before being caught by an external maintainer being
+credited incorrectly himself. See docs/specs/researcher-process.md's
+Accountability and sourcing section for the full rule.
+
 ### 4. Write conformance fixtures (TDD — fixtures first)
 tests/fixtures/AVE-YYYY-NNNNN_positive.md — a conforming implementation MUST flag this
 tests/fixtures/AVE-YYYY-NNNNN_negative.md — a conforming implementation MUST NOT flag this

--- a/docs/specs/researcher-process.md
+++ b/docs/specs/researcher-process.md
@@ -102,8 +102,25 @@ actually checks for, not a padded ideal:
 - `detection_methodology`, `indicators_of_compromise`, `remediation`
 
 **Accountability and sourcing**
-- `researcher`: the actual accountable individual's name, not a team
-  name implying staffing that doesn't exist
+- `researcher`: whoever actually did the real, primary vulnerability
+  research this record is based on, not whoever wrote the AVE record.
+  Nearly every record traces to a real external CVE, paper, vendor
+  disclosure, or a tool's own detection implementation, in which case
+  the named researcher, security team, or organization behind that
+  original source goes here, by name. Use an AVE maintainer's own name
+  only in the genuinely rare case where AVE itself is the original
+  discoverer of a behavioral class with no prior external source to
+  credit, which has not actually happened yet in this project's real
+  history. If you're unsure whether your candidate has a real external
+  source or is a first discovery, it almost certainly has one, check
+  again before defaulting to your own name.
+- `researcher_url`: must point at whoever is actually named in
+  `researcher`, not default to the AVE project's own site. If
+  `researcher` names an external party, find their real URL, or omit
+  `researcher_url` entirely if no clean one exists (it's optional),
+  rather than leave it pointing at an unrelated site. A
+  `researcher_url` that doesn't match `researcher` is the same
+  inconsistency this rule exists to prevent, just in a second field.
 - `published`, `last_updated`
 - `references`: at least one, with a real, working URL, not a
   placeholder
@@ -253,13 +270,25 @@ Step 4 checklist above):
     "enforcement_point": "server_card_fetch",
     "trifecta_control": "break_external_comms"
   },
-  "researcher": "Saray Chak",
+  "researcher": "OX Security",
+  "researcher_url": "https://www.ox.security",
   "published": "2026-07-27T00:00:00Z",
   "references": [
     {"tag": "OX Security disclosure", "text": "Original disclosure across multiple MCP SDKs, April 2026", "url": "https://www.ox.security"}
   ]
 }
 ```
+
+**Worth noting explicitly**: an earlier version of this worked example
+listed "Saray Chak" as researcher and "https://bawbel.io" as
+researcher_url here, both wrong for exactly the reason this document
+now states above, OX Security did the actual research; AVE catalogued
+it. Both fields needed correcting together, crediting the right name
+while still linking to AVE's own site would have been the same mistake
+relocated rather than fixed. Caught via an external maintainer's
+correction on a different pair of records, not caught internally
+first. Left this note rather than silently fixing it, the same
+standard this project has applied to every other correction.
 
 **Step 5, scoring**:
 

--- a/records/AVE-2026-00055.json
+++ b/records/AVE-2026-00055.json
@@ -62,8 +62,8 @@
   "remediation": "1. Never populate the command/args fields used to spawn an MCP server subprocess from unvalidated configuration, database, network, or model-generated data. 2. Restrict STDIO server launches to an explicit allowlist of known-safe executable paths or package names, not arbitrary caller-supplied commands. 3. Pin and verify the hash of a server's declared launch configuration at first audit; alert if it changes before the next explicit re-review. 4. Treat MCP config files as a privileged trust boundary -- require explicit human confirmation before an agent or any automated process modifies them. 5. Audit registry submission review processes; do not auto-install servers from registries with no review gate.",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "OX Security",
+  "researcher_url": "https://www.ox.security",
   "published": "2026-07-10T00:00:00Z",
   "last_updated": "2026-07-10T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00060.json
+++ b/records/AVE-2026-00060.json
@@ -48,8 +48,8 @@
   ],
   "remediation": "1. Update to a patched SDK version that uses parameterized subprocess invocation rather than shell string construction. 2. Never construct shell commands via string concatenation or interpolation from tool call parameters; use an execution API that treats arguments as an array, not a single shell string. 3. If shell invocation is genuinely required, apply strict allowlisting and escaping specific to the shell in use, not generic sanitization.",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "OX Security",
+  "researcher_url": "https://www.ox.security",
   "published": "2026-07-27T00:00:00Z",
   "last_updated": "2026-07-27T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00063.json
+++ b/records/AVE-2026-00063.json
@@ -48,7 +48,7 @@
   ],
   "remediation": "Do not expose a configuration-level bypass for approval gates on high-risk actions at all; if a narrower, explicitly-scoped auto-approval is a genuine product requirement, scope it to specific, named, low-risk actions rather than a blanket flag, and log every use of the bypass distinctly from a human-confirmed approval.",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-07-27T00:00:00Z",
   "last_updated": "2026-07-27T00:00:00Z",

--- a/records/AVE-2026-00064.json
+++ b/records/AVE-2026-00064.json
@@ -46,7 +46,7 @@
   ],
   "remediation": "Require explicit, un-bypassable user confirmation before any project-load auto-run executes, regardless of what the project's own configuration requests; treat auto-run configuration as a request the environment may deny, not an instruction the environment must honor.",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-07-27T00:00:00Z",
   "last_updated": "2026-07-27T00:00:00Z",

--- a/records/AVE-2026-00071.json
+++ b/records/AVE-2026-00071.json
@@ -51,7 +51,7 @@
   ],
   "remediation": "Remove any DOCKER_HOST override from committed configuration; if a remote build host is genuinely required, require it to be supplied out-of-band at invocation time rather than committed to a file an agent or its skills can read and silently rely on. Pin agent and MCP server configuration to the local daemon socket by default, and treat any remote daemon target as requiring explicit, separately-reviewed approval.",
   "kill_switch_active": false,
-  "researcher": "predictor2718",
+  "researcher": "Nicolai (predictor2718)",
   "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-06T00:00:00Z",
   "last_updated": "2026-08-06T00:00:00Z",

--- a/records/AVE-2026-00071.json
+++ b/records/AVE-2026-00071.json
@@ -51,8 +51,8 @@
   ],
   "remediation": "Remove any DOCKER_HOST override from committed configuration; if a remote build host is genuinely required, require it to be supplied out-of-band at invocation time rather than committed to a file an agent or its skills can read and silently rely on. Pin agent and MCP server configuration to the local daemon socket by default, and treat any remote daemon target as requiring explicit, separately-reviewed approval.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "predictor2718",
+  "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-06T00:00:00Z",
   "last_updated": "2026-08-06T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00072.json
+++ b/records/AVE-2026-00072.json
@@ -50,7 +50,7 @@
   ],
   "remediation": "Bind MCP servers to a loopback address (127.0.0.1 or ::1) by default; require an explicit, separately-reviewed opt-in before binding to a wildcard or LAN-reachable address. Where LAN or remote reachability is genuinely required, pair it with a mandatory authentication step, never rely on network position alone as an implicit trust boundary.",
   "kill_switch_active": false,
-  "researcher": "predictor2718",
+  "researcher": "Nicolai (predictor2718)",
   "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-06T00:00:00Z",
   "last_updated": "2026-08-06T00:00:00Z",

--- a/records/AVE-2026-00072.json
+++ b/records/AVE-2026-00072.json
@@ -50,8 +50,8 @@
   ],
   "remediation": "Bind MCP servers to a loopback address (127.0.0.1 or ::1) by default; require an explicit, separately-reviewed opt-in before binding to a wildcard or LAN-reachable address. Where LAN or remote reachability is genuinely required, pair it with a mandatory authentication step, never rely on network position alone as an implicit trust boundary.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "predictor2718",
+  "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-06T00:00:00Z",
   "last_updated": "2026-08-06T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00073.json
+++ b/records/AVE-2026-00073.json
@@ -53,8 +53,8 @@
   ],
   "remediation": "Validate telemetry, model, and provider endpoint configuration against an allowlist of known-legitimate hosts before the process starts, and refuse to proceed silently on a mismatch. Never accept an endpoint override from a repository's own committed configuration without an explicit trust confirmation step, the exact gap CVE-2026-21852 closed. Require TLS for any endpoint carrying an API key or bearer token; reject cleartext http:// destinations for such traffic outright.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "predictor2718",
+  "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-06T00:00:00Z",
   "last_updated": "2026-08-08T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00073.json
+++ b/records/AVE-2026-00073.json
@@ -53,7 +53,7 @@
   ],
   "remediation": "Validate telemetry, model, and provider endpoint configuration against an allowlist of known-legitimate hosts before the process starts, and refuse to proceed silently on a mismatch. Never accept an endpoint override from a repository's own committed configuration without an explicit trust confirmation step, the exact gap CVE-2026-21852 closed. Require TLS for any endpoint carrying an API key or bearer token; reject cleartext http:// destinations for such traffic outright.",
   "kill_switch_active": false,
-  "researcher": "predictor2718",
+  "researcher": "Nicolai (predictor2718)",
   "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-06T00:00:00Z",
   "last_updated": "2026-08-08T00:00:00Z",

--- a/records/AVE-2026-00074.json
+++ b/records/AVE-2026-00074.json
@@ -58,8 +58,8 @@
   ],
   "remediation": "Do not treat a specific, well-formed external reference as permanently safe once reviewed; periodically re-verify that referenced GitHub owners, packages, domains, and cloud subdomains still resolve to their original, reviewed owner before trusting content fetched or installed from them. Where feasible, pin to a content hash or commit SHA rather than a mutable owner/name, and treat any pre-install or pre-fetch step that resolves an external anchor as a point requiring a fresh trust check, not a one-time review at publication time. Registries hosting skills should periodically re-scan published skills for anchor decay rather than only screening at submission.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "AIR Security",
+  "researcher_url": "https://www.air.security",
   "published": "2026-08-07T00:00:00Z",
   "last_updated": "2026-08-07T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00075.json
+++ b/records/AVE-2026-00075.json
@@ -56,8 +56,8 @@
   ],
   "remediation": "Never trust a precompiled .pyc/.pyo file at face value; unmarshal and disassemble every bytecode artifact a skill ships and compare its actual referenced primitives against its own visible source before trusting the package. Reject skill packages that bundle precompiled bytecode with no legitimate build-pipeline reason to do so, and strip or refuse to load any .pyc/__pycache__ content from an unreviewed or third-party skill source, forcing recompilation from source instead. Static scanners that currently skip binary/.pyc content by design, the exact gap the 2026-06 CSA/Trail of Bits audit identified across multiple production skill scanners, should treat that skip as an explicit, documented blind spot rather than a silent pass.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "CSA / Trail of Bits",
+  "researcher_url": "https://labs.cloudsecurityalliance.org/research/csa-research-note-ai-agent-skill-scanner-bypass-20260610-csa/",
   "published": "2026-08-07T00:00:00Z",
   "last_updated": "2026-08-07T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00076.json
+++ b/records/AVE-2026-00076.json
@@ -53,8 +53,8 @@
   ],
   "remediation": "Treat a repository's own committed permissions/auto-run configuration file as untrusted content requiring the same review as code, not as inert settings. Define a list of action types (credential file access, destructive filesystem operations, non-loopback network calls) that always require human confirmation regardless of any allow_instructions text, so no natural-language steering entry can widen approval for them. Log every classifier-subagent approval distinctly from a human-confirmed one, and treat a probabilistic classifier's decision as steerable, not authoritative, for genuinely high-risk action classes.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "predictor2718",
+  "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-08T00:00:00Z",
   "last_updated": "2026-08-08T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00076.json
+++ b/records/AVE-2026-00076.json
@@ -53,7 +53,7 @@
   ],
   "remediation": "Treat a repository's own committed permissions/auto-run configuration file as untrusted content requiring the same review as code, not as inert settings. Define a list of action types (credential file access, destructive filesystem operations, non-loopback network calls) that always require human confirmation regardless of any allow_instructions text, so no natural-language steering entry can widen approval for them. Log every classifier-subagent approval distinctly from a human-confirmed one, and treat a probabilistic classifier's decision as steerable, not authoritative, for genuinely high-risk action classes.",
   "kill_switch_active": false,
-  "researcher": "predictor2718",
+  "researcher": "Nicolai (predictor2718)",
   "researcher_url": "https://github.com/predictor2718",
   "published": "2026-08-08T00:00:00Z",
   "last_updated": "2026-08-08T00:00:00Z",


### PR DESCRIPTION
This whole correction exists because of an external maintainer's honesty, not routine cleanup. [alexgreensh's correction on repo-forensics#39](https://github.com/alexgreensh/repo-forensics/issues/39#issuecomment-5223231541) pointed out that AVE-2026-00074 and AVE-2026-00075 credited "Saray Chak" as researcher when neither vulnerability class originated with AVE -- AIR Security disclosed SkillJacking, CSA/Trail of Bits demonstrated the bytecode-poisoning technique, repo-forensics built the detectors.

## Summary
- **The rule itself**: fixed in `docs/specs/researcher-process.md` (Accountability and sourcing section) and added directly to `.claude/skills/add-ave-record/SKILL.md`, which didn't mention the `researcher` field at all before this -- the live skill a drafting session actually reads needed it stated, not just reachable through a cross-reference. Both now also cover `researcher_url`: crediting the right name while still linking to AVE's own site is the same mistake relocated, not fixed.
- **The worked example**: `researcher-process.md`'s own STDIO-shell-injection worked example had the identical error (credited "Saray Chak" while its own references correctly cited OX Security). Fixed, with a visible note left in place rather than a silent edit.
- **The corpus sweep**: checked every record still carrying "Saray Chak" or "Bawbel Security Research Team" against its own references, not assumed. Ten records needed fixing, not just the two named in the correction:
  - `AVE-2026-00074`, `AVE-2026-00075` -- the two repo-forensics-sourced records, now AIR Security and CSA/Trail of Bits.
  - `AVE-2026-00055`, `AVE-2026-00060` -- same shape, both independently citing OX Security's own disclosure while crediting the cataloguer.
  - `AVE-2026-00071`, `AVE-2026-00072`, `AVE-2026-00073`, `AVE-2026-00076` -- each credits predictor2718 by name in its own references for real analytical work (a detailed mechanism breakdown on issue #68, or the PR that surfaced the AVE-2026-00076 candidate), not reflected in `researcher`.
  - `AVE-2026-00063`, `AVE-2026-00064` -- narrower fix, team name to individual name only. Their references describe a gap found during AVE's own crosswalk comparison, not a named external party's analytical work, so no re-attribution, just the pre-existing team-to-individual convention applied.
- Every other record matching the old team-name pattern was checked against its own references and left as-is -- most cite general frameworks (CWE/OWASP/MITRE) or foundational academic literature as background context, not a specific named discloser of that exact mechanism.

## Test plan
- [x] `python3 scripts/validate_records.py` -- 76/76 records valid
- [x] `pytest tests/ -x -q` -- 305 passed
- [x] No new em-dashes introduced in either doc (`SKILL.md`'s 5 pre-existing occurrences are untouched by this diff)