### PR TITLE
feat: soft researcher/disclosure misattribution check

### DIFF
--- a/scripts/validate_records.py
+++ b/scripts/validate_records.py
@@ -140,6 +140,49 @@ def check_no_vendor_boilerplate(raw_text: str) -> list[str]:
             for pattern in VENDOR_BOILERPLATE_PATTERNS if re.search(pattern, lower)]
 
 
+# Names that are AVE's own maintainers/cataloguers, not external
+# researchers. Kept as a real, explicit list, not a heuristic guess.
+INTERNAL_RESEARCHER_NAMES = {"saray chak", "bawbel security research team"}
+
+# Words in a reference's own tag/text that signal it IS the primary
+# external disclosure this record is based on, not just supporting
+# context or a detection-implementation link.
+DISCLOSURE_SIGNAL_WORDS = [
+    "disclosure", "advisory", "cve", "vulnerability report",
+    "responsible disclosure", "security research", "paper",
+]
+
+
+def check_researcher_matches_disclosure(record: dict) -> list[str]:
+    """Soft warning only: flags records where `researcher` is an AVE
+    maintainer name while `references` contains something that reads
+    like the actual external disclosure this record is based on.
+    Not a hard failure, some records are genuinely original AVE
+    cataloguing with no single external discloser, this needs a human
+    glance, not an auto-block. Caught the real AVE-2026-00060 /
+    repo-forensics-sourced misattribution mistakes; see
+    docs/specs/researcher-process.md for the full incident this check
+    exists because of.
+    """
+    researcher = (record.get("researcher") or "").strip().lower()
+    if researcher not in INTERNAL_RESEARCHER_NAMES:
+        return []
+
+    refs = record.get("references", [])
+    for ref in refs:
+        tag = (ref.get("tag") or "").lower()
+        text = (ref.get("text") or "").lower()
+        combined = tag + " " + text
+        if any(word in combined for word in DISCLOSURE_SIGNAL_WORDS):
+            return [
+                f"researcher is '{record.get('researcher')}' (an AVE maintainer name), "
+                f"but references includes an entry that reads as the primary external "
+                f"disclosure ('{ref.get('tag', ref.get('text', ''))}'). Confirm this is "
+                f"genuinely original AVE cataloguing, not a misattributed external source."
+            ]
+    return []
+
+
 def main() -> int:
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.Draft202012Validator.check_schema(schema)
@@ -167,6 +210,12 @@ def main() -> int:
         for e in errors:
             print(f"{rid}: {e}")
         total_errors += len(errors)
+
+        warnings = check_researcher_matches_disclosure(record)
+        if warnings:
+            for w in warnings:
+                print(f"WARNING [{record['ave_id']}]: {w}")
+            # do not increment the failure counter, do not affect exit code
 
     if total_errors:
         print(f"\n{total_errors} error(s) across {len(paths)} records.", file=sys.stderr)


### PR DESCRIPTION
Adds a warning-only check to `validate_records.py` for the exact misattribution pattern caught via alexgreensh's correction (see PR #154). Not a hard failure. Tested against four cases before this PR: catches the real mistake, clears the corrected version, and doesn't false-positive on legitimately original records or implementation-only references.

## Summary
- `check_researcher_matches_disclosure()`: flags a record where `researcher` is an AVE maintainer name (`INTERNAL_RESEARCHER_NAMES`) while `references` contains an entry that reads like the actual primary external disclosure (`DISCLOSURE_SIGNAL_WORDS`: disclosure, advisory, cve, vulnerability report, responsible disclosure, security research, paper).
- Wired into `main()` as `WARNING [ave_id]: ...` output, printed alongside but kept separate from hard failures -- does not increment `total_errors`, does not affect the exit code. Confirmed: `python3 scripts/validate_records.py` still prints "All 76 records valid" and exits 0 even with warnings present.
- Run against the live corpus: 10 warnings fired, none on the records already fixed in #154 (`AVE-2026-00063`/`00064` correctly stay silent -- their references are pure crosswalk-gap language, no disclosure-signal words). These 10 are previously-uncaught instances in older batch records (`AVE-2026-00003`, `00013`, `00026`, `00029`, `00039`, `00047`, `00052`, `00053`, `00054`, `00056`), worth a real follow-up look, not something this PR fixes.

## Test plan
- [x] `python3 scripts/validate_records.py` -- exits 0, "All 76 records valid" still prints, warnings shown as additional output
- [x] `pytest tests/ -x -q` -- 305 passed