### PR TITLE
fix: resolve the 10 records flagged by the researcher/disclosure check

### DIFF
--- a/records/AVE-2026-00003.json
+++ b/records/AVE-2026-00003.json
@@ -93,7 +93,7 @@
   "remediation": "1. Remove the component immediately.\n2. Rotate all environment variables and API keys accessible to the agent.\n3. Review outbound network logs for credential-shaped data.\n4. Audit all tool calls and external requests made during the exposure window.",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-01T09:00:00Z",
   "last_updated": "2026-05-12T00:00:00Z",

--- a/records/AVE-2026-00013.json
+++ b/records/AVE-2026-00013.json
@@ -68,7 +68,7 @@
   "remediation": "1. Remove the component immediately. 2. Identify what PII may have been accessed and transmitted. 3. Notify affected users per applicable data protection regulations (GDPR, CCPA). 4. Report the attacker endpoint to relevant authorities. 5. Implement data access controls - agents should not have broad access to PII stores.",
   "status": "active",
   "kill_switch_active": true,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
   "last_updated": "2026-05-12T00:00:00Z",

--- a/records/AVE-2026-00026.json
+++ b/records/AVE-2026-00026.json
@@ -86,7 +86,7 @@
   "remediation": "- Audit all tool parameters for encoded sensitive data before execution\n- Never allow credentials or PII to be passed as tool parameters\n- Implement output data loss prevention (DLP) on tool call parameters",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
   "last_updated": "2026-05-12T00:00:00Z",

--- a/records/AVE-2026-00029.json
+++ b/records/AVE-2026-00029.json
@@ -84,8 +84,8 @@
   "remediation": "- Normalise all Unicode input to NFC before processing\n- Reject files containing zero-width or bidirectional override characters\n- Use Unicode-aware security scanning - check for homoglyph substitution\n- Display files in a hex/unicode viewer before manual security review",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "Boucher & Anderson",
+  "researcher_url": "https://arxiv.org/abs/2111.00169",
   "published": "2026-04-19T09:00:00Z",
   "last_updated": "2026-05-12T00:00:00Z",
   "references": [

--- a/records/AVE-2026-00039.json
+++ b/records/AVE-2026-00039.json
@@ -88,7 +88,7 @@
   "remediation": "- Scan outputs for known covert channel patterns\n- Randomise response formatting to prevent timing-based channels\n- Apply information-theoretic analysis to detect unexpected data in outputs\n- Monitor entropy of agent outputs for anomalies",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
   "last_updated": "2026-05-12T00:00:00Z",

--- a/records/AVE-2026-00047.json
+++ b/records/AVE-2026-00047.json
@@ -76,7 +76,7 @@
   "remediation": "1. Replace hardcoded credentials with environment variable references: use DATABASE_URL from environment. 2. Use a secrets manager path instead of the secret value: vault://secret/db/prod. 3. Rotate any credential that has been committed immediately - assume it is compromised. 4. Add credential-pattern scanning to pre-commit hooks, failing on high-severity findings. 5. Suppress the finding with documented justification only for documented placeholder values.",
   "status": "active",
   "kill_switch_active": true,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-16T00:00:00Z",
   "last_updated": "2026-05-16T00:00:00Z",

--- a/records/AVE-2026-00052.json
+++ b/records/AVE-2026-00052.json
@@ -60,11 +60,16 @@
   "remediation": "1. Never pass caller-supplied parameter values into a shell command string; use an argument-array invocation form (execFile, spawn without shell:true) that does not invoke a shell interpreter. 2. Validate and allowlist parameter values against an expected format before any process-execution call. 3. If a local file reference is accepted as a parameter, resolve and canonicalize the path, then verify it stays within an expected working directory before use. 4. Run the MCP server process with the minimum OS privileges necessary, never as an administrator/root account or the interactive user's full session. 5. If using a known-vulnerable third-party tool package, upgrade to a patched version.",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "Peter Girnus (ZDI)",
+  "researcher_url": "https://www.zerodayinitiative.com/advisories/ZDI-26-021/",
   "published": "2026-07-10T00:00:00Z",
   "last_updated": "2026-07-10T00:00:00Z",
   "references": [
+    {
+      "tag": "ZDI-26-021",
+      "text": "Peter Girnus (@gothburz), Trend Research / Zero Day Initiative -- original discovery and coordinated disclosure of CVE-2026-0755, reported to the vendor 2025-07-25, published as a 0-day advisory 2026-01-09.",
+      "url": "https://www.zerodayinitiative.com/advisories/ZDI-26-021/"
+    },
     {
       "tag": "CVE",
       "text": "CVE-2026-0755 -- gemini-mcp-tool OS command injection (CWE-78), CVSS 9.8",

--- a/records/AVE-2026-00053.json
+++ b/records/AVE-2026-00053.json
@@ -61,7 +61,7 @@
   "remediation": "1. Resolve the caller-supplied path to its canonical absolute form (e.g. os.path.realpath, path.resolve) before any file operation. 2. Verify the resolved path is contained within a configured root directory using a proper prefix/containment check on the canonical path, not a blacklist of forbidden substrings. 3. Reject requests containing raw or encoded traversal sequences (../, ..\\, %2e%2e%2f) before resolution, as defense in depth. 4. Apply the same canonicalization and containment check to URL-based resource builders, not just filesystem path parameters -- dot-segment normalization during URL resolution is a common gap. 5. Run the MCP server process with read/write access limited to only the directories it actually needs.",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-07-10T00:00:00Z",
   "last_updated": "2026-07-10T00:00:00Z",

--- a/records/AVE-2026-00054.json
+++ b/records/AVE-2026-00054.json
@@ -58,11 +58,16 @@
   "remediation": "1. Use strong isolation primitives for untrusted code execution -- a dedicated microVM (e.g. Firecracker) or gVisor-class sandbox with its own kernel, not a shared-kernel container or in-process VM context. 2. Never expose Node.js vm.Script, Python exec()/eval() run in-process, or similar in-language sandboxing as the sole isolation boundary for untrusted code -- these share the host language runtime's prototype/object model and are not designed as a security boundary. 3. Run the code-execution process with the minimum host privileges necessary, never as root. 4. Monitor sandboxed process behavior for filesystem, network, or process-table access outside the declared execution boundary. 5. Apply defense-in-depth: scan submitted code for known escape-technique signatures before execution as an additional signal, not a sole control.",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "Jeremy Brown (CERT/CC)",
+  "researcher_url": "https://kb.cert.org/vuls/id/414811",
   "published": "2026-07-10T00:00:00Z",
   "last_updated": "2026-07-10T00:00:00Z",
   "references": [
+    {
+      "tag": "CERT/CC VU#414811",
+      "text": "Jeremy Brown -- original discovery (using AI-assisted vulnerability research) of the Cohere Terrarium sandbox escape, coordinated through CERT/CC. Cohere notified 2026-02-19; VU#414811 published 2026-04-21.",
+      "url": "https://kb.cert.org/vuls/id/414811"
+    },
     {
       "tag": "CVE",
       "text": "CVE-2026-5752 -- Cohere Terrarium sandbox escape via JavaScript prototype-chain traversal, CVSS 9.3, CERT/CC-reported",

--- a/records/AVE-2026-00056.json
+++ b/records/AVE-2026-00056.json
@@ -51,8 +51,8 @@
   "remediation": "1. Strip or proxy all externally-hosted images and auto-fetched links in agent-generated responses before rendering, or require explicit user confirmation before fetching. 2. Apply a content-security-policy-style allowlist restricting which domains a client may auto-fetch resources from. 3. Scan agent-generated responses for URLs containing conversation-derived data in query parameters before rendering. 4. Treat reference-style markdown links/images with the same scrutiny as inline ones -- redaction filters must resolve references, not just scan raw inline URLs. 5. Disable automatic image/resource loading in high-sensitivity deployments; render as a user-clickable link instead.",
   "status": "active",
   "kill_switch_active": false,
-  "researcher": "Bawbel Security Research Team",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "Aim Labs",
+  "researcher_url": "https://arxiv.org/abs/2509.10540",
   "published": "2026-07-10T00:00:00Z",
   "last_updated": "2026-07-10T00:00:00Z",
   "references": [

--- a/scripts/validate_records.py
+++ b/scripts/validate_records.py
@@ -140,6 +140,49 @@ def check_no_vendor_boilerplate(raw_text: str) -> list[str]:
             for pattern in VENDOR_BOILERPLATE_PATTERNS if re.search(pattern, lower)]
 
 
+# Names that are AVE's own maintainers/cataloguers, not external
+# researchers. Kept as a real, explicit list, not a heuristic guess.
+INTERNAL_RESEARCHER_NAMES = {"saray chak", "bawbel security research team"}
+
+# Words in a reference's own tag/text that signal it IS the primary
+# external disclosure this record is based on, not just supporting
+# context or a detection-implementation link.
+DISCLOSURE_SIGNAL_WORDS = [
+    "disclosure", "advisory", "cve", "vulnerability report",
+    "responsible disclosure", "security research", "paper",
+]
+
+
+def check_researcher_matches_disclosure(record: dict) -> list[str]:
+    """Soft warning only: flags records where `researcher` is an AVE
+    maintainer name while `references` contains something that reads
+    like the actual external disclosure this record is based on.
+    Not a hard failure, some records are genuinely original AVE
+    cataloguing with no single external discloser, this needs a human
+    glance, not an auto-block. Caught the real AVE-2026-00060 /
+    repo-forensics-sourced misattribution mistakes; see
+    docs/specs/researcher-process.md for the full incident this check
+    exists because of.
+    """
+    researcher = (record.get("researcher") or "").strip().lower()
+    if researcher not in INTERNAL_RESEARCHER_NAMES:
+        return []
+
+    refs = record.get("references", [])
+    for ref in refs:
+        tag = (ref.get("tag") or "").lower()
+        text = (ref.get("text") or "").lower()
+        combined = tag + " " + text
+        if any(word in combined for word in DISCLOSURE_SIGNAL_WORDS):
+            return [
+                f"researcher is '{record.get('researcher')}' (an AVE maintainer name), "
+                f"but references includes an entry that reads as the primary external "
+                f"disclosure ('{ref.get('tag', ref.get('text', ''))}'). Confirm this is "
+                f"genuinely original AVE cataloguing, not a misattributed external source."
+            ]
+    return []
+
+
 def main() -> int:
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.Draft202012Validator.check_schema(schema)
@@ -167,6 +210,12 @@ def main() -> int:
         for e in errors:
             print(f"{rid}: {e}")
         total_errors += len(errors)
+
+        warnings = check_researcher_matches_disclosure(record)
+        if warnings:
+            for w in warnings:
+                print(f"WARNING [{record['ave_id']}]: {w}")
+            # do not increment the failure counter, do not affect exit code
 
     if total_errors:
         print(f"\n{total_errors} error(s) across {len(paths)} records.", file=sys.stderr)


### PR DESCRIPTION
Follow-up to #157. Went through each of the 10 warnings that check surfaced against the live corpus, individually -- not batch-applying one rule to all ten.

## Real misattributions (4) -- re-attributed with verified sources
- **AVE-2026-00029**: Nicholas Boucher & Ross Anderson, "Trojan Source" (arXiv 2111.00169 / CVE-2021-42574) -- the paper the record's own references already cited but researcher didn't reflect.
- **AVE-2026-00052**: Peter Girnus (@gothburz), Trend Research / Zero Day Initiative -- confirmed via [ZDI-26-021](https://www.zerodayinitiative.com/advisories/ZDI-26-021/), added as an explicit reference entry.
- **AVE-2026-00054**: Jeremy Brown, coordinated through CERT/CC ([VU#414811](https://kb.cert.org/vuls/id/414811)) -- added as an explicit reference entry; the existing CVE reference only said "CERT/CC-reported" with no URL.
- **AVE-2026-00056**: Aim Labs (EchoLeak, CVE-2025-32711) -- credited via their own arXiv paper (2509.10540), not their company domain, which now redirects entirely to an unrelated acquirer's site.

## False positives (6) -- confirmed genuinely original AVE cataloguing
`AVE-2026-00003`, `00013`, `00026`, `00039`, `00047` cite only generic frameworks (CWE/ATT&CK/OWASP) or general background academic literature (e.g. a 2019 paper on secret leakage in public GitHub repos generally, not this specific mechanism), not a named discloser of this exact behavioral class -- the check matched on the word "Disclosure" inside OWASP's own category title. `AVE-2026-00053` synthesizes three independently-disclosed CVEs across three unrelated MCP implementations into one behavioral class; the pattern recognition connecting them is AVE's own contribution, so crediting any single one of the three would misattribute the actual synthesis work. All six got the pre-existing team-name-to-individual-name fix only (Bawbel Security Research Team -> Saray Chak), no re-attribution.

The check (#157) still flags these six going forward, correctly -- it can't know a human already reviewed them, and it shouldn't be silenced by one reviewer's private judgment call.

## Test plan
- [x] `python3 scripts/validate_records.py` -- 76/76 valid, exits 0, warnings now show only the 6 confirmed-original records
- [x] `python3 scripts/validate_crosswalks.py` -- 6/6 valid
- [x] `pytest tests/ -x -q` -- 305 passed