### PR TITLE
feat: notify workflow also fires on crosswalks/ and dist/ changes

### DIFF
--- a/.github/workflows/notify-ave-site.yml
+++ b/.github/workflows/notify-ave-site.yml
@@ -1,10 +1,16 @@
-name: Notify ave-site on records update
+name: Notify ave-site on data update
 
 # This workflow lives in aveproject/ave.
 # Place it at: .github/workflows/notify-ave-site.yml
 #
-# When records or schema change on main, it fires a
-# repository_dispatch to aveproject/ave-site so the site rebuilds automatically.
+# When records, schema, crosswalks, or the consolidated dist/ JSON change
+# on main, it fires a repository_dispatch to aveproject/ave-site so the
+# site rebuilds automatically. crosswalks/** and dist/** were added
+# alongside records/** and schema/** because ave-site's registry and
+# crosswalks pages both read from this repo's data and neither is any
+# less "live" than the other -- crosswalks/** previously firing nothing
+# is why ave-site's crosswalks/ was able to drift out of sync silently
+# in the first place.
 #
 # Required secret: AVE_SITE_DEPLOY_TOKEN
 # Create a fine-grained PAT with:
@@ -18,6 +24,8 @@ on:
     paths:
       - "records/**"
       - "schema/**"
+      - "crosswalks/**"
+      - "dist/**"
 
 jobs:
   notify:


### PR DESCRIPTION
## What's missing

`.github/workflows/notify-ave-site.yml` only fires the `repository_dispatch` that triggers an `ave-site` rebuild on `records/**` and `schema/**` changes to `main`. `crosswalks/**` and `dist/**` never triggered anything.

That's a real gap, not a hypothetical: `aveproject/ave-site`'s `crosswalks/` directory turned out to be a hand-maintained, stale copy — missing `cfgaudit-to-ave`, `nova-proximity-to-ave`, and `ramparts-to-ave` entirely, and stale on the three crosswalks it did have. Even with a real publish mechanism on the `ave-site` side (companion PR there), nothing on this side would ever have told it to run for a crosswalk-only change.

## Fix

Adds `crosswalks/**` and `dist/**` to the trigger paths, matching `records/**` and `schema/**`. Renames the workflow from "records update" to "data update" since it's no longer records-specific.

## Companion PR

`aveproject/ave-site` needs its own fix to actually publish crosswalks live (it currently has no mechanism for that at all, the same shape of gap `ave-site#56` fixed for schema files) — that PR is linked separately since these repos don't share a PR namespace. This one only fixes the trigger; without the `ave-site` side, `crosswalks/**` changes would fire a rebuild that still serves the same stale copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)