### PR TITLE
fix: ave-record-1.0.0.schema.json's $id still pointed at ave.bawbel.io

### DIFF
--- a/schema/ave-record-1.0.0.schema.json
+++ b/schema/ave-record-1.0.0.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ave.bawbel.io/schema/ave-record-1.0.0.schema.json",
+  "$id": "https://aveproject.org/schema/ave-record-1.0.0.schema.json",
   "title": "AVE Record",
   "description": "AVE (the behavioral vulnerability enumeration standard for agentic AI components) \u2014 static definition of one behavioral vulnerability class. Schema v1.0.0.",
   "type": "object",


### PR DESCRIPTION
Every other schema file's \`\$id\` already reads \`aveproject.org\` (org-move checklist §5.1 covered \`ave-record-1.1.0\` and the rest); this frozen v1.0.0 snapshot was missed. \`aveproject/ave-site\`'s \`scripts/publish-schemas.js\` warns about this on every build without altering it — publishing a copy of a wrong \`\$id\` isn't that repo's problem to paper over, it belongs here.

This also serves as the real end-to-end verification for a bigger fix made this session: \`ave-site\`'s GitHub Pages source was set to "Deploy from a branch" (legacy, zero-build static serving), which was racing against — and usually beating — the actual \`deploy.yml\` Actions pipeline. The legacy path has no build step, so it kept re-serving whatever \`records.js\` happened to be literally committed to \`ave-site\`'s git history, regardless of what \`deploy.yml\` had just correctly rebuilt from this repo. Switched \`ave-site\`'s Pages source to "GitHub Actions" via the API. Once this PR merges, \`notify-ave-site.yml\`'s push-triggered dispatch → \`ave-site\`'s \`deploy.yml\` → GitHub Pages should land live for real, not just succeed in isolation — will confirm against the live domain once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)