### PR TITLE
fix: ave-record-1.0.0.schema.json's $id still pointed at ave.bawbel.io

### DIFF
--- a/schema/ave-record-1.0.0.schema.json
+++ b/schema/ave-record-1.0.0.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://ave.bawbel.io/schema/ave-record-1.0.0.schema.json",
+  "$id": "https://aveproject.org/schema/ave-record-1.0.0.schema.json",
   "title": "AVE Record",
   "description": "AVE (the behavioral vulnerability enumeration standard for agentic AI components) \u2014 static definition of one behavioral vulnerability class. Schema v1.0.0.",
   "type": "object",


### PR DESCRIPTION
Same fix as #165, which already merged to \`main\`. Opening this against \`develop\` too since the two branches are otherwise in sync right now and this repo's history pairs a \`main\` PR with a matching \`develop\` PR.

Every other schema file's \`\$id\` already reads \`aveproject.org\` (org-move checklist §5.1); this frozen v1.0.0 snapshot was missed. Flagged by \`ave-site\`'s \`scripts/publish-schemas.js\`, which warns about it at every build without altering it.

Leaving this for manual merge, not merging it myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)