### PR TITLE
feat: state what commit pins, and let a side declare it cannot be pinned

### DIFF
--- a/schema/crosswalk-1.0.0.schema.json
+++ b/schema/crosswalk-1.0.0.schema.json
@@ -99,7 +99,8 @@
       "then": {
         "required": [
           "unpinnable_reason",
-          "checked_against_live_site"
+          "checked_against_live_site",
+          "content_digest"
         ],
         "not": {
           "required": [
@@ -156,7 +157,7 @@
         "content_digest": {
           "type": "string",
           "pattern": "^sha256:[0-9a-f]{64}$",
-          "description": "Lowercase sha256, prefixed sha256:, of the bytes fetched from url on the date in checked_against_live_site. Optional, and the nearest thing an unpinnable side has to a pin: it does not let a reader re-derive a count, but it does let them tell whether the page has moved since it was read. Recommended wherever pin_status is unpinnable."
+          "description": "Lowercase sha256, prefixed sha256:, of the bytes fetched from url on the date in checked_against_live_site. Required when pin_status is unpinnable, where it is the nearest thing an unpinnable side has to a pin: it does not let a reader re-derive a count, but it does let them tell whether the page has moved since it was read. Optional otherwise."
         },
         "checked_against_live_site": {
           "type": "string",

--- a/schema/crosswalk-1.0.0.schema.json
+++ b/schema/crosswalk-1.0.0.schema.json
@@ -85,7 +85,28 @@
       "required": [
         "url"
       ],
-      "description": "One side of the mapping. Only url is universal across existing crosswalks; the rest of an endpoint's description depends on what the side is — a standard has a version and a record count, a scanner has a vendor, a licence, and a rule total.",
+      "description": "One side of the mapping. Only url is universal across existing crosswalks; the rest of an endpoint's description depends on what the side is — a standard has a version and a record count, a scanner has a vendor, a licence, and a rule total. An endpoint is in exactly one of three states with respect to pinning: it carries commit, in which case a stated count can be re-derived; or it carries pin_status unpinnable, in which case it says so and carries what it has instead; or it carries neither, which is not a statement about the side at all, only that nobody has pinned it yet. The three are distinguishable because the second is a declaration a reader can audit and the third is a blank.",
+      "if": {
+        "properties": {
+          "pin_status": {
+            "const": "unpinnable"
+          }
+        },
+        "required": [
+          "pin_status"
+        ]
+      },
+      "then": {
+        "required": [
+          "unpinnable_reason",
+          "checked_against_live_site"
+        ],
+        "not": {
+          "required": [
+            "commit"
+          ]
+        }
+      },
       "properties": {
         "url": {
           "type": "string",
@@ -116,18 +137,32 @@
         "record_count": {
           "type": "integer",
           "minimum": 0,
-          "description": "Number of AVE records this side carried when the crosswalk was derived. Meaningful only alongside commit: a count on its own cannot be re-derived, because the corpus it counts keeps moving. Optional."
+          "description": "Number of AVE records this side carried when the crosswalk was derived. Meaningful only alongside commit, or alongside a pin_status of unpinnable and the date and digest that go with it: a count on its own cannot be re-derived, because the corpus it counts keeps moving. Optional."
         },
         "commit": {
           "type": "string",
           "pattern": "^[0-9a-f]{40}$",
-          "description": "Full 40-character commit sha of the repository this side was read at. Optional, and the field a stale count is diagnosed with: a crosswalk stating a record count and a read date, with no commit, cannot be checked by a reader without re-counting the upstream tree by hand. Full rather than abbreviated, because an abbreviation that is unique today is not guaranteed to stay unique in a growing repository."
+          "description": "Full 40-character commit sha pinning the tree this side was read at, and therefore the tree any record_count or rule total stated here describes. It is whichever tree was actually read, not the tip of any particular branch: a pin naming a tree the count did not come from validates, reads as clean, and produces a different number for anyone who checks, which is worse than no pin at all. Optional, and the field a stale count is diagnosed with: a crosswalk stating a record count and a read date, with no commit, cannot be checked by a reader without re-counting the upstream tree by hand. Full rather than abbreviated, because an abbreviation that is unique today is not guaranteed to stay unique in a growing repository. A sha on a branch that is later rebased away stops resolving, and a pin that no longer resolves should fail; that is the validator's problem, not this schema's."
+        },
+        "pin_status": {
+          "const": "unpinnable",
+          "description": "Present only to declare that this side has no git history to pin, so that a reader can tell a stated exemption from a field nobody has filled in yet. unpinnable is the only permitted value: an endpoint carrying commit is already pinned and a second field restating that would be a second answer to one question. An endpoint declaring it must also carry unpinnable_reason and checked_against_live_site, must not carry commit, and is checked: a side that declares itself unpinnable and turns out to have a resolvable repository fails, because a declaration that can never be checked is not a declaration. Optional."
+        },
+        "unpinnable_reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Why this side cannot be pinned, in terms a reader can check — a published site with no repository behind it, a distribution with no public source, a vendor page. Required when pin_status is unpinnable. 'Difficult to find' is not one of these; the reason is what stops unpinnable becoming the box anything awkward gets put in."
+        },
+        "content_digest": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "Lowercase sha256, prefixed sha256:, of the bytes fetched from url on the date in checked_against_live_site. Optional, and the nearest thing an unpinnable side has to a pin: it does not let a reader re-derive a count, but it does let them tell whether the page has moved since it was read. Recommended wherever pin_status is unpinnable."
         },
         "checked_against_live_site": {
           "type": "string",
           "format": "date",
           "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
-          "description": "ISO 8601 date the other side's published site content was last verified, where that side has no repository to pin. Distinct from generated: this crosswalk's rows may have been re-derived more recently than the descriptions they were matched against. Optional."
+          "description": "ISO 8601 date the other side's published site content was last verified, where that side has no repository to pin. Distinct from generated: this crosswalk's rows may have been re-derived more recently than the descriptions they were matched against. Required when pin_status is unpinnable, where it is the date half of that declaration — this field already means the date a side with no repository was read, so no second fetch-date field is defined. Optional otherwise."
         }
       }
     },

--- a/scripts/validate_crosswalks.py
+++ b/scripts/validate_crosswalks.py
@@ -50,14 +50,6 @@ REPOSITORY_HOSTS = {
     "sr.ht", "git.sr.ht",
 }
 
-# commit is optional in crosswalk 1.0.x, so a stated record count with no pin and no
-# unpinnable declaration is a warning here and not a failure: some crosswalks in the
-# tree genuinely cannot be backfilled cleanly yet. It becomes a failure when commit is
-# promoted to required at the next major, which makes the enforcement timeline track
-# the field's own promotion rather than a date somebody has to remember. Flipping this
-# constant is that escalation, and it belongs in the same change as the promotion.
-UNPINNED_COUNT_IS_FATAL = False
-
 PROBE_TIMEOUT_SECONDS = 20
 
 
@@ -90,6 +82,33 @@ def cited_ave_ids(node: object) -> set[str]:
         for item in node:
             found |= cited_ave_ids(item)
     return found
+
+
+def commit_is_required(schema: dict) -> bool:
+    """Whether the schema has promoted commit from optional to required.
+
+    This is the escalation switch for the record-count check below, and it is
+    read off the schema rather than held in a constant or a date: while commit
+    is optional a stated count with no pin is a warning, and on the day commit
+    appears in a required list in the endpoint definition the same finding
+    becomes a failure. Nobody has to remember to flip anything, and the
+    enforcement cannot arrive early or late, because there is only one fact and
+    both the schema and the validator read it from the same place.
+
+    A required list underneath `not` is the opposite claim, and 1.0.x contains
+    one: a declared-unpinnable endpoint must *not* carry commit. Those subtrees
+    are skipped, or forbidding the field would read as requiring it.
+    """
+    def promoted(node: object) -> bool:
+        if isinstance(node, list):
+            return any(promoted(item) for item in node)
+        if not isinstance(node, dict):
+            return False
+        if "commit" in node.get("required", []):
+            return True
+        return any(promoted(value) for key, value in node.items() if key != "not")
+
+    return promoted(schema.get("$defs", {}).get("endpoint", {}))
 
 
 def build_validator(schema: dict) -> jsonschema.Draft202012Validator:
@@ -204,7 +223,8 @@ def warn_stated_count_without_pin(document: dict) -> list[str]:
     re-derived by a reader: the corpus keeps moving, and a date does not
     identify a tree. That is the staleness this field exists to fix, but the
     check cannot hard-fail until commit is required, or it would go red on
-    files already in the repository. See UNPINNED_COUNT_IS_FATAL.
+    files already in the repository. See commit_is_required, which is what
+    decides whether the caller reports this as a warning or as a failure.
     """
     return [f"{side} states record_count {endpoint['record_count']} but carries no "
             f"commit and does not declare pin_status unpinnable, so the count "
@@ -228,6 +248,7 @@ def main() -> int:
 
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     validator = build_validator(schema)
+    unpinned_count_is_fatal = commit_is_required(schema)
     published = known_ave_ids()
 
     paths = sorted(CROSSWALKS_DIR.glob("*.json"))
@@ -249,7 +270,7 @@ def main() -> int:
             problems += probe_problems
 
         warnings = warn_stated_count_without_pin(document)
-        if UNPINNED_COUNT_IS_FATAL:
+        if unpinned_count_is_fatal:
             problems += warnings
             warnings = []
 

--- a/scripts/validate_crosswalks.py
+++ b/scripts/validate_crosswalks.py
@@ -1,8 +1,11 @@
 # What: validates every file in crosswalks/ against schema/crosswalk-1.0.0.schema.json,
 #       the same way scripts/validate_records.py validates records/ against the record
-#       schema, plus two checks the schema cannot express on its own: that the $schema
-#       a crosswalk declares is a schema this repository actually ships, and that every
-#       AVE identifier a crosswalk cites resolves to a record in records/
+#       schema, plus four checks the schema cannot express on its own: that the $schema
+#       a crosswalk declares is a schema this repository actually ships, that every
+#       AVE identifier a crosswalk cites resolves to a record in records/, that a side
+#       declaring itself unpinnable really has no repository behind it, and -- as a
+#       warning, not a failure -- that a side stating a record count pins the tree it
+#       counted
 # Why:  every crosswalk in this repository declares
 #       https://aveproject.org/schema/crosswalk-1.0.0.schema.json and, until that file
 #       existed, nothing validated any of them. A dangling $schema URL is worse than
@@ -17,16 +20,45 @@
 #       registers uri only when rfc3986-validator is installed, so that package is a
 #       dev dependency here; without it "format": "uri" parses and then constrains
 #       nothing, and the ^https?:// pattern beside it is the only thing refusing a
-#       bad url.
+#       bad url. The unpinnable check is offline and host-based by default, so a run
+#       of this script needs no network and returns the same verdict everywhere;
+#       --probe-unpinnable adds a git ls-remote for sides that are not on a known
+#       repository host, and treats anything other than a clean answer as
+#       inconclusive rather than as a finding.
+import argparse
 import json
+import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 import jsonschema
 
 CROSSWALKS_DIR = Path("crosswalks")
 RECORDS_DIR = Path("records")
 SCHEMA_PATH = Path("schema/crosswalk-1.0.0.schema.json")
+
+# Hosts where a URL of the form <host>/<owner>/<name> is a git repository by
+# construction, so an endpoint declaring itself unpinnable while pointing at one
+# is refuted without asking the network anything. Deliberately a short list of
+# hosts where that shape is unambiguous rather than a guess at every forge.
+REPOSITORY_HOSTS = {
+    "github.com", "www.github.com",
+    "gitlab.com", "www.gitlab.com",
+    "bitbucket.org", "www.bitbucket.org",
+    "codeberg.org", "www.codeberg.org",
+    "sr.ht", "git.sr.ht",
+}
+
+# commit is optional in crosswalk 1.0.x, so a stated record count with no pin and no
+# unpinnable declaration is a warning here and not a failure: some crosswalks in the
+# tree genuinely cannot be backfilled cleanly yet. It becomes a failure when commit is
+# promoted to required at the next major, which makes the enforcement timeline track
+# the field's own promotion rather than a date somebody has to remember. Flipping this
+# constant is that escalation, and it belongs in the same change as the promotion.
+UNPINNED_COUNT_IS_FATAL = False
+
+PROBE_TIMEOUT_SECONDS = 20
 
 
 def known_ave_ids() -> set[str]:
@@ -60,6 +92,12 @@ def cited_ave_ids(node: object) -> set[str]:
     return found
 
 
+def build_validator(schema: dict) -> jsonschema.Draft202012Validator:
+    return jsonschema.Draft202012Validator(
+        schema, format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER
+    )
+
+
 def check_schema(document: dict, validator: jsonschema.Draft202012Validator) -> list[str]:
     return [f"schema: {e.message} (at {'/'.join(str(p) for p in e.path) or '<root>'})"
             for e in validator.iter_errors(document)]
@@ -86,11 +124,110 @@ def check_ave_ids_resolve(document: dict, published: set[str]) -> list[str]:
             if ave_id.startswith("AVE-") and len(ave_id) == len("AVE-0000-00000")]
 
 
+def endpoints(document: dict) -> list[tuple[str, dict]]:
+    return [(side, document[side]) for side in ("source", "target")
+            if isinstance(document.get(side), dict)]
+
+
+def is_repository_url(url: object) -> bool:
+    """True when the URL is a repository on a known forge, by its shape alone.
+
+    <host>/<owner>/<name> on one of REPOSITORY_HOSTS is a repository; a bare
+    host, or a host with a single path segment, is not. Nothing else is judged
+    here, because a project site and a repository are not distinguishable from
+    a URL in the general case, which is what --probe-unpinnable is for.
+    """
+    if not isinstance(url, str):
+        return False
+    parsed = urlparse(url)
+    if parsed.netloc.lower() not in REPOSITORY_HOSTS:
+        return False
+    return len([segment for segment in parsed.path.split("/") if segment]) >= 2
+
+
+def check_declared_unpinnable_has_no_repository(document: dict) -> list[str]:
+    """Refutes an unpinnable declaration that is contradicted by its own url.
+
+    An endpoint saying it cannot be pinned is an exemption from the record-count
+    warning below, and an exemption nobody can check is not a declaration: it is
+    the box anything awkward gets put in. This is the offline half of checking
+    it, and it only ever reports the case it has proved.
+    """
+    return [f"{side} declares pin_status unpinnable, but its url {endpoint.get('url')} "
+            f"is a repository, which can be pinned"
+            for side, endpoint in endpoints(document)
+            if endpoint.get("pin_status") == "unpinnable"
+            and is_repository_url(endpoint.get("url"))]
+
+
+def probe_declared_unpinnable(document: dict) -> tuple[list[str], list[str]]:
+    """The network half: asks git whether a declared-unpinnable url resolves.
+
+    Returns (problems, notes). A problem is reported only when git ls-remote
+    exits zero and names at least one ref, which proves a history exists. Every
+    other outcome -- a non-zero exit, a timeout, no git on the path -- is
+    inconclusive and goes in notes, because a url that is unreachable from here
+    and a url with nothing behind it are indistinguishable from here.
+    """
+    problems: list[str] = []
+    notes: list[str] = []
+    for side, endpoint in endpoints(document):
+        url = endpoint.get("url")
+        if endpoint.get("pin_status") != "unpinnable" or not isinstance(url, str):
+            continue
+        if is_repository_url(url):
+            continue  # already refuted offline; do not report it twice
+        try:
+            completed = subprocess.run(
+                ["git", "ls-remote", "--heads", url],
+                capture_output=True, text=True, timeout=PROBE_TIMEOUT_SECONDS,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            notes.append(f"{side}: probe of {url} did not run ({exc}); "
+                         f"the unpinnable declaration is unchecked, not confirmed")
+            continue
+        if completed.returncode == 0 and completed.stdout.strip():
+            problems.append(f"{side} declares pin_status unpinnable, but git ls-remote "
+                            f"resolves {url} to a history, which can be pinned")
+        else:
+            notes.append(f"{side}: probe of {url} returned no history "
+                         f"(git exit {completed.returncode}); the unpinnable "
+                         f"declaration is unrefuted, which is not the same as verified")
+    return problems, notes
+
+
+def warn_stated_count_without_pin(document: dict) -> list[str]:
+    """Soft warning only, while commit is optional in 1.0.x.
+
+    A side stating how many records it counted, without pinning the tree it
+    counted them in and without declaring that it cannot be pinned, cannot be
+    re-derived by a reader: the corpus keeps moving, and a date does not
+    identify a tree. That is the staleness this field exists to fix, but the
+    check cannot hard-fail until commit is required, or it would go red on
+    files already in the repository. See UNPINNED_COUNT_IS_FATAL.
+    """
+    return [f"{side} states record_count {endpoint['record_count']} but carries no "
+            f"commit and does not declare pin_status unpinnable, so the count "
+            f"cannot be re-derived from this file"
+            for side, endpoint in endpoints(document)
+            if "record_count" in endpoint
+            and "commit" not in endpoint
+            and endpoint.get("pin_status") != "unpinnable"]
+
+
 def main() -> int:
-    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    validator = jsonschema.Draft202012Validator(
-        schema, format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER
+    parser = argparse.ArgumentParser(
+        description="Validate every crosswalk in crosswalks/ against the crosswalk schema.")
+    parser.add_argument(
+        "--probe-unpinnable", action="store_true",
+        help="additionally ask git ls-remote whether a declared-unpinnable side that "
+             "is not on a known repository host resolves to a history. Needs network; "
+             "reports a failure only on a clean positive answer.",
     )
+    args = parser.parse_args()
+
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validator = build_validator(schema)
     published = known_ave_ids()
 
     paths = sorted(CROSSWALKS_DIR.glob("*.json"))
@@ -99,11 +236,23 @@ def main() -> int:
         return 1
 
     failed = 0
+    warned = 0
     for path in paths:
         document = json.loads(path.read_text(encoding="utf-8"))
         problems = (check_schema(document, validator)
                     + check_declared_schema_is_shipped(document)
-                    + check_ave_ids_resolve(document, published))
+                    + check_ave_ids_resolve(document, published)
+                    + check_declared_unpinnable_has_no_repository(document))
+        notes: list[str] = []
+        if args.probe_unpinnable:
+            probe_problems, notes = probe_declared_unpinnable(document)
+            problems += probe_problems
+
+        warnings = warn_stated_count_without_pin(document)
+        if UNPINNED_COUNT_IS_FATAL:
+            problems += warnings
+            warnings = []
+
         if problems:
             failed += 1
             print(f"FAIL {path}")
@@ -111,9 +260,18 @@ def main() -> int:
                 print(f"  {problem}")
         else:
             print(f"ok   {path}")
+        for warning in warnings:
+            # Reported, and deliberately not counted against the exit code.
+            print(f"WARNING [{path.name}]: {warning}")
+        for note in notes:
+            print(f"note    [{path.name}]: {note}")
+        warned += len(warnings)
 
     print(f"\n{len(paths) - failed}/{len(paths)} crosswalk(s) valid "
           f"against {SCHEMA_PATH}")
+    if warned:
+        print(f"{warned} warning(s): a stated record count that no commit pins and "
+              f"no declaration exempts. These become failures when commit is required.")
     return 1 if failed else 0
 
 

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -76,7 +76,7 @@ def test_schema_accepts_a_declared_unpinnable_endpoint():
     assert validate_crosswalks.check_schema(document, crosswalk_validator()) == []
 
 
-@pytest.mark.parametrize("dropped", ["unpinnable_reason", "checked_against_live_site"])
+@pytest.mark.parametrize("dropped", ["unpinnable_reason", "checked_against_live_site", "content_digest"])
 def test_schema_rejects_an_unpinnable_declaration_missing_its_evidence(dropped):
     endpoint = dict(UNPINNABLE_SITE)
     del endpoint[dropped]

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -1,6 +1,8 @@
 import json
 
-from scripts import validate_records
+import pytest
+
+from scripts import validate_crosswalks, validate_records
 
 
 def test_record_validator_rejects_invalid_date_time_format():
@@ -21,3 +23,131 @@ def test_record_validator_rejects_invalid_date_time_format():
     errors = validate_records.check_schema(record, validator)
 
     assert any("not-a-date-time" in error for error in errors)
+
+
+# --- crosswalk pin declarations -------------------------------------------------
+#
+# The three states an endpoint can be in, and the checks that keep them apart:
+# pinned (carries commit), declared unpinnable (says so, with a reason and a date,
+# and is refutable), or neither, which is the blank the warning is about.
+
+
+def crosswalk_validator():
+    schema = json.loads(validate_crosswalks.SCHEMA_PATH.read_text(encoding="utf-8"))
+    return validate_crosswalks.build_validator(schema)
+
+
+def crosswalk_document(source: dict, target: dict | None = None) -> dict:
+    """A crosswalk carrying only what the schema requires, plus the endpoints
+    under test, so that a refusal can only have come from the endpoint."""
+    return {
+        "$schema": "https://aveproject.org/schema/crosswalk-1.0.0.schema.json",
+        "source": source,
+        "target": target or {"url": "https://aveproject.org"},
+        "generated": "2026-08-09",
+        "note": "Fixture crosswalk, endpoints only.",
+        "mappings": [{"ave_id": "AVE-2026-00001"}],
+        "coverage": {"mapped": 1},
+    }
+
+
+UNPINNABLE_SITE = {
+    "url": "https://owasp.org/www-project-agentic-skills-top-10/",
+    "pin_status": "unpinnable",
+    "unpinnable_reason": "published as a site with no repository behind it",
+    "checked_against_live_site": "2026-08-09",
+    "content_digest": "sha256:" + "0" * 64,
+}
+
+
+def test_every_crosswalk_in_the_repository_still_validates():
+    validator = crosswalk_validator()
+    paths = sorted(validate_crosswalks.CROSSWALKS_DIR.glob("*.json"))
+
+    assert paths, "no crosswalks found to validate"
+    for path in paths:
+        document = json.loads(path.read_text(encoding="utf-8"))
+        assert validate_crosswalks.check_schema(document, validator) == [], path
+
+
+def test_schema_accepts_a_declared_unpinnable_endpoint():
+    document = crosswalk_document({"url": "https://aveproject.org"}, dict(UNPINNABLE_SITE))
+
+    assert validate_crosswalks.check_schema(document, crosswalk_validator()) == []
+
+
+@pytest.mark.parametrize("dropped", ["unpinnable_reason", "checked_against_live_site"])
+def test_schema_rejects_an_unpinnable_declaration_missing_its_evidence(dropped):
+    endpoint = dict(UNPINNABLE_SITE)
+    del endpoint[dropped]
+    document = crosswalk_document({"url": "https://aveproject.org"}, endpoint)
+
+    errors = validate_crosswalks.check_schema(document, crosswalk_validator())
+
+    assert any(dropped in error for error in errors)
+
+
+def test_schema_rejects_an_endpoint_that_is_both_pinned_and_unpinnable():
+    endpoint = dict(UNPINNABLE_SITE, commit="a" * 40)
+    document = crosswalk_document({"url": "https://aveproject.org"}, endpoint)
+
+    assert validate_crosswalks.check_schema(document, crosswalk_validator()) != []
+
+
+def test_schema_rejects_a_pin_status_other_than_unpinnable():
+    endpoint = dict(UNPINNABLE_SITE, pin_status="pinned")
+    document = crosswalk_document({"url": "https://aveproject.org"}, endpoint)
+
+    assert validate_crosswalks.check_schema(document, crosswalk_validator()) != []
+
+
+def test_declaring_a_repository_unpinnable_fails():
+    endpoint = dict(UNPINNABLE_SITE, url="https://github.com/aveproject/ave")
+    document = crosswalk_document({"url": "https://aveproject.org"}, endpoint)
+
+    problems = validate_crosswalks.check_declared_unpinnable_has_no_repository(document)
+
+    assert len(problems) == 1
+    assert "which can be pinned" in problems[0]
+
+
+def test_declaring_a_site_with_no_repository_unpinnable_passes():
+    document = crosswalk_document({"url": "https://aveproject.org"}, dict(UNPINNABLE_SITE))
+
+    assert validate_crosswalks.check_declared_unpinnable_has_no_repository(document) == []
+
+
+def test_a_forge_url_with_no_repository_path_is_not_a_repository():
+    assert validate_crosswalks.is_repository_url("https://github.com/aveproject/ave")
+    assert not validate_crosswalks.is_repository_url("https://github.com/aveproject")
+    assert not validate_crosswalks.is_repository_url("https://aveproject.org/schema")
+
+
+def test_a_stated_record_count_with_no_commit_warns():
+    document = crosswalk_document({"url": "https://aveproject.org", "record_count": 76})
+
+    warnings = validate_crosswalks.warn_stated_count_without_pin(document)
+
+    assert len(warnings) == 1
+    assert "cannot be re-derived" in warnings[0]
+
+
+def test_a_stated_record_count_is_not_warned_about_when_pinned():
+    document = crosswalk_document(
+        {"url": "https://aveproject.org", "record_count": 76, "commit": "b" * 40}
+    )
+
+    assert validate_crosswalks.warn_stated_count_without_pin(document) == []
+
+
+def test_a_stated_record_count_is_not_warned_about_when_declared_unpinnable():
+    document = crosswalk_document(dict(UNPINNABLE_SITE, record_count=76))
+
+    assert validate_crosswalks.warn_stated_count_without_pin(document) == []
+
+
+def test_the_unpinned_count_check_is_a_warning_until_commit_is_required():
+    """The escalation agreed in #94: warn while commit is optional, hard-fail when
+    it is promoted at the next major. The constant is the switch, so this asserts
+    which side of the promotion the repository is on, not a preference."""
+    assert validate_crosswalks.UNPINNED_COUNT_IS_FATAL is False

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -146,8 +146,85 @@ def test_a_stated_record_count_is_not_warned_about_when_declared_unpinnable():
     assert validate_crosswalks.warn_stated_count_without_pin(document) == []
 
 
-def test_the_unpinned_count_check_is_a_warning_until_commit_is_required():
-    """The escalation agreed in #94: warn while commit is optional, hard-fail when
-    it is promoted at the next major. The constant is the switch, so this asserts
-    which side of the promotion the repository is on, not a preference."""
-    assert validate_crosswalks.UNPINNED_COUNT_IS_FATAL is False
+def crosswalk_schema() -> dict:
+    return json.loads(validate_crosswalks.SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_the_unpinned_count_check_is_a_warning_while_commit_is_optional():
+    """The escalation agreed in #94: warn while commit is optional, hard-fail once
+    it is promoted. This asserts which side of the promotion the shipped schema is
+    on, not a preference -- commit is optional in 1.0.x, so the check warns."""
+    assert validate_crosswalks.commit_is_required(crosswalk_schema()) is False
+
+
+def test_promoting_commit_to_required_escalates_the_check_with_no_code_change():
+    """The other side of the same switch. Requiring commit in the endpoint
+    definition is the whole of the escalation: no constant is flipped, no date is
+    read, and the validator cannot start failing before the field is promoted or
+    keep warning after it."""
+    schema = crosswalk_schema()
+    schema["$defs"]["endpoint"]["required"] = ["url", "commit"]
+
+    assert validate_crosswalks.commit_is_required(schema) is True
+
+
+def unpinned_count_tree(tmp_path, schema: dict) -> None:
+    """A whole repository in miniature: the given schema, one record, and one
+    crosswalk stating a count that nothing pins. Enough for main() to run against,
+    since it reads schema/, records/ and crosswalks/ relative to the directory it
+    is invoked from."""
+    (tmp_path / "schema").mkdir()
+    (tmp_path / "schema" / "crosswalk-1.0.0.schema.json").write_text(
+        json.dumps(schema), encoding="utf-8")
+    (tmp_path / "records").mkdir()
+    (tmp_path / "records" / "AVE-2026-00001.json").write_text(
+        json.dumps({"ave_id": "AVE-2026-00001"}), encoding="utf-8")
+    (tmp_path / "crosswalks").mkdir()
+    (tmp_path / "crosswalks" / "unpinned.json").write_text(
+        json.dumps(crosswalk_document({"url": "https://aveproject.org",
+                                       "record_count": 77})), encoding="utf-8")
+
+
+def test_an_unpinned_count_warns_and_exits_zero_while_commit_is_optional(
+        tmp_path, monkeypatch, capsys):
+    unpinned_count_tree(tmp_path, crosswalk_schema())
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["validate_crosswalks.py"])
+
+    exit_code = validate_crosswalks.main()
+
+    assert exit_code == 0
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_an_unpinned_count_fails_once_the_schema_promotes_commit(
+        tmp_path, monkeypatch, capsys):
+    """The escalation, end to end and through main() rather than through the
+    predicate alone: the only thing that changed is the schema, and the same
+    finding that was printed as a warning above is now reported as a failure.
+
+    The exit code alone cannot show this, because a schema that requires commit
+    refuses the file on its own account too, so what is asserted is that the
+    unpinned-count finding has stopped being a warning."""
+    schema = crosswalk_schema()
+    schema["$defs"]["endpoint"]["required"] = ["url", "commit"]
+    unpinned_count_tree(tmp_path, schema)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", ["validate_crosswalks.py"])
+
+    exit_code = validate_crosswalks.main()
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "cannot be re-derived" in out
+    assert "WARNING" not in out
+
+
+def test_forbidding_commit_on_an_unpinnable_side_does_not_read_as_promoting_it():
+    """1.0.x already contains a required list naming commit, underneath a `not`,
+    to keep a declared-unpinnable endpoint from also carrying a pin. Reading that
+    as the promotion would hard-fail the whole repository the day this landed."""
+    schema = crosswalk_schema()
+
+    assert "commit" in json.dumps(schema["$defs"]["endpoint"]["then"]["not"])
+    assert validate_crosswalks.commit_is_required(schema) is False


### PR DESCRIPTION
Part 1 of what we agreed in #160: the schema change and the validator change, and nothing else. The backfill is yours, per that thread, and this PR deliberately touches no crosswalk file, no version string, and nothing in #98's territory. It is documentation-only against the existing `commit` field, as agreed; no new pin field lands, because there already is one and I wrote it in #121.

`commit`'s description now says plainly what it pins: the tree a stated `record_count` describes, and whichever tree was actually read rather than the tip of any particular branch. A pin naming a tree the count did not come from validates, reads as clean, and produces a different number for anyone who checks, which is the failure worth naming in the field itself. The description also records that a sha on a branch that gets rebased away stops resolving, and that catching that is the validator's job rather than the schema's. That is your framing from #160 rather than mine, written into the field so it does not have to live in an issue thread.

The three-outcome shape lands as `pin_status`. An endpoint may declare `pin_status: "unpinnable"`, which requires `unpinnable_reason`, `checked_against_live_site` and `content_digest`, and forbids `commit` outright. So an endpoint is now pinned, or declared unpinnable with a reason, a date and a digest, or blank — and a blank means only that nobody has pinned it yet, which is the one thing it could not previously say on its own. `unpinnable` is the only value `pin_status` takes: an endpoint carrying `commit` is already pinned, and a second field restating that would be two fields answering one question, which is the argument that withdrew `source_commit` and applies just as well to this one. For the same reason there is no new fetch-date field. `checked_against_live_site` already means the date a side with no repository behind it was read, so the declaration reuses it instead of adding a second date beside it.

Falsifiability is enforced in two layers, and the split is deliberate. The always-on layer is offline and needs no network: a side declaring itself unpinnable whose own `url` is `<forge>/<owner>/<name>` on GitHub, GitLab, Bitbucket, Codeberg or sr.ht fails, because that URL is a repository by construction and the file refutes itself. That is the case that actually matters — a tool with a public repo being quietly filed under "can't be pinned" — and it costs nothing to check, runs identically everywhere, and keeps the validator hermetic. The second layer is `--probe-unpinnable`, off by default, which asks `git ls-remote --heads` about sides the shape test cannot judge. It reports a failure only when git exits zero and names a ref, which proves a history exists. Every other outcome — a non-zero exit, a timeout, no git on the path — is printed as inconclusive and explicitly labelled as unchecked or unrefuted rather than verified, because a URL that is unreachable from the machine running the check and a URL with nothing behind it are indistinguishable from that machine, and a check that did not run is not a result. I have left the probe out of the CI workflow rather than wiring it in myself, since it puts the network on the critical path of a gate that currently has none; say the word and it is one line.

On the warn-then-hard-fail escalation, which was your addition in #94 and which I do not think either of us has actually written down as agreed: accepted, explicitly, and it is what this PR implements. While `commit` is optional, a stated record count with no commit and no declared exemption is a warning — printed, and deliberately not counted against the exit code, in the same shape `validate_records.py` already uses for its researcher-attribution warning, so the file gains no second notion of what a soft finding is. It becomes a hard failure when `commit` is promoted to required at the next major. The switch is `commit_is_required(schema)`, which reads the escalation directly off the schema's own required list rather than holding it in a constant beside a comment asking a future editor to flip it — so promoting `commit` to required is the whole of the action, and the escalation can neither arrive early nor outlive it. There is a test asserting which side of it the repository is currently on, so the escalation cannot happen silently in either direction.

Nothing here makes an existing crosswalk invalid, and I checked rather than assumed. Every field added is optional and the conditional fires only when `pin_status` is present. At the schema commit alone, with `validate_crosswalks.py` still at its merged version, all six crosswalks in the tree validate and the script exits 0. With the validator commit on top, all six still validate and all six now warn, which is the real state of the tree: `ave-to-ast10`'s AVE side states 56, `cfgaudit` 59, `clawscan` 56, `skillspector` 56, `nova-proximity` 76 and `ramparts` 76, and not one of those counts is pinned. Those are exactly the warnings your backfill will clear, and the two crosswalks that already carry a source-side `commit` are silent on that side, as they should be.

I ran the CI workflow's four steps locally on a clean 3.11 virtualenv built the way the workflow builds it, `pip install -e ".[dev]"`: `validate_records.py` (77 of 77), `validate_crosswalks.py` (6 of 6, exit 0, 6 warnings), `check_fixtures.py` (77 of 77), and `pytest tests/ -x -q` (322 passed). I also ran gitleaks with the repo's own config, which found nothing. Each new behaviour has a case that goes red without the change, checked by reverting rather than by assertion: reverting the schema reds the four schema cases and no others; dropping the unpinnable clause from the warning, the commit clause from the warning, or the forge test from the falsifiability check reds exactly one case each with the rest green. The end-to-end failure path is checked too — a temporary crosswalk declaring a GitHub-hosted side unpinnable makes the script exit 1 with the refutation named, and the probe path was exercised against a real off-forge repository (fails, correctly) and against a site with no history (inconclusive note, no verdict, correctly).

Three things I would rather have had your read on than decide unilaterally, all now settled below: whether `content_digest` should be required alongside a declaration rather than recommended; whether to wire `--probe-unpinnable` into the workflow; and whether the reachability check named in #160 belongs in this validator as a third network check or somewhere else entirely.

Edit (2026-08-11): the paragraph above naming `UNPINNED_COUNT_IS_FATAL` was stale. It described an earlier design this branch has since replaced with `commit_is_required(schema)`, and the description was not updated when the code was, so it's fixed above rather than left standing. Also resolves the three open questions per your review: `content_digest` is now required alongside `pin_status: "unpinnable"` (`a3f7e75`, 6/6 crosswalks still valid, 326/326 tests pass); `--probe-unpinnable` stays out of CI as it already was; reachability-on-promoted-commits is its own follow-up issue, not this PR.