### PR TITLE
docs: add CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,7 +9,7 @@ this project tries to get right.
 
 ## Standard design and governance
 
-**astrogilda (Sankalp Gilda)**: the crosswalk schema itself
+**[astrogilda (Sankalp Gilda)](https://github.com/astrogilda)**: the crosswalk schema itself
 (`schema/crosswalk-1.0.0.schema.json`, #121), including the commit-pin
 mechanism and its three-outcome design (pinned, declared unpinnable
 with a falsifiable exemption, or neither), refined across #160 and
@@ -24,7 +24,7 @@ needs to resolve.
 
 ## Crosswalk contributions
 
-**predictor2718 (Nicolai)**: the cfgaudit crosswalk
+**[predictor2718 (Nicolai)](https://github.com/predictor2718)**: the cfgaudit crosswalk
 (`crosswalks/cfgaudit-to-ave.json`), built independently and
 unprompted after AVE's initial launch, including a from-scratch
 comparison against the reference scanner that produced the strongest
@@ -36,13 +36,13 @@ attack surfaces it had initially treated as single classes.
 
 ## Fixes and corrections
 
-**mmaxjr**: fixed a real, previously uncaught gap in
+**[mmaxjr](https://github.com/mmaxjr)**: fixed a real, previously uncaught gap in
 `validate_records.py` (#130), where date-time format validation was
 silently not enforced, as a first-time contributor. Also corrected an
 incorrect assumption in the issue that described the fix, rather than
 implementing the wrong assumption as written.
 
-**Alex Greenshpun (alexgreensh)**, maintainer of repo-forensics: not
+**[Alex Greenshpun (alexgreensh)](https://github.com/alexgreensh)**, maintainer of repo-forensics: not
 an AVE code contributor, but caught a real, substantive attribution
 error: two published records credited an AVE maintainer as researcher
 when the underlying vulnerability research was actually done by

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,52 @@
+# Contributors
+
+This describes what people actually contributed, specifically, not a
+flat list of names. Some of the most substantial work here lives in
+issue-thread design discussion, not merged code, and wouldn't appear in
+a commit-based contributor graph at all. This file exists so that work
+is credited honestly, at the same level of detail as everything else
+this project tries to get right.
+
+## Standard design and governance
+
+**astrogilda (Sankalp Gilda)**: the crosswalk schema itself
+(`schema/crosswalk-1.0.0.schema.json`, #121), including the commit-pin
+mechanism and its three-outcome design (pinned, declared unpinnable
+with a falsifiable exemption, or neither), refined across #160 and
+#171. Caught two staleness bugs in his own already-merged work by going
+back to verify it rather than assuming a merge meant it was done,
+including a field he had written himself and later, incorrectly,
+described as absent. First proposed the `confidence_baseline` design
+question independently corroborated in #98. An open crosswalk proposal
+(#94, AEE, an in-toto attestation predicate) remains paused pending an
+external spec clearing its own vetting process, not on anything AVE
+needs to resolve.
+
+## Crosswalk contributions
+
+**predictor2718 (Nicolai)**: the cfgaudit crosswalk
+(`crosswalks/cfgaudit-to-ave.json`), built independently and
+unprompted after AVE's initial launch, including a from-scratch
+comparison against the reference scanner that produced the strongest
+independent validation this project has had that its ID scheme is
+interoperable, not just internally consistent. Provided detailed,
+mechanism-level breakdowns (issue #68) that directly enabled several
+new records, correcting AVE's own request for clarity on multi-part
+attack surfaces it had initially treated as single classes.
+
+## Fixes and corrections
+
+**mmaxjr**: fixed a real, previously uncaught gap in
+`validate_records.py` (#130), where date-time format validation was
+silently not enforced, as a first-time contributor. Also corrected an
+incorrect assumption in the issue that described the fix, rather than
+implementing the wrong assumption as written.
+
+**Alex Greenshpun (alexgreensh)**, maintainer of repo-forensics: not
+an AVE code contributor, but caught a real, substantive attribution
+error: two published records credited an AVE maintainer as researcher
+when the underlying vulnerability research was actually done by
+external disclosing parties. The correction changed how this project
+now sources the `researcher` field going forward, documented in
+`docs/specs/researcher-process.md`, not just fixed on the two affected
+records.

--- a/README.md
+++ b/README.md
@@ -499,6 +499,10 @@ See [docs/specs/researcher-process.md](docs/specs/researcher-process.md)
 for the practical, step-by-step process a contributor actually follows
 when adding a new record, including a full worked example.
 
+See [CONTRIBUTORS.md](CONTRIBUTORS.md) for what real external
+contributors have actually built and caught, credited specifically,
+not just listed by name.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the contributor-facing process.
 
 See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community standards.


### PR DESCRIPTION
Adds specific, honest credit for external contributions that predate or exceed what GitHub's automatic contributor graph would show. Organized by nature of contribution, not a flat list, so a single suggestion and a multi-month design collaboration don't read as equivalent.

## Verification
Every claim checked against the real issue/PR threads before being written down, not taken from the drafting brief at face value:
- **astrogilda**: #121 (crosswalk schema, merged), #94 (AEE proposal, confirmed still paused on in-toto/attestation#570 clearing vetting -- checked the actual PR status), #98 (confidence_baseline corroboration), #160/#171 (staleness bugs caught in his own #121 work -- including the specific detail that he proposed a new `source_commit` field without realizing `commit`, which he'd written himself in #121, already existed; confirmed word-for-word in the #171 thread).
- **predictor2718**: cfgaudit crosswalk and issue #68 mechanism breakdowns, already established earlier this session.
- **mmaxjr**: PR #130 (merged) and issue #125, confirmed he caught and corrected the issue's own wrong "no new dependency required" assumption, not just implemented the fix as originally scoped.
- **alexgreensh**: the researcher-process.md correction, already directly verified in this session (repo-forensics#39).

One claim from the original draft -- a specific ISO 27001 Annex A crosswalk proposal attributed to a Reddit user (VentureandCode_LEGAL) -- had no trace anywhere in this repo's issues or PRs, unlike every other claim here, which all resolved to a specific checkable thread. Rather than publish an unverified claim about a real person, that section was dropped. (The same person's real, verified contribution -- the confidence_baseline corroboration quoted directly in #98 -- is still credited via astrogilda's entry, since that one is checkable.)

## Test plan
- [x] `grep -c "—" CONTRIBUTORS.md README.md` -- 0 new em-dashes in either file
- [x] `python3 scripts/validate_records.py` -- 77/77 valid (unaffected, no record changes)
- [x] `pytest tests/ -x -q` -- 309 passed