### PR TITLE
chore: regenerate consolidated records JSON

### DIFF
--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 80,
-  "generated_at": "2026-08-14T16:46:21.108Z",
+  "generated_at": "2026-08-14T16:49:50.966Z",
   "source": "https://github.com/aveproject/ave"
 }


### PR DESCRIPTION
Auto-generated by `scripts/build-records.js` after a change to
`records/` on `develop`. Regenerates `dist/ave-records-latest.json`
(and its manifest) to stay in sync with the current record set.
The versioned `dist/ave-records-v<schema_version>.json` snapshot
is only touched the first time a given schema version appears --
if this diff includes one, that means a new schema version's
frozen snapshot was just created, not that an existing one
changed.