### PR TITLE
fix: correct AVE-2026-00070 researcher attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 ## [Unreleased]
 
 ### Changed
+- AVE-2026-00070: `researcher`/`researcher_url` correction — was
+  listed as "Saray Chak" / bawbel.io despite the record's own
+  `references` entry already citing the actual external source (Zhu,
+  Li, Lyu, Sun, Su, Shao, "Collaborative Shadows: Distributed Backdoor
+  Attacks in LLM-Based Multi-Agent Systems," arXiv:2510.11246); the
+  exact misattribution pattern `docs/specs/researcher-process.md`
+  documents as previously caught and fixed on two other records
+  (see the AVE-2026-00060 worked example), recurring here uncaught
+  until now. Corrected to the paper's real six authors and the actual
+  arXiv abstract page. No score, severity, or mechanism-description
+  change.
 - `mitre_atlas` corrections on 43 records, per issue #127's audit of
   `AML.T0043`/`T0048`/`T0051`/`T0054`: those four IDs were largely
   applied by template rather than per-record verification against

--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -8802,8 +8802,8 @@
     ],
     "remediation": "Treat tool outputs shared across multiple agents in a collaborative task as a cross-agent attack surface, not just a per-call one; correlate observations across the full task's agent roster, not each agent in isolation. Apply provenance labeling to tool outputs so downstream memory retention can be audited against its source. Where feasible, isolate or sanitize tool observations before they persist into an agent's longer-term memory, rather than retaining raw tool output unmodified.",
     "kill_switch_active": false,
-    "researcher": "Saray Chak",
-    "researcher_url": "https://bawbel.io",
+    "researcher": "Pengyu Zhu, Lijun Li, Yaxing Lyu, Li Sun, Sen Su, Jing Shao",
+    "researcher_url": "https://arxiv.org/abs/2510.11246",
     "published": "2026-08-02T00:00:00Z",
     "last_updated": "2026-08-02T00:00:00Z",
     "references": [

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 77,
-  "generated_at": "2026-08-13T15:39:05.714Z",
+  "generated_at": "2026-08-14T16:03:12.862Z",
   "source": "https://github.com/aveproject/ave"
 }

--- a/records/AVE-2026-00070.json
+++ b/records/AVE-2026-00070.json
@@ -46,8 +46,8 @@
   ],
   "remediation": "Treat tool outputs shared across multiple agents in a collaborative task as a cross-agent attack surface, not just a per-call one; correlate observations across the full task's agent roster, not each agent in isolation. Apply provenance labeling to tool outputs so downstream memory retention can be audited against its source. Where feasible, isolate or sanitize tool observations before they persist into an agent's longer-term memory, rather than retaining raw tool output unmodified.",
   "kill_switch_active": false,
-  "researcher": "Saray Chak",
-  "researcher_url": "https://bawbel.io",
+  "researcher": "Pengyu Zhu, Lijun Li, Yaxing Lyu, Li Sun, Sen Su, Jing Shao",
+  "researcher_url": "https://arxiv.org/abs/2510.11246",
   "published": "2026-08-02T00:00:00Z",
   "last_updated": "2026-08-02T00:00:00Z",
   "references": [


### PR DESCRIPTION
## Summary

`AVE-2026-00070` (Distributed Cross-Agent Backdoor Fragments) listed
`researcher: "Saray Chak"` / `researcher_url: "https://bawbel.io"`
despite the record's own `references` array already citing the actual
external source it's based on: Zhu, Li, Lyu, Sun, Su, Shao,
"Collaborative Shadows: Distributed Backdoor Attacks in LLM-Based
Multi-Agent Systems" ([arXiv:2510.11246](https://arxiv.org/abs/2510.11246)).

This is the exact misattribution pattern
`docs/specs/researcher-process.md`'s worked example
(`AVE-2026-00060`) documents as previously caught and fixed on two
other records — recurring here, uncaught until now. Flagged during an
unrelated review pass, fixed as its own PR rather than folded into
that pass's changes.

## Fix

Verified the paper's real author list against the actual arXiv
abstract page (not inferred from the reference text alone):

- `researcher`: "Saray Chak" → "Pengyu Zhu, Lijun Li, Yaxing Lyu, Li
  Sun, Sen Su, Jing Shao"
- `researcher_url`: `https://bawbel.io` → `https://arxiv.org/abs/2510.11246`

No score, severity, mechanism description, or any other field change.

## Checklist

- [x] `python3 scripts/validate_records.py` — 77/77 valid
- [x] `pytest tests/ -x -q` — 309 passed
- [x] Republished via `node scripts/build-records.js`
- [x] CHANGELOG updated