### PR TITLE
Pin the AVE side of six crosswalks to the tree each count was read at

### DIFF
--- a/crosswalks/ave-to-ast10.json
+++ b/crosswalks/ave-to-ast10.json
@@ -4,7 +4,8 @@
     "standard": "AVE",
     "version": "1.1.0",
     "url": "https://aveproject.org",
-    "record_count": 56
+    "record_count": 56,
+    "commit": "38b6cf0c384eec42a1370f080ba976de6cae2700"
   },
   "target": {
     "tool": "OWASP Agentic Skills Top 10 (AST10)",

--- a/crosswalks/cfgaudit-to-ave.json
+++ b/crosswalks/cfgaudit-to-ave.json
@@ -15,7 +15,8 @@
     "version": "1.1.0",
     "url": "https://aveproject.org",
     "record_count": 70,
-    "static_record_count": 51
+    "static_record_count": 51,
+    "commit": "71b3e53c2e3f1de94c8c98c9ba2a388e513606ce"
   },
   "generated": "2026-08-05",
   "note": "cfgaudit is a static auditor of committable AI-agent CONFIGURATION files. It does not connect to running servers or observe runtime, so it maps only to AVE's static_detection records. Each cfgaudit rule emits its primary AVE id in JSON/SARIF output (see github.com/cfgaudit/cfgaudit/blob/main/docs/cfgaudit-to-ave.md). Mappings are class-level behavioral equivalence, not asserted identity. cfgaudit now maps 53 config-surface rules onto 23 AVE behavioral classes, up from 35 onto 19 at v1.10.0. Most of that growth is not new cfgaudit rules: it is previously unmapped rules finding a home in AVE-2026-00061 through AVE-2026-00064, the four config classes AVE added from this crosswalk's own gap list (aveproject/ave#68). CFG091 moved from AVE-2026-00021 to AVE-2026-00063: 00021 describes a component that explicitly INSTRUCTS the agent to bypass confirmation, while qwen's tools.approvalMode is a setting, which is what 00063 covers 'independent of any instruction text'.",

--- a/crosswalks/clawscan-to-ave.json
+++ b/crosswalks/clawscan-to-ave.json
@@ -12,7 +12,8 @@
     "standard": "AVE",
     "version": "1.1.0",
     "url": "https://aveproject.org",
-    "record_count": 56
+    "record_count": 56,
+    "commit": "38b6cf0c384eec42a1370f080ba976de6cae2700"
   },
   "generated": "2026-07-12",
   "note": "Crosswalk from ClawScan's 7 analyzer modules and their rule IDs to AVE behavioral class ids. Rule-level mappings below were last checked against ClawScan's live scan output and documentation on 2026-06-21 and reflect the 51-record set current at that time. AVE-2026-00052 through 00056 (added 2026-07-10) are not yet reflected in the mappings or gaps below -- that requires re-checking ClawScan's actual rule catalog, which this repo does not have live access to; the AVE side of that recheck (target.record_count) is updated, the ClawScan side is not. Gaps indicate behavioral classes covered by ClawScan that AVE does not yet enumerate.",

--- a/crosswalks/nova-proximity-to-ave.json
+++ b/crosswalks/nova-proximity-to-ave.json
@@ -12,7 +12,8 @@
     "version": "1.1.0",
     "url": "https://aveproject.org",
     "record_count": 76,
-    "static_record_count": 57
+    "static_record_count": 57,
+    "commit": "a97254dc18677bd6a2fcb76ae1bc7bf173158c31"
   },
   "generated": "2026-08-08",
   "note": "No shared external taxonomy exists between NOVA's rule format and AVE (unlike the Ramparts crosswalk, which anchored on OWASP MCP Top 10 tagging both projects already carried), so this crosswalk matches by direct comparison of each Nova rule's real trigger logic against AVE's behavioral fingerprints, not by a shared tag. Several Nova rules split into multiple sub-cases with different AVE mappings, DetectMaliciousToolPermissions alone covers three distinct AVE classes depending on which pattern fires. One AVE class (AVE-2026-00004, curl|bash execution) is independently caught by two separate Nova rules, DetectMaliciousToolPermissions and DetectSuspiciousScriptPatterns, both correctly converging on the same mechanism. Four confirmed gaps, each a genuinely distinct mechanism from any existing AVE record: sudo/chmod/netcat/reverse-shell keyword detection, backdoor-library detection (paramiko, fabric, pexpect, socket.connect), plain bracket-tag concealment ([hidden], [SYSTEM], [ASSISTANT]) as distinct from AVE-2026-00029's Unicode-based concealment mechanism, and known exfil-channel domain detection (webhook.site, ngrok, pastebin) as a materially different mechanism from AVE's closest label. One partial miss: fake-certification impersonation language does not cleanly fit any existing AVE record. Also worth noting, unrelated to AVE itself: Nova's own DetectHiddenInstructions and DetectSkillPromptInjection rules appear to independently detect the same bracket-marker concealment pattern, surfaced as a byproduct of this comparison, not confirmed as intentional redundancy or worth consolidating.",

--- a/crosswalks/ramparts-to-ave.json
+++ b/crosswalks/ramparts-to-ave.json
@@ -12,7 +12,8 @@
     "version": "1.1.0",
     "url": "https://aveproject.org",
     "record_count": 76,
-    "static_record_count": 57
+    "static_record_count": 57,
+    "commit": "a97254dc18677bd6a2fcb76ae1bc7bf173158c31"
   },
   "generated": "2026-08-08",
   "note": "Ramparts and AVE both draft their own reading of the still-unratified OWASP MCP Top 10, independently, and their MCP01-MCP10 numbering does not align category-for-category; Ramparts' MCP03 (Excessive Agency) and AVE's MCP03 (Tool Poisoning) are unrelated despite sharing a number. This crosswalk matches by verified mechanism, not by shared tag number, see AVE issue #138 for the full verification. One Ramparts rule, EnvironmentVariableLeakage, splits into two distinct AVE mappings depending on which internal condition fires, a literal-value branch and a theft-language branch, not one-to-one. Near-miss not included in mappings: Ramparts' CommandInjection is a signature match over dangerous syntax anywhere in content; AVE-2026-00052 specifically requires a taint path from a caller-supplied parameter to shell exec. Same subject, different rigor, the exact distinction between signature-based scanning and reachability analysis. Real gaps in both directions: Ramparts' cross-origin tool confusion detection and its MCPConfigChanged baseline-diff check (a previously-approved server's fingerprint changing after the fact) have no AVE analog today; AVE has nothing for session-memory or cross-agent-state poisoning, which Ramparts does not currently touch either.",

--- a/crosswalks/skillspector-to-ave.json
+++ b/crosswalks/skillspector-to-ave.json
@@ -13,7 +13,8 @@
     "standard": "AVE",
     "version": "1.1.0",
     "url": "https://aveproject.org",
-    "record_count": 56
+    "record_count": 56,
+    "commit": "38b6cf0c384eec42a1370f080ba976de6cae2700"
   },
   "generated": "2026-07-12",
   "note": "Crosswalk from SkillSpector's 16 scanner categories to AVE behavioral class ids. Rule-level mappings below were last checked against SkillSpector 2.0.0's category/pattern documentation on 2026-06-21 and reflect the 51-record set current at that time. AVE-2026-00052 through 00056 (added 2026-07-10) are not yet reflected in the mappings or gaps below -- that requires re-checking SkillSpector's actual category catalog, which this repo does not have live access to; the AVE side of that recheck (target.record_count) is updated, the SkillSpector side is not. SkillSpector organises detection as an internal scanner taxonomy; AVE is a behavioral standard. Some SkillSpector categories are scanner mechanics (YARA signatures, taint tracking, AST analysis) rather than vulnerability classes -- these are marked as no_ave_class with an explanation. Gaps indicate behavioral classes that AVE does not yet enumerate.",

--- a/scripts/validate_crosswalks.py
+++ b/scripts/validate_crosswalks.py
@@ -164,19 +164,37 @@ def is_repository_url(url: object) -> bool:
     return len([segment for segment in parsed.path.split("/") if segment]) >= 2
 
 
+def repository_fields(endpoint: dict) -> list[tuple[str, str]]:
+    """Every field on this endpoint whose value is a repository URL, with its key.
+
+    Deliberately not just url. The endpoint definition sets additionalProperties
+    true, so a side may describe itself with as many URL-valued fields as it
+    needs, and two sides in this repository already do: the AST10 side of
+    ave-to-ast10.json carries its OWASP project page under url and its
+    repository under github, and the ClawScan side of clawscan-to-ave.json
+    carries the repository under url and the project site under site. Reading
+    only url therefore refutes a false unpinnable declaration when the
+    repository happens to sit under the one key the check looks at, and misses
+    it otherwise, which is a fact about where an author put a link rather than
+    anything about the declaration.
+    """
+    return [(key, value) for key, value in sorted(endpoint.items())
+            if is_repository_url(value)]
+
+
 def check_declared_unpinnable_has_no_repository(document: dict) -> list[str]:
-    """Refutes an unpinnable declaration that is contradicted by its own url.
+    """Refutes an unpinnable declaration that its own fields contradict.
 
     An endpoint saying it cannot be pinned is an exemption from the record-count
     warning below, and an exemption nobody can check is not a declaration: it is
     the box anything awkward gets put in. This is the offline half of checking
     it, and it only ever reports the case it has proved.
     """
-    return [f"{side} declares pin_status unpinnable, but its url {endpoint.get('url')} "
+    return [f"{side} declares pin_status unpinnable, but its {key} {url} "
             f"is a repository, which can be pinned"
             for side, endpoint in endpoints(document)
             if endpoint.get("pin_status") == "unpinnable"
-            and is_repository_url(endpoint.get("url"))]
+            for key, url in repository_fields(endpoint)]
 
 
 def probe_declared_unpinnable(document: dict) -> tuple[list[str], list[str]]:
@@ -194,7 +212,7 @@ def probe_declared_unpinnable(document: dict) -> tuple[list[str], list[str]]:
         url = endpoint.get("url")
         if endpoint.get("pin_status") != "unpinnable" or not isinstance(url, str):
             continue
-        if is_repository_url(url):
+        if repository_fields(endpoint):
             continue  # already refuted offline; do not report it twice
         try:
             completed = subprocess.run(

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -111,6 +111,34 @@ def test_declaring_a_repository_unpinnable_fails():
     assert "which can be pinned" in problems[0]
 
 
+def test_declaring_a_repository_unpinnable_fails_when_the_repository_is_not_under_url():
+    """The shape the check used to miss, taken from a real endpoint.
+
+    The AST10 side of ave-to-ast10.json carries its OWASP project page under url
+    and its repository under github. Reading only url leaves that endpoint free
+    to declare itself unpinnable and pass, and the network probe reaches the
+    same verdict for the same reason, because it probes the project page and
+    correctly finds no history behind it. Both halves would report clean on a
+    declaration that is false.
+    """
+    endpoint = dict(UNPINNABLE_SITE,
+                    github="https://github.com/OWASP/www-project-agentic-skills-top-10")
+    document = crosswalk_document({"url": "https://aveproject.org"}, endpoint)
+
+    problems = validate_crosswalks.check_declared_unpinnable_has_no_repository(document)
+
+    assert len(problems) == 1
+    assert "its github" in problems[0]
+    assert "which can be pinned" in problems[0]
+
+
+def test_a_site_with_no_repository_under_any_field_is_still_declarable():
+    """The widening must not swallow the case the declaration exists for."""
+    endpoint = dict(UNPINNABLE_SITE, site="https://owasp.org/projects/")
+
+    assert validate_crosswalks.repository_fields(endpoint) == []
+
+
 def test_declaring_a_site_with_no_repository_unpinnable_passes():
     document = crosswalk_document({"url": "https://aveproject.org"}, dict(UNPINNABLE_SITE))
 


### PR DESCRIPTION
This is step 2 of the sequence on #126, the backfill. It pins the AVE side of every crosswalk that states a record count, and it fixes a hole in the check that guards the unpinnable declaration. Two things I told you in #126 were wrong, and both are corrected here rather than left for review to find.

The first is the count. I said four crosswalks. It is six endpoints across six files, and the repository's own validator says so on a clean checkout of main. Running python scripts/validate_crosswalks.py before this change prints six warnings: ave-to-ast10.json source, cfgaudit-to-ave.json target, clawscan-to-ave.json target, nova-proximity-to-ave.json target, ramparts-to-ave.json target, and skillspector-to-ave.json target. The two I missed are nova-proximity and ramparts, both added after I wrote the plan and both stating a count of 76. Had the backfill covered only the four I named, step 3 would have hard-failed the moment you made the field required, on two files nobody had looked at. After this change the same command prints nine ok lines and zero warnings.

The second is worse, because it was the part of the plan you singled out. I said ave-to-ast10.json would declare itself unpinnable, on the reasoning that the OWASP AST10 project is a published site with no repository to pin. The warning on that file is not on the AST10 side at all. It is on the source, and the source is AVE, which is this repository, which has a history and pins like any other. So the unpinnable declaration I described was never needed there. Worse, if it had been written on the side I claimed it belonged to, it would have been false: the AST10 endpoint carries a `github` value of https://github.com/OWASP/www-project-agentic-skills-top-10 alongside its owasp.org project page. That means the example I gave you of the three outcome design meeting a real non pilot case does not exist. This backfill contains six real commits and zero unpinnable declarations, and the first live use of that declaration is still ahead of us.

That second error also exposed a hole in the check, which is the other commit here. `check_declared_unpinnable_has_no_repository` reads only the `url` field. The endpoint definition sets `additionalProperties: true`, so a side may describe itself with as many URL bearing fields as it needs, and two sides in this repository already do: AST10 carries its project page under url and its repository under github, and ClawScan carries the repository under url and its project site under `site`. A check reading one key of an open ended object refutes a false declaration only when the repository happens to sit under the key it looks at, which is a fact about where an author put a link rather than anything about the declaration. The network probe reaches the same wrong verdict by a different route: it would probe the owasp.org page, correctly find no history behind it, and emit the note saying the declaration is unrefuted. A false declaration would have read as clean twice, and the endpoint it would have read as clean on is the exact one my plan proposed to declare. The docstring on that check already states the contract it was missing, that an exemption nobody can check is not a declaration but the box anything awkward gets put in, so this is the check meeting its own stated bar rather than a new requirement. It now scans every field on the endpoint and names the field it found. No endpoint in the repository declares itself unpinnable today, so no verdict changes anywhere. Both new tests fail without the widening and pass with it, which I checked by reverting the script and rerunning.

On how the pins were chosen, I have taken your correction and it is the better statement. The failure on #160 was not that develop was the wrong branch. It was presenting a commit as verified history without confirming where it came from. So every pin here was read rather than inferred. All six are the AVE side, so all six are commits in this repository, which makes them checkable without leaving the tree. The ave-to-ast10 source, the clawscan target and the skillspector target state 56 and pin 38b6cf0c, the commit that brought records/ to 56. The cfgaudit target states 70 records and 51 static and pins 71b3e53c. The nova-proximity and ramparts targets state 76 and 57 static and pin a97254dc. At each of those commits the number of records/AVE-*.json files equals the stated `record_count`, and the number of records whose `detection_stage` is static_detection equals the stated `static_record_count`. I checked that derivation first against semia-to-ave.json, which already carries a pin, and it reproduces both of that file's numbers exactly, so the method was proved on a case you had already accepted before I applied it to six you had not. Each commit was taken out of main's own history and each is an ancestor of main.

One detail worth stating rather than leaving implicit. Where a stated count is unchanged across a run of commits, more than one tree re-derives it, and I cannot know which one was actually in front of whoever generated the crosswalk. Rather than pick one and present it as the tree that was read, each pin names the commit that established the count, which is the one commit in that run identifiable from the history instead of chosen. Every crosswalk's generated date falls inside the run its pin opens.

There is a third thing, which is not an error in the plan but does affect the change you are about to write, so it is better said now than discovered by your CI. I simulated step 3 two ways against the backfilled corpus. Promoting the field into the required list on the endpoint definition outright fails four more endpoints, all of them tool sides that state no record count and were therefore never covered by the warning: the AST10 side of ave-to-ast10, and the cfgaudit, ClawScan and SkillSpector sides of their files. Scoping the requirement to endpoints that state a count leaves all nine files green. SkillSpector is the one we already agreed has no resolvable version upstream, so the blunt form would reopen that. I did not pin those four, because guessing which upstream tree a tool crosswalk was read against is exactly the move your #160 correction rules out, and if you want them pinned it is a separate piece of work with real reading behind it. Which form step 3 takes is your call, and this backfill closes the count scoped form completely.

The repository's three validators and the test suite all pass on this branch. The record validator reports all 80 records valid, with the six pre-existing researcher attribution warnings unchanged. The crosswalk validator reports 9 of 9 valid with no warnings, down from six. The fixture checker reports all 80 records have positive and negative fixtures. The test suite passes 341 tests, up from 339.

The two commits are separate and the second one stands alone, so if you would rather review the check widening as its own pull request I will split it out and rebase this down to the six line backfill. I kept them together because the hole in the check is what my own plan walked into, and reading them apart loses why the widening is worth having.
