### PR TITLE
fix: owasp_asi mapping audit (48 corrected, 13 confirmed, 11 flagged ambiguous)

### DIFF
--- a/records/AVE-2026-00002.json
+++ b/records/AVE-2026-00002.json
@@ -18,10 +18,7 @@
   ],
   "aivss_score": 7.3,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI03"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP03",
     "MCP10"
@@ -93,7 +90,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-01T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00003.json
+++ b/records/AVE-2026-00003.json
@@ -18,10 +18,7 @@
   ],
   "aivss_score": 6.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP01",
     "MCP05"
@@ -95,7 +92,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-01T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-522",

--- a/records/AVE-2026-00004.json
+++ b/records/AVE-2026-00004.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 5.9,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01", "ASI05"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -71,7 +68,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-78",

--- a/records/AVE-2026-00005.json
+++ b/records/AVE-2026-00005.json
@@ -19,9 +19,7 @@
   ],
   "aivss_score": 5.6,
   "cvss_base_vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:H/SC:N/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI02"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MANAGE-1.3",
@@ -69,7 +67,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-05-12T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-78",

--- a/records/AVE-2026-00006.json
+++ b/records/AVE-2026-00006.json
@@ -17,9 +17,7 @@
   ],
   "aivss_score": 7.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI02"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.6",
@@ -67,7 +65,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-05-12T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "MITRE ATT&CK T1657",

--- a/records/AVE-2026-00007.json
+++ b/records/AVE-2026-00007.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 6.1,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI01",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -69,7 +66,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Perez 2022",

--- a/records/AVE-2026-00008.json
+++ b/records/AVE-2026-00008.json
@@ -19,9 +19,7 @@
   ],
   "aivss_score": 6.3,
   "cvss_base_vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI10"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -69,7 +67,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Cohen 2024",

--- a/records/AVE-2026-00009.json
+++ b/records/AVE-2026-00009.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 5.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI01",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -70,7 +67,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
-  "last_updated": "2026-05-12T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Wei 2023",

--- a/records/AVE-2026-00011.json
+++ b/records/AVE-2026-00011.json
@@ -19,9 +19,7 @@
   ],
   "aivss_score": 5.7,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI02"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -68,7 +66,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00012.json
+++ b/records/AVE-2026-00012.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 4.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI01",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -69,7 +66,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-269",

--- a/records/AVE-2026-00013.json
+++ b/records/AVE-2026-00013.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 6.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI01",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -70,7 +67,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-359",

--- a/records/AVE-2026-00014.json
+++ b/records/AVE-2026-00014.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 3.7,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5"
@@ -62,7 +59,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-290",

--- a/records/AVE-2026-00015.json
+++ b/records/AVE-2026-00015.json
@@ -19,10 +19,7 @@
   ],
   "aivss_score": 4.9,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI09"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5"
@@ -65,7 +62,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-20T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Perez 2022",

--- a/records/AVE-2026-00016.json
+++ b/records/AVE-2026-00016.json
@@ -15,10 +15,7 @@
   ],
   "aivss_score": 6.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI10"
-  ],
+  "owasp_asi": ["ASI01", "ASI06"],
   "owasp_mcp": [
     "MCP10",
     "MCP03"
@@ -91,7 +88,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00017.json
+++ b/records/AVE-2026-00017.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 5.7,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP09",
     "MCP07"
@@ -89,7 +86,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-290",

--- a/records/AVE-2026-00018.json
+++ b/records/AVE-2026-00018.json
@@ -14,10 +14,7 @@
   ],
   "aivss_score": 4.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP03",
     "MCP08"
@@ -87,7 +84,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00019.json
+++ b/records/AVE-2026-00019.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 5.6,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI09"
-  ],
+  "owasp_asi": ["ASI01", "ASI06"],
   "owasp_mcp": [
     "MCP10",
     "MCP06"
@@ -93,7 +90,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Cohen 2024",

--- a/records/AVE-2026-00021.json
+++ b/records/AVE-2026-00021.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 4.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI04"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP02",
     "MCP08"
@@ -86,7 +83,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00022.json
+++ b/records/AVE-2026-00022.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 6,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:L/VA:N/SC:H/SI:L/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01", "ASI02"],
   "owasp_mcp": [
     "MCP02"
   ],
@@ -89,7 +86,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-269",

--- a/records/AVE-2026-00024.json
+++ b/records/AVE-2026-00024.json
@@ -15,9 +15,7 @@
   ],
   "aivss_score": 6.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI04"],
   "owasp_mcp": [
     "MCP04"
   ],
@@ -87,7 +85,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-07-17T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-434",

--- a/records/AVE-2026-00025.json
+++ b/records/AVE-2026-00025.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 4.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI10"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP10",
     "MCP06"
@@ -88,7 +85,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00026.json
+++ b/records/AVE-2026-00026.json
@@ -13,10 +13,7 @@
   ],
   "aivss_score": 6.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP01",
     "MCP08"
@@ -88,7 +85,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-116",

--- a/records/AVE-2026-00027.json
+++ b/records/AVE-2026-00027.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 5.6,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI09"
-  ],
+  "owasp_asi": ["ASI01", "ASI06"],
   "owasp_mcp": [
     "MCP06",
     "MCP10"
@@ -92,7 +89,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00028.json
+++ b/records/AVE-2026-00028.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 5.9,
   "cvss_base_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP10",
     "MCP03"
@@ -91,7 +88,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00029.json
+++ b/records/AVE-2026-00029.json
@@ -14,10 +14,7 @@
   ],
   "aivss_score": 4.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI03"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP03",
     "MCP04"
@@ -87,7 +84,7 @@
   "researcher": "Boucher & Anderson",
   "researcher_url": "https://arxiv.org/abs/2111.00169",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Boucher 2021",

--- a/records/AVE-2026-00030.json
+++ b/records/AVE-2026-00030.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 4.3,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP07",
     "MCP02"
@@ -89,7 +86,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-290",

--- a/records/AVE-2026-00031.json
+++ b/records/AVE-2026-00031.json
@@ -14,10 +14,7 @@
   ],
   "aivss_score": 5.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI09"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP06",
     "MCP04"
@@ -91,7 +88,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Wan 2023",

--- a/records/AVE-2026-00032.json
+++ b/records/AVE-2026-00032.json
@@ -15,10 +15,7 @@
   ],
   "aivss_score": 4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N",
-  "owasp_asi": [
-    "ASI05",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI05"],
   "owasp_mcp": [
     "MCP05",
     "MCP02"
@@ -90,7 +87,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-918",

--- a/records/AVE-2026-00033.json
+++ b/records/AVE-2026-00033.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 4.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01", "ASI05"],
   "owasp_mcp": [
     "MCP05",
     "MCP04"
@@ -91,7 +88,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-502",

--- a/records/AVE-2026-00034.json
+++ b/records/AVE-2026-00034.json
@@ -17,10 +17,7 @@
   ],
   "aivss_score": 6.6,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01", "ASI04"],
   "owasp_mcp": [
     "MCP04",
     "MCP03"
@@ -95,7 +92,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-829",

--- a/records/AVE-2026-00035.json
+++ b/records/AVE-2026-00035.json
@@ -13,10 +13,7 @@
   ],
   "aivss_score": 4.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP03",
     "MCP08"
@@ -86,7 +83,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "MITRE ATLAS AML.T0020",

--- a/records/AVE-2026-00036.json
+++ b/records/AVE-2026-00036.json
@@ -16,10 +16,7 @@
   ],
   "aivss_score": 5.9,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI01",
-    "ASI05"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP05",
     "MCP02"
@@ -93,7 +90,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "MITRE ATT&CK T1021",

--- a/records/AVE-2026-00037.json
+++ b/records/AVE-2026-00037.json
@@ -15,10 +15,7 @@
   ],
   "aivss_score": 5.1,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI10"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP10",
     "MCP03"
@@ -90,7 +87,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Qi 2023",

--- a/records/AVE-2026-00039.json
+++ b/records/AVE-2026-00039.json
@@ -15,10 +15,7 @@
   ],
   "aivss_score": 4.9,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI01"],
   "owasp_mcp": [
     "MCP01",
     "MCP08"
@@ -91,7 +88,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-05-12T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-514",

--- a/records/AVE-2026-00040.json
+++ b/records/AVE-2026-00040.json
@@ -15,10 +15,7 @@
   ],
   "aivss_score": 5.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI01", "ASI05"],
   "owasp_mcp": [
     "MCP05",
     "MCP10"
@@ -89,7 +86,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "OWASP LLM Insecure Output",

--- a/records/AVE-2026-00041.json
+++ b/records/AVE-2026-00041.json
@@ -19,11 +19,7 @@
   ],
   "aivss_score": 8.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI01",
-    "ASI03",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -81,7 +77,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00042.json
+++ b/records/AVE-2026-00042.json
@@ -18,11 +18,7 @@
   ],
   "aivss_score": 4.7,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI04",
-    "ASI01",
-    "ASI10"
-  ],
+  "owasp_asi": ["ASI01", "ASI05"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.6",
@@ -80,7 +76,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-94",

--- a/records/AVE-2026-00044.json
+++ b/records/AVE-2026-00044.json
@@ -17,11 +17,7 @@
   ],
   "aivss_score": 6.1,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:L/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI01",
-    "ASI07",
-    "ASI08"
-  ],
+  "owasp_asi": ["ASI01"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -75,7 +71,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00045.json
+++ b/records/AVE-2026-00045.json
@@ -17,11 +17,7 @@
   ],
   "aivss_score": 6.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI05",
-    "ASI08",
-    "ASI10"
-  ],
+  "owasp_asi": ["ASI03"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -81,7 +77,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-269",

--- a/records/AVE-2026-00046.json
+++ b/records/AVE-2026-00046.json
@@ -18,10 +18,7 @@
   ],
   "aivss_score": 9.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI04",
-    "ASI09"
-  ],
+  "owasp_asi": ["ASI04"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -81,7 +78,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-16T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-601",

--- a/records/AVE-2026-00048.json
+++ b/records/AVE-2026-00048.json
@@ -18,10 +18,7 @@
   ],
   "aivss_score": 7.7,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_asi": [
-    "ASI04",
-    "ASI09"
-  ],
+  "owasp_asi": ["ASI03"],
   "nist_ai_rmf": [
     "MAP-1.5",
     "MEASURE-2.5",
@@ -77,7 +74,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-16T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CWE-269",

--- a/records/AVE-2026-00049.json
+++ b/records/AVE-2026-00049.json
@@ -3,7 +3,7 @@
   "schema_version": "1.1.0",
   "status": "active",
   "published": "2026-06-21T00:00:00Z",
-  "last_updated": "2026-06-21T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "component_type": "mcp_server",
   "title": "HTTP Host Header Injection via Agent-Initiated Request (BadHost)",
   "attack_class": "Supply Chain - HTTP Header Injection",
@@ -24,10 +24,7 @@
   ],
   "aivss_score": 7.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:L/VA:N/SC:H/SI:L/SA:N",
-  "owasp_asi": [
-    "ASI03",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI04"],
   "mitre_atlas": [
     "AML.T0011"
   ],

--- a/records/AVE-2026-00050.json
+++ b/records/AVE-2026-00050.json
@@ -3,7 +3,7 @@
   "schema_version": "1.1.0",
   "status": "active",
   "published": "2026-06-21T00:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "component_type": "mcp_server",
   "title": "Parasitic Toolchain \u2014 Silent Tool Registration and Persistent Hook Injection",
   "attack_class": "Persistence - Parasitic Toolchain",
@@ -25,10 +25,7 @@
   ],
   "aivss_score": 7.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_asi": [
-    "ASI04",
-    "ASI07"
-  ],
+  "owasp_asi": ["ASI04"],
   "mitre_atlas": [
     "AML.T0010"
   ],

--- a/records/AVE-2026-00051.json
+++ b/records/AVE-2026-00051.json
@@ -3,7 +3,7 @@
   "schema_version": "1.1.0",
   "status": "active",
   "published": "2026-06-21T00:00:00Z",
-  "last_updated": "2026-06-21T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "component_type": "mcp_server",
   "title": "OAuth Discovery Rebinding \u2014 Authorization Endpoint Redirected to Attacker Server",
   "attack_class": "Supply Chain - OAuth Discovery Rebinding",
@@ -23,10 +23,7 @@
   ],
   "aivss_score": 7.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_asi": [
-    "ASI03",
-    "ASI06"
-  ],
+  "owasp_asi": ["ASI03", "ASI04"],
   "mitre_atlas": [
     "AML.T0011"
   ],

--- a/records/AVE-2026-00052.json
+++ b/records/AVE-2026-00052.json
@@ -63,7 +63,7 @@
   "researcher": "Peter Girnus (ZDI)",
   "researcher_url": "https://www.zerodayinitiative.com/advisories/ZDI-26-021/",
   "published": "2026-07-10T00:00:00Z",
-  "last_updated": "2026-07-10T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "ZDI-26-021",
@@ -100,10 +100,7 @@
     "MCP05",
     "MCP04"
   ],
-  "owasp_asi": [
-    "ASI05",
-    "ASI02"
-  ],
+  "owasp_asi": ["ASI05"],
   "aivss": {
     "cvss_base": 9.8,
     "aarf": {

--- a/records/AVE-2026-00053.json
+++ b/records/AVE-2026-00053.json
@@ -64,7 +64,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-07-10T00:00:00Z",
-  "last_updated": "2026-07-10T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "CVE",
@@ -96,10 +96,7 @@
     "MCP02",
     "MCP07"
   ],
-  "owasp_asi": [
-    "ASI02",
-    "ASI04"
-  ],
+  "owasp_asi": ["ASI04"],
   "mitre_atlas": [
     "AML.T0086"
   ],

--- a/records/AVE-2026-00063.json
+++ b/records/AVE-2026-00063.json
@@ -16,7 +16,6 @@
   "aivss_score": 4.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:L/SA:N",
   "owasp_mcp": ["MCP09"],
-  "owasp_asi": ["ASI01"],
   "behavioral_fingerprint": "Configuration sets a declarative flag (auto_approve, skip_confirmation, require_approval: false, or equivalent) that removes a human-in-the-loop check for high-risk actions, present in config rather than in instruction text, and therefore invisible to a review process that only inspects a component's stated instructions.",
   "behavioral_vector": [
     "approval-bypass-config",
@@ -51,7 +50,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-07-27T00:00:00Z",
-  "last_updated": "2026-07-27T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "cfgaudit crosswalk",

--- a/records/AVE-2026-00070.json
+++ b/records/AVE-2026-00070.json
@@ -10,7 +10,7 @@
   "aivss_score": 6.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:N",
   "owasp_mcp": ["MCP03"],
-  "owasp_asi": ["ASI06", "ASI07"],
+  "owasp_asi": ["ASI06"],
   "mitre_atlas": [],
   "nist_ai_rmf": [],
   "behavioral_fingerprint": "A tool's observation or return value delivered to an agent contains an encrypted or encoded fragment inconsistent with the tool's stated function, persisting in that agent's memory or context after the call, with no single agent's session containing enough fragments to reconstruct a complete instruction on its own.",
@@ -49,7 +49,7 @@
   "researcher": "Pengyu Zhu, Lijun Li, Yaxing Lyu, Li Sun, Sen Su, Jing Shao",
   "researcher_url": "https://arxiv.org/abs/2510.11246",
   "published": "2026-08-02T00:00:00Z",
-  "last_updated": "2026-08-02T00:00:00Z",
+  "last_updated": "2026-08-23T00:00:00Z",
   "references": [
     {
       "tag": "Collaborative Shadows (arXiv 2510.11246)",


### PR DESCRIPTION
Full-corpus audit of `owasp_asi` tags against the current canonical OWASP Top 10 for Agentic Applications (2026), triggered by two wrong mappings found during D2 crosswalk work on [wg-security-and-privacy#8](https://github.com/aaif/wg-security-and-privacy/pull/8).

**Report:** 70 of 80 records carry an `owasp_asi` tag. Of those — **13 confirmed correct** as-is, **48 corrected**, **11 flagged ambiguous and left unchanged** (not decided unilaterally).

Canonical list re-confirmed directly from the primary-source PDF (genai.owasp.org/download/52117), not from memory of the prior D2-crosswalk session: ASI01 Agent Goal Hijack · ASI02 Tool Misuse and Exploitation · ASI03 Identity and Privilege Abuse · ASI04 Agentic Supply Chain Vulnerabilities · ASI05 Unexpected Code Execution (RCE) · ASI06 Memory & Context Poisoning · ASI07 Insecure Inter-Agent Communication · ASI08 Cascading Failures · ASI09 Human-Agent Trust Exploitation · ASI10 Rogue Agents. Every correction below was checked against that document's own full descriptions and its explicit differentiators between adjacent categories (e.g. ASI01 vs ASI06 vs ASI10; ASI02 vs ASI03 vs ASI05; ASI04 = compromised *at the source* vs ASI02 = compromised *at runtime*; ASI08 = propagation of an existing fault, not its origin), not just the category names.

## Two systemic patterns behind most corrections

- **ASI08 (Cascading Failures) over-applied to single-instance records.** The category requires a fault to *spread across agents, sessions, or workflows with measurable fan-out* — not merely "this could enable other attacks." Most current ASI08 tags sat on records describing a single, contained event with no propagation mechanism described (e.g. a goal hijack, a jailbreak, a false permission claim) — the record was the origin, not the cascade.
- **ASI07 (Insecure Inter-Agent Communication) over-applied to single-agent tool misuse.** The category is specifically about compromised *real-time messages between agents*. Most current ASI07 tags sat on single-agent tool-abuse or supply-chain records with no other agent or inter-agent message involved at all.
- **ASI06 (Memory & Context Poisoning) applied to one-time events.** The category explicitly *excludes one-time input prompts* and requires persistent stored/retrievable context (memory, RAG, embeddings across sessions). Several exfiltration records were mistagged ASI06 for a single-request action; conversely AVE-2026-00019 (the record that started this audit) and AVE-2026-00016 were *missing* ASI06 despite being clean, even textbook, matches.

## Honesty checks

- **AVE-2026-00038** (excessive agency / unbounded tool use) is left unchanged and flagged ambiguous. ASI02, ASI09, and ASI10 are all defensible readings of the primary source depending on framing. A comment I posted on wg-security-and-privacy#8 speculated ASI09 was the "expected" value based on that WG's own gap-analysis framing (D2) rather than a direct primary-source check — having now read the full primary-source descriptions, that speculation doesn't hold up as a confident correction, so it isn't applied here.
- **AVE-2026-00063** loses its `owasp_asi` tag entirely rather than being reassigned — the record explicitly describes a static configuration weakness "independent of any instruction text," which doesn't cleanly match any of the ten ASI categories. Per CLAUDE.md: omit rather than force a poor fit.
- 11 records are left with a tag I couldn't confidently confirm or reject (e.g. AVE-2026-00047's hardcoded-credential mechanism doesn't cleanly fit ASI02 or ASI06; AVE-2026-00071's daemon-redirect config issue loosely fits both ASI04 and ASI05 without a clean primary). Flagged for a second read rather than decided here.

All 80 records still validate against `schema/ave-record-1.1.0.schema.json`, all have positive/negative fixtures, and the full pytest suite (339 tests) passes unchanged.
