### PR TITLE
docs: owasp_asi tagging rule, from the #196 audit

### DIFF
--- a/.claude/skills/add-ave-record/SKILL.md
+++ b/.claude/skills/add-ave-record/SKILL.md
@@ -67,15 +67,28 @@ one is an honest, defensible state.
   — a repo's raw files, the framework's own published PDF — never a
   search result, a summarized page, or a third-party blog's retelling
   of it, and never corpus precedent no matter how many existing
-  records agree with each other.** Roughly 65 records in this corpus
-  and the schema's own `owasp_asi` regex all consistently use an
-  `ASI01`-`ASI10` numbering for OWASP's Agentic Security Initiative —
-  discovered, on fetching the real primary-source PDF directly and
-  grepping its full text, to not exist anywhere in that document at
-  all. The real taxonomy uses `T1`-`T17`. Sixty-five records agreeing
-  with each other was never evidence; it was sixty-five copies of the
-  same unverified pattern. See issue #179 for the full writeup before
-  citing `owasp_asi` on any new record.
+  records agree with each other.** `ASI01`-`ASI10`, the numbering this
+  corpus and the schema's own `owasp_asi` regex both use, is correct —
+  it's OWASP's own "Top 10 for Agentic Applications 2026" document's
+  category IDs. A separate OWASP document, "Agentic AI – Threats and
+  Mitigations," uses a different, `T1`-`T17` numbering; issue #179
+  fetched only that second document, found no `ASI0` matches in it,
+  and initially (wrongly) concluded the corpus's numbering was
+  fabricated — corrected in that issue's own thread once the first
+  document was found. Same underlying discipline either way: fetch and
+  read the actual primary source before trusting corpus precedent, and
+  when a framework's publisher maintains more than one document, check
+  that the one fetched is actually the one whose ID format is being
+  verified.
+
+  **Before assigning `owasp_asi`, also check the real category
+  definition, not just the label that sounds closest.** A full-corpus
+  audit (#196) found 48 of 70 tagged records wrong, mostly `ASI08`
+  applied to single-instance failures with no real cross-agent
+  propagation, and `ASI07` applied to single-agent tool misuse with no
+  actual inter-agent messaging involved. See
+  docs/specs/researcher-process.md's own note on this for the full
+  pattern.
 
 ### 4. Write conformance fixtures (TDD — fixtures first)
 tests/fixtures/AVE-YYYY-NNNNN_positive.md — a conforming implementation MUST flag this

--- a/docs/specs/researcher-process.md
+++ b/docs/specs/researcher-process.md
@@ -287,16 +287,50 @@ side effect of adding one record, that's a separate, deliberate decision.
   one says nobody checked, the other says checking happened and came
   up empty. Fixed by adding the key with `[]` plus a one-line
   `aivss.notes` explanation of what was checked and why nothing fit.
-- **Treating a framework's ID scheme as settled because the corpus
-  already uses it consistently.** Roughly 65 records and the schema's
-  own `owasp_asi` regex all independently agree on `ASI01`-`ASI10` —
-  consistent, and consistently wrong. OWASP's own Agentic Security
-  Initiative document uses `T1`-`T17`, confirmed by fetching the real
-  PDF directly and grepping the full text (see issue #179). Internal
-  agreement across many records is not the same evidence as one
-  primary-source document actually opened and read; sixty-five
-  records copying the same wrong pattern from each other produces
-  consensus, not correctness.
+- **Assuming there's only one possible primary-source document for a
+  framework, and stopping once the first fetch confirms a hypothesis.**
+  Issue #179 fetched OWASP's "Agentic AI – Threats and Mitigations" PDF
+  (`T1`-`T17`), found zero `ASI0` matches in it, and concluded the
+  corpus's `ASI01`-`ASI10` values (used consistently across ~65
+  records, and by the schema's own `owasp_asi` regex) were fabricated.
+  They aren't: a separate, also-current OWASP document, "Top 10 for
+  Agentic Applications 2026," uses `ASI01`-`ASI10` as its own category
+  IDs, and its own Appendix A formally cross-maps the two, describing
+  `T1`-`T17` as the more granular, subordinate taxonomy the `ASI0X`
+  framework references — not a competing or replacement scheme.
+  Corrected in issue #179's own thread once found (during the docs
+  write-up for #196, a genuinely unrelated audit). The lesson isn't
+  "trust corpus consensus less than a fetched PDF" — it's that a
+  single fetched PDF isn't automatically *the* primary source either
+  when a framework's publisher maintains more than one document under
+  the same initiative; check that a fetched document is the *right*
+  one, specifically the one whose own ID format matches what's being
+  verified, before concluding the corpus is wrong.
+
+### owasp_asi tagging, common mistakes worth checking before assigning
+
+Found via a full-corpus audit (#196) that corrected 48 of 70 tagged
+records, most tracing to two specific, avoidable patterns. Check the
+real ASI category definition, not just the closest-sounding label,
+before assigning any of these three:
+
+- **ASI08 (Cascading Failures)** requires described, measurable
+  propagation across multiple agents or sessions. A severe but
+  single-instance failure with no actual fan-out doesn't qualify, no
+  matter how bad that one instance is.
+- **ASI07 (Insecure Inter-Agent Communication)** requires actual
+  messaging between agents as the mechanism. Tool misuse by a single
+  agent doesn't qualify on its own, a tool call isn't inter-agent
+  communication.
+- **ASI06 (Memory & Context Poisoning)** excludes one-time
+  exfiltration events by its own definition. Check both directions,
+  this tag was both over-applied to records that didn't qualify and
+  missing from records that were clean matches.
+
+The general rule underneath all three: verify against OWASP's actual,
+current category definitions before tagging, not against how similar
+the record's own title or attack_class sounds to a category name. That
+similarity is exactly what produced 48 wrong tags across this corpus.
 
 ## Full worked example: AVE-2026-00060
 


### PR DESCRIPTION
Writes the two systemic mistagging patterns found in #196 into researcher-process.md and add-ave-record/SKILL.md, so the next record drafted doesn't reproduce the same mistake at the individual-record level. Same treatment already applied to the researcher-field attribution rule.

**Also corrects a wrong claim already sitting in both docs** (from issue #179, discovered while writing this up — genuinely unrelated to #196 otherwise): both docs previously stated OWASP's Agentic Security Initiative 'really' uses `T1`-`T17` and that the corpus's `ASI01`-`ASI10` numbering (used by ~65+ records and the schema's own regex) was fabricated. It isn't. Issue #179 fetched OWASP's 'Agentic AI – Threats and Mitigations' PDF (`T1`-`T17`) and found zero `ASI0` matches, but never found the separate, also-current 'OWASP Top 10 for Agentic Applications 2026' document, which uses `ASI01`-`ASI10` as its own category IDs and whose own Appendix A formally cross-maps `T1`-`T17` as the more granular, subordinate taxonomy the ASI framework references — not a competing scheme. Full correction posted on issue #179 directly. PR #196's corrections stand on the correct scheme; no schema or corpus rework needed as a result of this.

Schema's own `owasp_asi` field description (`schema/ave-record-1.1.0.schema.json`) deliberately left untouched — it's a frozen, versioned file per CLAUDE.md's hard rule, and any pointer addition belongs in the next version bump (already tracked in #178), not retrofitted here.