### PR TITLE
docs: fix stale independent-crosswalk count in README (3 -> 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ AVE fixes that.
 AVE's ID scheme has been tested by people who didn't build it, not
 just used by people who did.
 
-Three independent tools, cfgaudit, Ramparts, and nova-proximity, none
-of them sharing code with AVE or with each other, built crosswalks
-against AVE's records on their own initiative, unprompted. In each
-case the comparison went beyond matching category labels: mechanism-
-level correspondence was checked field by field, real trigger
-conditions against real behavioral fingerprints, and dozens of
+Eight independent tools, cfgaudit, ClawScan, nova-proximity, Ramparts,
+Semia, SkillSpector (NVIDIA), skill-security-scanner, and skillsentry,
+none of them sharing code with AVE or with each other, built
+crosswalks against AVE's records on their own initiative, unprompted.
+In each case the comparison went beyond matching category labels:
+mechanism-level correspondence was checked field by field, real
+trigger conditions against real behavioral fingerprints, and dozens of
 findings converged on the identical AVE ID independently.
 
 One of those crosswalks (Ramparts) also surfaced a real methodological
@@ -92,7 +93,7 @@ two published AVE records, corrected the underlying process
 documentation, not just the two records, credited in
 [CONTRIBUTORS.md](CONTRIBUTORS.md).
 
-80 records. 3 independent crosswalks. See
+80 records. 8 independent crosswalks. See
 [crosswalks/](crosswalks/) for the full mappings, and
 [docs/writeups/](docs/writeups/) for full technical write-ups on
 individual records.
@@ -511,8 +512,14 @@ at [aveproject.org/crosswalks.html](https://aveproject.org/crosswalks.html).
 
 | This scanner | Maps to AVE via |
 |---|---|
-| SkillSpector (NVIDIA) | [`crosswalks/skillspector-to-ave.json`](crosswalks/skillspector-to-ave.json) |
+| cfgaudit | [`crosswalks/cfgaudit-to-ave.json`](crosswalks/cfgaudit-to-ave.json) |
 | ClawScan (OpenClaw) | [`crosswalks/clawscan-to-ave.json`](crosswalks/clawscan-to-ave.json) |
+| nova-proximity (Nova-Hunting) | [`crosswalks/nova-proximity-to-ave.json`](crosswalks/nova-proximity-to-ave.json) |
+| Ramparts (Highflame Inc.) | [`crosswalks/ramparts-to-ave.json`](crosswalks/ramparts-to-ave.json) |
+| Semia (RiemaLabs) | [`crosswalks/semia-to-ave.json`](crosswalks/semia-to-ave.json) |
+| SkillSpector (NVIDIA) | [`crosswalks/skillspector-to-ave.json`](crosswalks/skillspector-to-ave.json) |
+| skill-security-scanner (honysyang) | [`crosswalks/skill-security-scanner-to-ave.json`](crosswalks/skill-security-scanner-to-ave.json) |
+| skillsentry (vythanhtra) | [`crosswalks/skillsentry-to-ave.json`](crosswalks/skillsentry-to-ave.json) |
 
 Maintaining a scanner? The [implementer guide](docs/specs/ave-implementer-guide.md)
 covers how to map your rule IDs to AVE ids and add AVE ID emission to your


### PR DESCRIPTION
Found while writing the org profile README (aveproject/.github, now live at github.com/aveproject).

This repo's own README undercounted its independent crosswalks in two separate places:
- The top **Independent validation** section said "Three independent tools, cfgaudit, Ramparts, and nova-proximity."
- The **Framework crosswalks** table's "This scanner → Maps to AVE via" only listed SkillSpector and ClawScan.

Verified against the real `crosswalks/` directory rather than trusting either existing claim: 8 real, populated `*-to-ave.json` crosswalk files exist — cfgaudit, ClawScan, nova-proximity, Ramparts, Semia, SkillSpector (NVIDIA), skill-security-scanner, and skillsentry. Each checked individually for a real `source.tool`/`vendor` field and a non-empty `mappings` array, not assumed from the file listing alone. Semia in particular is already complete (16 mappings) — nothing in the corpus suggested it was still "in progress."

Both counts ("Three independent tools" → eight, named; "3 independent crosswalks" → 8) fixed, plus the crosswalk table filled out to all 8. No other stale count found elsewhere in the file.