### PR TITLE
Require commit on endpoints that state a record count

### DIFF
--- a/schema/crosswalk-1.0.0.schema.json
+++ b/schema/crosswalk-1.0.0.schema.json
@@ -108,6 +108,31 @@
           ]
         }
       },
+      "allOf": [
+        {
+          "$comment": "An endpoint that STATES a record count must say which commit the count was read at, so the number can be re-derived rather than taken on trust. Scoped to count-stating endpoints because an endpoint that states no count has nothing to re-derive. The `not` clause is load-bearing: without it this rule and the unpinnable rule above are jointly unsatisfiable for a side that declares itself unpinnable AND states a count, because one demands commit and the other forbids it, which would silently delete one of the three pinning states this endpoint's own description defines.",
+          "if": {
+            "required": [
+              "record_count"
+            ],
+            "not": {
+              "properties": {
+                "pin_status": {
+                  "const": "unpinnable"
+                }
+              },
+              "required": [
+                "pin_status"
+              ]
+            }
+          },
+          "then": {
+            "required": [
+              "commit"
+            ]
+          }
+        }
+      ],
       "properties": {
         "url": {
           "type": "string",

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -178,11 +178,14 @@ def crosswalk_schema() -> dict:
     return json.loads(validate_crosswalks.SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
-def test_the_unpinned_count_check_is_a_warning_while_commit_is_optional():
-    """The escalation agreed in #94: warn while commit is optional, hard-fail once
-    it is promoted. This asserts which side of the promotion the shipped schema is
-    on, not a preference -- commit is optional in 1.0.x, so the check warns."""
-    assert validate_crosswalks.commit_is_required(crosswalk_schema()) is False
+def test_the_shipped_schema_has_promoted_commit_for_count_stating_endpoints():
+    """The escalation agreed in #94, now landed: warn while commit is optional,
+    hard-fail once it is promoted. This asserts which side of the promotion the
+    shipped schema is on, not a preference -- the promotion is in, so the check
+    fails rather than warns. The promotion is SCOPED to endpoints stating a
+    record_count, which is what #126 settled, so `commit_is_required` reads True
+    without every endpoint in the repository being obliged to carry a commit."""
+    assert validate_crosswalks.commit_is_required(crosswalk_schema()) is True
 
 
 def test_promoting_commit_to_required_escalates_the_check_with_no_code_change():
@@ -213,16 +216,22 @@ def unpinned_count_tree(tmp_path, schema: dict) -> None:
                                        "record_count": 77})), encoding="utf-8")
 
 
-def test_an_unpinned_count_warns_and_exits_zero_while_commit_is_optional(
+def test_an_unpinned_count_now_fails_against_the_shipped_schema(
         tmp_path, monkeypatch, capsys):
+    """The same tree that warned before the promotion, run against the schema as
+    it now ships. This is the half that would have gone unnoticed: the sibling
+    test below builds its own promoted schema, so it passed both before and after
+    and could never have told anyone whether the promotion had actually landed."""
     unpinned_count_tree(tmp_path, crosswalk_schema())
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr("sys.argv", ["validate_crosswalks.py"])
 
     exit_code = validate_crosswalks.main()
 
-    assert exit_code == 0
-    assert "WARNING" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "cannot be re-derived" in out
+    assert "WARNING" not in out
 
 
 def test_an_unpinned_count_fails_once_the_schema_promotes_commit(
@@ -249,10 +258,42 @@ def test_an_unpinned_count_fails_once_the_schema_promotes_commit(
 
 
 def test_forbidding_commit_on_an_unpinnable_side_does_not_read_as_promoting_it():
-    """1.0.x already contains a required list naming commit, underneath a `not`,
-    to keep a declared-unpinnable endpoint from also carrying a pin. Reading that
-    as the promotion would hard-fail the whole repository the day this landed."""
+    """The schema contains a required list naming commit underneath a `not`, to
+    keep a declared-unpinnable endpoint from also carrying a pin. Reading that as
+    the promotion would hard-fail the whole repository the day it landed.
+
+    This asserts against a schema with the promotion REMOVED rather than against
+    the shipped one. It used to read the shipped schema, which worked only while
+    nothing else promoted commit; now that something does, that form would pass
+    for the wrong reason and would keep passing if the `not` skip were deleted.
+    A test that cannot fail when the thing it describes breaks is not a test."""
     schema = crosswalk_schema()
+    schema["$defs"]["endpoint"].pop("allOf", None)
 
     assert "commit" in json.dumps(schema["$defs"]["endpoint"]["then"]["not"])
     assert validate_crosswalks.commit_is_required(schema) is False
+
+
+def test_an_unpinnable_side_may_still_state_a_count(tmp_path):
+    """The interaction the scoping exists for, and the reason the promotion is not
+    a bare entry in the endpoint's required list.
+
+    The endpoint description defines three pinning states, and one of them is a
+    side that declares itself unpinnable and carries a content digest instead. Such
+    a side may still state a record count. Requiring commit of every count-stating
+    endpoint without excluding that case would demand a field the unpinnable rule
+    directly above forbids, leaving no document that satisfies both and silently
+    deleting one of the three states."""
+    validator = validate_crosswalks.build_validator(crosswalk_schema())
+    endpoint = {
+        "url": "https://example.org/standard",
+        "record_count": 12,
+        "pin_status": "unpinnable",
+        "unpinnable_reason": "the endpoint publishes no repository to pin",
+        "checked_against_live_site": "2026-08-23",
+        "content_digest": "sha256:" + "a" * 64,
+    }
+
+    errors = list(validator.iter_errors(crosswalk_document(endpoint)))
+
+    assert errors == [], [error.message for error in errors]


### PR DESCRIPTION
Step 3 of the sequence on #126. The commit field becomes required on endpoints that state a `record_count`, so a stated number can be re-derived instead of trusted. An endpoint stating no count has nothing to re-derive, so it is untouched.

Nine crosswalk files, eighteen endpoints, nine stating a count, and all nine already carry a commit. The scoped rule fails nothing on a clean checkout. Requiring commit outright still fails four sides that state no count: the ave-to-ast10 target and the cfgaudit, clawscan and skillspector sources. Re-measured on main at cd1010e, after #199 landed, rather than carried over from the estimate on #126.

## The exclusion is load-bearing

The rule skips a side that declares itself unpinnable, and that clause is why this is not a one-line entry in the endpoint's required list.

The endpoint description defines three pinning states. One is a side that declares itself unpinnable and carries a content digest instead. Such a side can still state a count. Requiring commit of every count-stating endpoint would then demand a field the unpinnable rule directly above forbids. No document satisfies both, so that state stops being expressible, and nothing here would report it, because no endpoint declares itself unpinnable today.

The validator already agrees. Its warning reads `does not declare pin_status unpinnable`, so it was written with this scoping and only the schema was missing it.

## Tests

Two staged tests flip with the promotion, as written.

A third needed restructuring rather than a new expected value. `test_forbidding_commit_on_an_unpinnable_side_does_not_read_as_promoting_it` proves the escalation switch ignores a required list underneath a `not`, and it read the shipped schema to prove it. That worked only while nothing else promoted the field. Against this branch it would pass for the wrong reason, and it would keep passing if the skip were deleted. It now removes the promotion first.

One test is new: an unpinnable side that states a count must validate.

## Checks on this branch

Nine of nine crosswalks valid with zero warnings. Eighty records valid, with the six pre-existing attribution warnings unchanged. Eighty fixture pairs present. The suite is 342 passing, up from 339.

Both new assertions are mutation-checked. Deleting the exclusion fails only the unpinnable-with-count test. Reverting the promotion fails only the two promotion tests.
