### PR TITLE
fix: AVE-2026-00048 attribution and remediation branding

### DIFF
--- a/records/AVE-2026-00048.json
+++ b/records/AVE-2026-00048.json
@@ -68,13 +68,13 @@
     "Actions on sensitive systems traced back to sub-agent with no direct user trigger",
     "Parent agent audit trail ends before sub-agent actions begin"
   ],
-  "remediation": "1. Scope sub-agent permissions explicitly in the delegation instruction - list exactly which tools the sub-agent may use. 2. Never use full access or inherit all in delegation instructions. 3. Require explicit user confirmation before any sub-agent is spawned. 4. Ensure MCP infrastructure logs sub-agent tool calls under the parent session ID with a delegation trace. 5. Use bawbel-accept with expiry if orchestrator delegation is intentional and scoped.",
+  "remediation": "1. Scope sub-agent permissions explicitly in the delegation instruction - list exactly which tools the sub-agent may use. 2. Never use full access or inherit all in delegation instructions. 3. Require explicit user confirmation before any sub-agent is spawned. 4. Ensure MCP infrastructure logs sub-agent tool calls under the parent session ID with a delegation trace. 5. If intentional, scoped orchestrator delegation is required, implement a time-bounded, explicit grant mechanism rather than an open-ended permission inheritance, and log the grant's expiry alongside the delegation trace.",
   "status": "active",
   "kill_switch_active": true,
-  "researcher": "Bawbel Security Research Team",
+  "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-16T00:00:00Z",
-  "last_updated": "2026-08-23T00:00:00Z",
+  "last_updated": "2026-08-26T00:00:00Z",
   "references": [
     {
       "tag": "CWE-269",


### PR DESCRIPTION
Two issues found on a record currently being read by an external OpenCRE contributor.

**Researcher attribution**: still had the deprecated `Bawbel Security Research Team` team-name convention. Before fixing, read the full Cohen et al. paper (arXiv:2403.02817) cited in this record's own references, to check whether it's actually the source of the delegation-inheritance mechanism rather than defaulting either way. It isn't — the paper describes a self-replicating worm (Morris-II) propagating via RAG-based indirect prompt injection across GenAI applications, a related but structurally different problem. A full-text search for delegation/sub-agent/permission-inheritance/trust-boundary language returns zero substantive matches. This is AVE's own synthesis of CWE-269/284 into the agentic delegation context, so `researcher` is corrected to `Saray Chak`; Cohen et al. stays cited in `references` as related context, unchanged.

**Remediation branding**: point 5 named a specific Bawbel product feature (`bawbel-accept`). Replaced with a generic, vendor-neutral time-bounded-grant control description.

**Corpus-wide check** (both patterns, not assumed isolated): branded remediation text was isolated to this one record. Stale researcher attribution was **not** — 50 of 80 records still carry `Bawbel Security Research Team`, far more than this task's premise of a single record missed by an already-complete pass. Not fixed here, per this task's own scope instruction — flagging as a separate, deliberate follow-up audit rather than silently expanding this PR.