### PR TITLE
chore: regenerate consolidated records JSON

### DIFF
--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -916,13 +916,13 @@
       "Actions on sensitive systems traced back to sub-agent with no direct user trigger",
       "Parent agent audit trail ends before sub-agent actions begin"
     ],
-    "remediation": "1. Scope sub-agent permissions explicitly in the delegation instruction - list exactly which tools the sub-agent may use. 2. Never use full access or inherit all in delegation instructions. 3. Require explicit user confirmation before any sub-agent is spawned. 4. Ensure MCP infrastructure logs sub-agent tool calls under the parent session ID with a delegation trace. 5. Use bawbel-accept with expiry if orchestrator delegation is intentional and scoped.",
+    "remediation": "1. Scope sub-agent permissions explicitly in the delegation instruction - list exactly which tools the sub-agent may use. 2. Never use full access or inherit all in delegation instructions. 3. Require explicit user confirmation before any sub-agent is spawned. 4. Ensure MCP infrastructure logs sub-agent tool calls under the parent session ID with a delegation trace. 5. If intentional, scoped orchestrator delegation is required, implement a time-bounded, explicit grant mechanism rather than an open-ended permission inheritance, and log the grant's expiry alongside the delegation trace.",
     "status": "active",
     "kill_switch_active": true,
-    "researcher": "Bawbel Security Research Team",
+    "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-05-16T00:00:00Z",
-    "last_updated": "2026-08-23T00:00:00Z",
+    "last_updated": "2026-08-26T00:00:00Z",
     "references": [
       {
         "tag": "CWE-269",

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 80,
-  "generated_at": "2026-08-23T08:47:24.955Z",
+  "generated_at": "2026-08-25T23:48:33.423Z",
   "source": "https://github.com/aveproject/ave"
 }


### PR DESCRIPTION
Auto-generated by `scripts/build-records.js` after a change to
`records/` on `develop`. Regenerates `dist/ave-records-latest.json`
(and its manifest) to stay in sync with the current record set.
The versioned `dist/ave-records-v<schema_version>.json` snapshot
is only touched the first time a given schema version appears --
if this diff includes one, that means a new schema version's
frozen snapshot was just created, not that an existing one
changed.