### PR TITLE
fix: sync AVE-2026-00048 last_updated to unblock PR #204

### DIFF
--- a/records/AVE-2026-00048.json
+++ b/records/AVE-2026-00048.json
@@ -74,7 +74,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-16T00:00:00Z",
-  "last_updated": "2026-08-23T00:00:00Z",
+  "last_updated": "2026-08-26T00:00:00Z",
   "references": [
     {
       "tag": "CWE-269",


### PR DESCRIPTION
PR #204 (develop → main) is blocked by a real merge conflict on
\`records/AVE-2026-00048.json\`'s \`last_updated\`:

- \`main\` has \`2026-08-23\` (from #199's owasp_asi audit)
- \`develop\` has \`2026-08-26\` (from #202's attribution/de-branding fix,
  a genuine edit made after #199)

Both sides changed the same field independently from a common ancestor,
so git flags it as a conflict no matter what commit lands on \`develop\`
downstream — \`develop\`'s tip already holds \`2026-08-26\` and that value
is correct (it's chronologically the latest real edit to the record).

This PR aligns \`main\`'s copy to \`2026-08-26\` to match, which makes the
field identical on both branches and clears the conflict without a merge
commit (not permitted on either branch per this repo's ruleset). Verified
locally: a test merge of \`origin/develop\` into this branch now completes
with zero conflicts.

No other field differs in a conflicting way — \`remediation\` and
\`researcher\` differ between the branches too, but those are clean
one-sided changes (develop's #202 fix, not yet landed on main) that
PR #204 itself will carry over normally.

Validated: \`scripts/validate_records.py\` and \`pytest tests/\` pass
(80 records, 342 tests).