### PR TITLE
Add consumer-side confidence signal check for self-reported confidence_baseline (issue #98)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Check every record has positive and negative conformance fixtures
         run: python scripts/check_fixtures.py
 
+      - name: Confidence signal soft warning (issue #98 consumer check)
+        run: python scripts/check_confidence_signal.py
+
       - name: Run tests
         run: pytest tests/ -x -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@ description. Reviewers will ask for this if it is missing.
 pip install -e ".[dev]"
 python scripts/validate_records.py    # schema-checks every record, including yours
 python scripts/check_fixtures.py      # confirms every record has +/- fixtures
+python scripts/check_confidence_signal.py  # soft-warns on #98 high-confidence floor-basis records
 pytest tests/ -x -q                   # full suite: schema, AIVSS arithmetic, mitigation enums
 ```
 

--- a/docs/guides/confidence-baseline-consumer-guide.md
+++ b/docs/guides/confidence-baseline-consumer-guide.md
@@ -1,0 +1,77 @@
+# confidence_baseline: consumer handling guide
+
+This guide answers issue #98's first shape ("document the handling, don't
+change the field") and the compliance angle raised independently on
+r/ai_governance. It is the consumer-side companion to
+`scripts/check_confidence_signal.py`.
+
+## What `confidence_baseline` is
+
+A float, 0.0 to 1.0, assigned by the record's author. Today it is
+self-reported: nothing external verifies it, and the same value appears
+whether the underlying evidence is a formally disclosed CVE or a
+speculative pattern match. That asymmetry is the gap this issue names.
+
+## How to read it (bands)
+
+- `>= 0.85` — "high-signal" band. Only act on this band when the record's
+  derived evidence basis is structurally strong (multiple engines, or a
+  non-inferred evidence kind).
+- `0.55 to 0.84` — "mid-signal" band. Consistent with a floor basis; treat
+  as an unverified declaration unless the basis is strong.
+- `< 0.55` — "low-signal" band. Consistent with a floor basis; safe to
+  treat as low-confidence regardless of basis.
+
+## When to distrust the number
+
+A record whose `confidence_baseline` is `>= 0.85` while its derived basis
+is at the floor is a "declared, not structurally verified" signal. The
+floor is defined as:
+
+- `evidence_basis_engines` has one member (regardless of which engine), or
+- `evidence_kind_default` is `semantic_inference`.
+
+`scripts/check_confidence_signal.py` computes this for every record in
+`records/`. It is a soft warning: it prints findings and leaves the exit
+code alone (the same shape as `check_researcher_matches_disclosure` in
+`validate_records.py`), so it fits next to the existing validator machinery
+without changing gate behaviour.
+
+## The disagreement rule
+
+The check flags disagreement; it does not certify truth. A record flagged
+as floor-basis with high confidence has not been proven wrong. It has been
+proven unsupported: the author's number carries no structural backing a
+consumer can re-derive. Do not describe the check as auditability. It
+closes a self-certification gap; it does not create an audit trail on its
+own.
+
+## Known false-positive shape
+
+AVE-2026-00074 is deliberately shipped as the fixture for this check. Its
+`confidence_baseline` (0.85) sits at the high band while its basis reads as
+a floor, but its own `detection_methodology` says the finding came from
+querying external authorities (GitHub's users API, package registries,
+RDAP, provider fingerprints). The floor there is an enum gap:
+`evidence_basis_engines` has no member for "an external authority was
+queried and returned a determinate answer." The honest author wrote the
+nearest available value and the derived basis came out at the floor.
+
+The check prints a note on this shape so it reads as an enum gap, not an
+overclaim.
+
+## Escalation condition
+
+Per the issue thread: when `evidence_basis_engines` carries a member for an
+external-authority query (the thread's agreed name: `external_authority`),
+and a re-run of this check fires zero times on any record whose
+`detection_methodology` names an authority probe, the field has earned its
+version bump. Both halves of that condition are read off the schema and the
+data, so it needs no date, constant, curation queue, or outcome tracking.
+
+## Normalisation
+
+The 80 records carry 13 distinct basis sets written 18 different ways
+(five sets appear in two orders each). The check compares engine sets
+(set-normalised), not raw lists, so consumers see 13 bases, not 18.
+Canonicalising the files themselves is worth doing separately.

--- a/scripts/check_confidence_signal.py
+++ b/scripts/check_confidence_signal.py
@@ -38,14 +38,14 @@ FLOOR_KIND = "semantic_inference"
 
 # Substrings in a record's detection_methodology that identify an
 # external-authority probe: the case where the floor is an enum gap, not an
-# overclaim (AVE-2026-00074).
+# overclaim (AVE-2026-00074). Deliberately specific terms only: bare
+# "registry" or "domain" match ordinary static-scan prose (astrogilda's
+# attack test, 2026-08-26) and a false attach is worse than a false flag.
 AUTHORITY_PROBE_HINTS = (
     "api.github.com",
-    "registry",
     "rdap",
     "github's users api",
     "package registry",
-    "domain",
     "authoritative source",
     "provider fingerprint",
 )
@@ -53,10 +53,16 @@ AUTHORITY_PROBE_HINTS = (
 
 def is_floor_basis(record: dict) -> bool:
     """True when the record's evidence basis is at the floor: a single-engine
-    set (regardless of which engine) or semantic_inference as the kind."""
+    set (regardless of which) or semantic_inference as the kind.
+
+    The cardinality test is on the set, not the list: a duplicated member
+    (["pattern", "pattern"], ["pattern", "PATTERN"]) is a single-engine
+    basis wearing a list of length two, and must not dodge the floor
+    (astrogilda's attack test, 2026-08-26).
+    """
     engines = record.get("evidence_basis_engines") or []
     kind = record.get("evidence_kind_default") or ""
-    if len(engines) <= 1:
+    if len(set(engines)) <= 1:
         return True
     return kind == FLOOR_KIND
 

--- a/scripts/check_confidence_signal.py
+++ b/scripts/check_confidence_signal.py
@@ -1,0 +1,134 @@
+# What: consumer-side confidence signal check for AVE records. Reads every
+#       record in records/ and reports the ones whose self-reported
+#       confidence_baseline sits at the high band while their derived
+#       evidence basis sits at the floor, the exact shape issue #98 names:
+#       "a float the record's author assigns ... the same shape whether the
+#       underlying evidence is a formally disclosed CVE or a speculative
+#       pattern match."
+# Why:  confidence_baseline is self-reported today; nothing external verifies
+#       it. A compliance team building workflows on AVE-classified findings
+#       (the r/ai_governance angle in #98) needs to know which records'
+#       confidence they can act on and which are declarations resting on
+#       pattern-level inference alone. This check makes that distinction
+#       computable without a schema change: it reads fields that already
+#       exist on every record.
+# How:  high = confidence_baseline >= HIGH_CONFIDENCE (0.85, matching the
+#       schema's "high-signal" band). Floor = the evidence basis carries a
+#       single engine member (regardless of which) or evidence_kind_default
+#       is semantic_inference. A record in both sets is a "declared, not
+#       structurally verified" signal. List ordering is normalized by
+#       comparing engine sets, so the check sees 13 distinct bases where the
+#       files write them 18 ways (issue #98 comment 2026-08-20). The check
+#       is a soft warning: it prints findings and leaves the exit code
+#       alone, the same shape as check_researcher_matches_disclosure in
+#       validate_records.py. Escalation condition (per the thread): when
+#       evidence_basis_engines carries a member for an external-authority
+#       query and a re-run fires zero times on any record whose
+#       detection_methodology names an authority probe, the field earns its
+#       version bump.
+import argparse
+import json
+import sys
+from pathlib import Path
+
+RECORDS_DIR = Path("records")
+
+HIGH_CONFIDENCE = 0.85
+FLOOR_KIND = "semantic_inference"
+
+# Substrings in a record's detection_methodology that identify an
+# external-authority probe: the case where the floor is an enum gap, not an
+# overclaim (AVE-2026-00074).
+AUTHORITY_PROBE_HINTS = (
+    "api.github.com",
+    "registry",
+    "rdap",
+    "github's users api",
+    "package registry",
+    "domain",
+    "authoritative source",
+    "provider fingerprint",
+)
+
+
+def is_floor_basis(record: dict) -> bool:
+    """True when the record's evidence basis is at the floor: a single-engine
+    set (regardless of which engine) or semantic_inference as the kind."""
+    engines = record.get("evidence_basis_engines") or []
+    kind = record.get("evidence_kind_default") or ""
+    if len(engines) <= 1:
+        return True
+    return kind == FLOOR_KIND
+
+
+def names_authority_probe(record: dict) -> bool:
+    """True when the record's own detection methodology says the finding came
+    from querying an external authority, i.e. the floor is an enum gap."""
+    methodology = (record.get("detection_methodology") or "").lower()
+    return any(h in methodology for h in AUTHORITY_PROBE_HINTS)
+
+
+def confidence_signal(record: dict):
+    """Return a human-readable signal string for a record whose declared
+    confidence sits high while its basis sits at the floor, else None."""
+    cb = record.get("confidence_baseline")
+    if cb is None:
+        return None  # absent confidence is a separate concern, not this check
+    if cb < HIGH_CONFIDENCE or not is_floor_basis(record):
+        return None
+    engines = ", ".join(sorted(set(record.get("evidence_basis_engines") or [])))
+    kind = record.get("evidence_kind_default") or "(none)"
+    note = ""
+    if names_authority_probe(record):
+        note = (
+            " NOTE: this record's detection_methodology names an external-authority "
+            "probe (registry/RDAP/API); the floor here is an enum gap, not an "
+            "overclaim. Expected to clear when evidence_basis_engines carries an "
+            "external-authority member."
+        )
+    return (
+        f"confidence_baseline {cb} sits at the high band while the derived basis "
+        f"is at the floor (engines=[{engines}], evidence_kind_default={kind}). "
+        f"Declared confidence without structural verification -- see issue #98."
+        f"{note}"
+    )
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report AVE records whose self-reported confidence_baseline "
+        "sits high while their derived evidence basis sits at the floor (issue #98)."
+    )
+    parser.add_argument(
+        "--json", dest="as_json", action="store_true",
+        help="emit findings as JSON for downstream tooling",
+    )
+    args = parser.parse_args(argv)
+
+    paths = sorted(RECORDS_DIR.glob("AVE-*.json"))
+    if not paths:
+        print(f"No records found under {RECORDS_DIR}/", file=sys.stderr)
+        return 2
+
+    findings = []
+    for path in paths:
+        record = json.loads(path.read_text())
+        signal = confidence_signal(record)
+        if signal:
+            findings.append({"ave_id": record.get("ave_id", path.stem), "signal": signal})
+
+    if args.as_json:
+        print(json.dumps({"findings": findings, "count": len(findings)}, indent=2))
+    else:
+        if findings:
+            print(f"{len(findings)} record(s) with high confidence on a floor-level basis (soft warning):")
+            for f in findings:
+                print(f"- {f['ave_id']}: {f['signal']}")
+        else:
+            print(f"All {len(paths)} records have confidence consistent with their basis.")
+
+    return 0  # soft warning: exit code untouched, same as check_researcher_matches_disclosure
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_confidence_signal.py
+++ b/tests/test_confidence_signal.py
@@ -1,0 +1,96 @@
+import json
+
+import pytest
+
+from scripts import check_confidence_signal
+
+
+def base_record(**overrides):
+    record = {
+        "ave_id": "AVE-2026-99999",
+        "schema_version": "1.1.0",
+        "status": "active",
+        "title": "Confidence signal fixture",
+        "description": "Fixture record for the confidence signal check.",
+        "attack_class": "test",
+        "behavioral_fingerprint": "test",
+        "references": [{"tag": "Source", "text": "Source", "url": "https://example.com"}],
+        "confidence_baseline": 0.85,
+        "evidence_basis_engines": ["pattern"],
+        "evidence_kind_default": "behavioral_pattern",
+    }
+    record.update(overrides)
+    return record
+
+
+def test_high_confidence_on_floor_basis_is_flagged():
+    """The issue #98 shape: a high float with no structural verification.
+
+    Mirrors AVE-2026-00074's actual shape: pattern-only engine set, high
+    confidence. The agreed design ships this record as the fixture.
+    """
+    record = base_record()
+    result = check_confidence_signal.confidence_signal(record)
+    assert result is not None
+    assert "confidence_baseline 0.85" in result
+    assert "high band" in result
+    assert "floor" in result
+
+
+def test_high_confidence_with_multi_engine_basis_is_not_flagged():
+    """Two or more engines is not a floor basis, regardless of which engines."""
+    record = base_record(
+        evidence_basis_engines=["pattern", "semgrep"],
+        evidence_kind_default="behavioral_pattern",
+    )
+    assert check_confidence_signal.confidence_signal(record) is None
+
+
+def test_semantic_inference_kind_is_floor_even_with_multiple_engines():
+    """semantic_inference is a floor kind on its own."""
+    record = base_record(
+        confidence_baseline=0.9,
+        evidence_basis_engines=["yara", "semgrep"],
+        evidence_kind_default="semantic_inference",
+    )
+    assert check_confidence_signal.confidence_signal(record) is not None
+
+
+def test_low_confidence_on_floor_basis_is_not_flagged():
+    """Low declared confidence is consistent with a weak basis: no signal."""
+    record = base_record(confidence_baseline=0.45)
+    assert check_confidence_signal.confidence_signal(record) is None
+
+
+def test_missing_confidence_is_not_flagged():
+    """Absent confidence is a separate concern; the signal check stays silent."""
+    record = base_record(confidence_baseline=None)
+    assert check_confidence_signal.confidence_signal(record) is None
+
+
+def test_engine_list_ordering_is_normalized():
+    """The corpus writes the same basis sets in multiple orders (18 ways for
+    13 distinct bases); the check must see them as the same basis."""
+    a = base_record(evidence_basis_engines=["pattern", "semgrep"])
+    b = base_record(evidence_basis_engines=["semgrep", "pattern"])
+    assert check_confidence_signal.confidence_signal(a) == check_confidence_signal.confidence_signal(b)
+
+
+def test_authority_probe_note_is_appended_to_00074_shape():
+    """AVE-2026-00074's detection methodology names authority probes; the
+    floor there is an enum gap, not an overclaim, and the signal says so."""
+    record = base_record(
+        detection_methodology="Queries GitHub's users API for owners, the package "
+        "registry for names, RDAP for domains, provider fingerprints for cloud "
+        "subdomains; a failed probe degrades to silence.",
+    )
+    result = check_confidence_signal.confidence_signal(record)
+    assert result is not None
+    assert "external-authority probe" in result
+    assert "enum gap" in result
+
+
+def test_main_is_soft_warning_exit_zero():
+    """The agreed design: warn-not-fail, exit code untouched (same shape as
+    check_researcher_matches_disclosure)."""
+    assert check_confidence_signal.main([]) == 0

--- a/tests/test_confidence_signal.py
+++ b/tests/test_confidence_signal.py
@@ -76,6 +76,19 @@ def test_engine_list_ordering_is_normalized():
     assert check_confidence_signal.confidence_signal(a) == check_confidence_signal.confidence_signal(b)
 
 
+def test_duplicate_engine_members_are_still_a_floor_basis():
+    """astrogilda's attack test (2026-08-26): a duplicated member is a
+    single-engine basis wearing a list of length two and must not dodge
+    the floor. len(set(engines)) <= 1 pins the fixed behaviour."""
+    record = base_record(
+        confidence_baseline=0.95,
+        evidence_basis_engines=["pattern", "pattern"],
+    )
+    result = check_confidence_signal.confidence_signal(record)
+    assert result is not None
+    assert "floor" in result
+
+
 def test_authority_probe_note_is_appended_to_00074_shape():
     """AVE-2026-00074's detection methodology names authority probes; the
     floor there is an enum gap, not an overclaim, and the signal says so."""
@@ -88,6 +101,22 @@ def test_authority_probe_note_is_appended_to_00074_shape():
     assert result is not None
     assert "external-authority probe" in result
     assert "enum gap" in result
+
+
+def test_authority_probe_note_negative_control():
+    """astrogilda's attack test (2026-08-26): prose that merely mentions a
+    registry or domain is not an authority probe. The note is the only
+    exculpatory sentence in the output, so a false attach is worse than a
+    false flag; the negative case must stay quiet."""
+    for methodology in (
+        "Static pattern scan for hardcoded credentials in packages published to the npm registry.",
+        "Domain-specific heuristics over the tool description string.",
+        "Matches the Windows registry key path written by the installer.",
+    ):
+        record = base_record(detection_methodology=methodology)
+        result = check_confidence_signal.confidence_signal(record)
+        assert result is not None
+        assert "external-authority probe" not in result, methodology
 
 
 def test_main_is_soft_warning_exit_zero():


### PR DESCRIPTION
## Type of change

- [ ] New AVE record submission
- [ ] Update to existing AVE record
- [ ] Schema change (v1.0.0)
- [ ] New detection rule (YARA / Semgrep / pattern)
- [ ] Crosswalk addition or update
- [ ] Documentation improvement
- [x] Other: consumer-side confidence signal check (issue #98)

---

## Description

Addresses the consumer half of issue #98: `confidence_baseline` is a
self-reported float with no structural verification, and downstream
consumers (compliance teams building on AVE-classified findings) cannot
tell a record backed by a formally disclosed CVE from one resting on a
speculative pattern match. This PR adds a check that makes that
distinction computable **without a schema change**, plus the issue's
shape-1 documentation of how consumers should handle the field.

The design follows the issue thread (astrogilda's write-up of 2026-08-20,
chaksaray's endorsement, and the convergence agreed on 2026-08-25):

1. `scripts/check_confidence_signal.py` — reads fields that already exist
   (`evidence_basis_engines`, `evidence_kind_default`,
   `confidence_baseline`). A record whose confidence sits at the high band
   (`>= 0.85`) while its derived basis sits at the floor (single-engine
   set, regardless of which engine, or `evidence_kind_default` =
   `semantic_inference`) is a "declared, not structurally verified"
   signal. Engine lists are compared set-normalised, so the 13 distinct
   bases written 18 different ways read as 13, not 18. The check is a soft
   warning: it prints findings and leaves the exit code alone, the same
   shape as `check_researcher_matches_disclosure` in
   `validate_records.py`.

2. `tests/test_confidence_signal.py` — unit tests for the band/floor rule,
   the set-normalisation, the exit-code contract, and the enum-gap note.

3. `docs/guides/confidence-baseline-consumer-guide.md` — the issue's
   "document the handling" shape: band-by-band consumer guidance, the
   fail-closed disagreement rule for consuming tools, and the escalation
   condition (an `external_authority` member in the engines enum plus zero
   fires on authority-probe records, both halves read off schema and
   data).

**AVE-2026-00074 is shipped as the fixture**, per the thread. The check
fires on it, and the signal notes that the floor there is an enum gap, not
an overclaim: its `detection_methodology` probes external authorities
(GitHub's users API, package registries, RDAP, provider fingerprints), and
`evidence_basis_engines` has no member for "an external authority was
queried and returned a determinate answer." The honest author wrote the
nearest available value. This is the false positive that makes the gap
visible, kept deliberately, with the escalation condition that will clear
it.

Result on today's corpus: exactly 1 soft warning — AVE-2026-00074. The
check flags disagreement; it does not certify truth.

---

## AVE record(s)

N/A — no records added or modified. This is a tooling/documentation
contribution.

---

## Checklist

### For all PRs

- [x] I have read CONTRIBUTING.md
- [x] `ave_id` values are immutable — no renumbering
- [x] No references to SPEC.md (removed), template.json (removed), or bawbel/bawbel-ave (wrong path)
- [x] I agree my contribution is licensed under Apache 2.0

### Verification (local, Python 3.12)

- `python scripts/validate_records.py` — all 80 records valid (exit 0)
- `python scripts/validate_crosswalks.py` — 9/9 valid (exit 0)
- `python scripts/check_fixtures.py` — all 80 records have fixtures (exit 0)
- `python scripts/check_confidence_signal.py` — 1 soft warning (AVE-2026-00074), exit 0
- `python -m pytest tests/` — 349 passed, 1 pre-existing failure
  (`test_record_validator_rejects_invalid_date_time_format`, fails on clean
  `main` too under the local jsonschema version; unrelated to this PR)