### PR TITLE
Derive verification_basis from a record's own evidence axes (issue #98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ pip install -e ".[dev]"
 pytest tests/ -x -q                   # validate records + fixtures
 python scripts/validate_records.py    # schema-check every record
 python scripts/check_fixtures.py      # every record has +/- fixtures
+python scripts/write_verification_basis.py   # derive verification_basis from the evidence axes
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,7 @@ description. Reviewers will ask for this if it is missing.
 pip install -e ".[dev]"
 python scripts/validate_records.py    # schema-checks every record, including yours
 python scripts/check_fixtures.py      # confirms every record has +/- fixtures
+python scripts/write_verification_basis.py   # derives verification_basis; reports declarations its axes refute
 pytest tests/ -x -q                   # full suite: schema, AIVSS arithmetic, mitigation enums
 ```
 
@@ -163,7 +164,11 @@ record's own stated `aarf`/`cvss_base`/`thm`/`mitigation_factor`
 values (a common failure mode is drafting against one set of factors
 and writing down another), and `check_fixtures.py` confirms
 `tests/fixtures/AVE-YYYY-NNNNN_positive.md` and `_negative.md` both
-exist -- required for every record, see Step 4. If `npm`-based schema
+exist -- required for every record, see Step 4. If your record states
+`evidence_vantage` or `evidence_method`, `validate_records.py` also
+recomputes `verification_basis` from them and fails when a declared value
+disagrees, so the declaration is checkable rather than taken on trust --
+see docs/guides/evidence-vantage-producer-guide.md. If `npm`-based schema
 tooling (`ajv`) is more convenient for your own workflow, it's a valid
 supplementary check, but the record must pass the scripts above before
 a PR is reviewed, not just an ad-hoc schema validator.

--- a/docs/guides/evidence-vantage-producer-guide.md
+++ b/docs/guides/evidence-vantage-producer-guide.md
@@ -1,0 +1,98 @@
+# Evidence vantage: producer guide
+
+This is the producer half of issue #98. A consumer-side check can read what
+a record says about its own confidence, but everything it reads was typed by
+the record's author, so it is reading a self-report however carefully it
+reads it. What changes that is the record stating structurally where its
+evidence came from. That is what `evidence_vantage` and `evidence_method`
+are for, and `verification_basis` is what the validator computes from them.
+
+## The two axes
+
+`evidence_vantage` says where every input this class's evidence depends on
+was obtained.
+
+- `substrate` -- obtained at a vantage the observed artifact could neither
+  forge nor suppress: a registry answering about a package, RDAP answering
+  about a domain, a sandbox watching execution from outside.
+- `artifact` -- at least one input derives from output the artifact itself
+  produced: its own text, its own manifest, its own logs.
+
+`evidence_method` says how the evidence was established.
+
+- `intercepted` -- from events captured as they occurred.
+- `reconstructed` -- from state examined after the fact.
+
+Both are taken from the **weakest input**. A determination computed by
+trusted machinery over content the artifact wrote is `artifact`, however
+trusted the machinery, because the artifact could have written that content
+without doing the thing the record describes. A claim that fuses a live
+capture with an after-the-fact examination is `reconstructed`.
+
+## The floor is always available
+
+`artifact` and `reconstructed` are the weaker value of each axis, and each
+is a claim a producer may always truthfully make. Stating either is not an
+admission and carries no penalty. A consumer learns from it only that the
+record lacks the stronger binding. This matters more than it looks: if the
+weaker value reads as a confession, honest authors avoid it, values drift
+upward, and the axis stops meaning anything within a year.
+
+Both axes are optional, and **absence reads as the floor**. Silence is never
+credited as the stronger claim.
+
+## verification_basis is computed, never written
+
+`verification_basis` is the composition of the two axes with the vantage the
+record's `evidence_basis_engines` set can reach. Compute it with:
+
+```bash
+python scripts/write_verification_basis.py            # report disagreements
+python scripts/write_verification_basis.py --write    # stamp the derived value
+```
+
+The engine set is a **ceiling** and the declared vantage is the **claim**,
+and the derived value is the weaker of the two. `pattern`, `yara`,
+`semgrep`, `llm` and `magika` all read content the artifact produced, so a
+record detected only by those cannot reach `substrate` whatever it declares.
+`sandbox` and `external_authority` can.
+
+A record may carry a declared `verification_basis`, and
+`scripts/validate_records.py` then recomputes it and **fails** on a
+mismatch. That is the point of allowing the declaration at all: it is
+falsifiable, unlike a number an author simply assigns. Understating fails
+too, because the field states what the derivation computes.
+
+`--write` refuses any record whose file is not already in the script's own
+serialisation, rather than reformatting it. Most of the corpus is not, so
+canonicalising the record files is separate work, done deliberately and
+reviewed on its own.
+
+## external_authority
+
+The `evidence_basis_engines` enum gained `external_authority` for the case
+where a party outside the observed artifact was queried and returned a
+determinate answer: a package registry, RDAP, a forge's user API. The six
+existing members all run over content, and none of them can say an outside
+party was asked and answered, so before this member existed a record of that
+shape had no value to write and its author wrote the nearest one.
+
+The name states the observation rung and nothing about whether the answer
+was right. A determinate answer from an authority is still an answer that
+can be wrong, and reading it as verification is exactly the overclaim this
+issue exists to prevent.
+
+`AVE-2026-00074` is the record that made the gap visible: its
+`detection_methodology` probes GitHub's users API, package registries, RDAP
+and provider fingerprints, and its `evidence_basis_engines` reads
+`["pattern"]` because that was the closest available value. Adding the new
+member to that record is a deliberate follow-up, not part of adding the
+member to the enum, because it is also the record
+`scripts/check_confidence_signal.py` ships as its fixture.
+
+## What this does not do
+
+It does not certify that a record is right. It says where an observation was
+made from and how, so a consumer can tell a determination resting on an
+outside answer from one resting on a phrase match. That closes a
+self-certification gap. It does not create an audit trail on its own.

--- a/schema/ave-record-1.1.0.schema.json
+++ b/schema/ave-record-1.1.0.schema.json
@@ -544,10 +544,37 @@
           "semgrep",
           "llm",
           "sandbox",
-          "magika"
+          "magika",
+          "external_authority"
         ]
       },
-      "description": "Scanner hint — engines capable of detecting this class. Optional. Used to populate evidence_basis on findings."
+      "description": "Scanner hint — engines capable of detecting this class. Optional. Used to populate evidence_basis on findings. external_authority means a party outside the observed artifact was queried and returned a determinate answer (a package registry, RDAP, a forge's user API); it names the observation rung, not whether the answer was right."
+    },
+    "evidence_vantage": {
+      "type": "string",
+      "enum": [
+        "substrate",
+        "artifact"
+      ],
+      "description": "Producer statement — the vantage every input this class's evidence depends on was obtained at, taken from the weakest input. substrate: obtained where the observed artifact could neither forge nor suppress it. artifact: at least one input derives from output the artifact itself produced. artifact is a floor a producer may always truthfully state; a consumer learns from it only that the evidence lacks the stronger binding. Optional."
+    },
+    "evidence_method": {
+      "type": "string",
+      "enum": [
+        "intercepted",
+        "reconstructed"
+      ],
+      "description": "Producer statement — how the evidence for this class is established, taken from the weakest input. intercepted: from events captured as they occurred. reconstructed: from state examined after the fact. reconstructed is a floor a producer may always truthfully state. Optional; absent reads as reconstructed."
+    },
+    "verification_basis": {
+      "type": "string",
+      "enum": [
+        "substrate_intercepted",
+        "substrate_reconstructed",
+        "artifact_intercepted",
+        "artifact_reconstructed"
+      ],
+      "description": "Derived, not authored — the composition of evidence_vantage and evidence_method with the vantage implied by evidence_basis_engines, each taken by weakest input. scripts/write_verification_basis.py computes it. A record may carry a declared value, which validate_records.py then checks against the derivation and fails on a mismatch, so the declaration is falsifiable rather than self-reported. Optional."
     },
     "derivable_into": {
       "type": "array",

--- a/schema/ave-record.schema.json
+++ b/schema/ave-record.schema.json
@@ -544,10 +544,37 @@
           "semgrep",
           "llm",
           "sandbox",
-          "magika"
+          "magika",
+          "external_authority"
         ]
       },
-      "description": "Scanner hint — engines capable of detecting this class. Optional. Used to populate evidence_basis on findings."
+      "description": "Scanner hint — engines capable of detecting this class. Optional. Used to populate evidence_basis on findings. external_authority means a party outside the observed artifact was queried and returned a determinate answer (a package registry, RDAP, a forge's user API); it names the observation rung, not whether the answer was right."
+    },
+    "evidence_vantage": {
+      "type": "string",
+      "enum": [
+        "substrate",
+        "artifact"
+      ],
+      "description": "Producer statement — the vantage every input this class's evidence depends on was obtained at, taken from the weakest input. substrate: obtained where the observed artifact could neither forge nor suppress it. artifact: at least one input derives from output the artifact itself produced. artifact is a floor a producer may always truthfully state; a consumer learns from it only that the evidence lacks the stronger binding. Optional."
+    },
+    "evidence_method": {
+      "type": "string",
+      "enum": [
+        "intercepted",
+        "reconstructed"
+      ],
+      "description": "Producer statement — how the evidence for this class is established, taken from the weakest input. intercepted: from events captured as they occurred. reconstructed: from state examined after the fact. reconstructed is a floor a producer may always truthfully state. Optional; absent reads as reconstructed."
+    },
+    "verification_basis": {
+      "type": "string",
+      "enum": [
+        "substrate_intercepted",
+        "substrate_reconstructed",
+        "artifact_intercepted",
+        "artifact_reconstructed"
+      ],
+      "description": "Derived, not authored — the composition of evidence_vantage and evidence_method with the vantage implied by evidence_basis_engines, each taken by weakest input. scripts/write_verification_basis.py computes it. A record may carry a declared value, which validate_records.py then checks against the derivation and fails on a mismatch, so the declaration is falsifiable rather than self-reported. Optional."
     },
     "derivable_into": {
       "type": "array",

--- a/scripts/validate_records.py
+++ b/scripts/validate_records.py
@@ -3,7 +3,8 @@
 #       enforcement config, no dual-empty behavioral_vector/example_patterns),
 #       plus AIVSS score arithmetic and vendor-neutral language, added after a
 #       hand-drafted batch of records caught real instances of exactly these
-#       problems that nothing here checked
+#       problems that nothing here checked, plus a declared verification_basis
+#       that the record's own evidence axes contradict
 # Why:  a malformed or drifted record breaks every downstream scanner that loads it,
 #       and a free-text value in `mitigation` would let vendor-specific config
 #       leak back into a standard that is supposed to stay vendor-neutral.
@@ -16,13 +17,27 @@
 #       schema/ave-record-1.1.0.schema.json (handles the draft-vs-active
 #       conditional required set natively and enforces date-time / uri metadata),
 #       plus a handful of checks the schema's additionalProperties:false already
-#       implies but which deserve a readable, named failure message of their own
+#       implies but which deserve a readable, named failure message of their own.
+#       verification_basis is a hard error rather than a warning because it is
+#       derived rather than authored: a value disagreeing with the derivation is
+#       not a judgement call needing a human glance, it is a statement the
+#       record's own contents refute, and the whole point of carrying the field
+#       is that the declaration can be falsified.
 import json
 import re
 import sys
 from pathlib import Path
 
 import jsonschema
+
+# CI runs this file as `python scripts/validate_records.py`, which puts scripts/
+# on sys.path rather than the repository root, so the sibling module has to be
+# reachable by the same name the tests import it under (pyproject sets
+# pythonpath = ["."] for pytest). Adding the root explicitly makes both entry
+# points resolve one module rather than each resolving a different one.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.write_verification_basis import check_record as check_verification_basis  # noqa: E402
 
 RECORDS_DIR = Path("records")
 SCHEMA_PATH = Path("schema/ave-record-1.1.0.schema.json")
@@ -206,6 +221,7 @@ def main() -> int:
             + check_mitigation_enums_only(record)
             + check_aivss_arithmetic(record)
             + check_no_vendor_boilerplate(raw_text)
+            + check_verification_basis(record)
         )
         for e in errors:
             print(f"{rid}: {e}")

--- a/scripts/write_verification_basis.py
+++ b/scripts/write_verification_basis.py
@@ -1,0 +1,210 @@
+# What: derives verification_basis for every record in records/ from the
+#       record's own closed axes -- evidence_vantage, evidence_method, and the
+#       vantage the evidence_basis_engines set implies -- and either writes the
+#       derived value into the records (--write) or reports where a declared
+#       value disagrees with it (the default). This is the producer half of
+#       issue #98: scripts/check_confidence_signal.py reads what a record says
+#       about its own confidence, and this decides what the record is entitled
+#       to say.
+# Why:  confidence_baseline is a float its author assigns, and a check that
+#       reads it is still reading a self-report, only a better organised one.
+#       What changes that is a producer stating structurally what it observed
+#       rather than what it believed. So verification_basis is computed here and
+#       never authored: an author who types one has it checked against this
+#       derivation by validate_records.py and fails on a mismatch, which is the
+#       same shape as a crosswalk endpoint declaring itself unpinnable while
+#       pointing at a repository. A field an author can simply assert would be
+#       the field issue #98 was opened about, wearing a better name.
+# How:  each axis is a closed vocabulary composed by weakest input, taken from
+#       the AEE predicate's basis/method split that this ports. A record's
+#       vantage is the weaker of what its author declared and what its engine
+#       set can reach: pattern, yara, semgrep, llm and magika all read content
+#       the artifact produced, so they reach only `artifact`; sandbox observes
+#       execution from outside it and external_authority asks a party outside it
+#       entirely, so either reaches `substrate`. Method defaults to the weaker
+#       value when absent, so silence is never read as a claim. The engine set
+#       is a ceiling and the declaration is the claim, and the derived value is
+#       the weaker of the two, which is what makes external_authority
+#       load-bearing rather than decorative: before it existed, a record whose
+#       finding came from an outside answer had its ceiling pinned at `artifact`
+#       by an enum with no member for that rung, so no honest author could reach
+#       `substrate` however the evidence was actually obtained. Adding the
+#       member does not raise any record on its own -- an author still has to
+#       state the vantage -- it makes the true statement available.
+import argparse
+import json
+import sys
+from pathlib import Path
+
+RECORDS_DIR = Path("records")
+
+# Engines that can reach a substrate vantage. Everything else in the enum reads
+# content the observed artifact itself produced, and so is artifact-sourced
+# however trusted the machinery reading it: the artifact could have written what
+# the engine read without doing the thing the record claims. sandbox observes
+# execution from outside the artifact; external_authority asks a party outside
+# it. An engine absent from the enum entirely is not assumed to reach anything.
+SUBSTRATE_ENGINES = frozenset({"sandbox", "external_authority"})
+
+VANTAGE_VALUES = ("substrate", "artifact")
+METHOD_VALUES = ("intercepted", "reconstructed")
+
+# The weaker value of each axis, and the value a producer may always truthfully
+# state. Absence reads as the floor, so a record that says nothing is never
+# credited with the stronger claim.
+FLOOR_VANTAGE = "artifact"
+FLOOR_METHOD = "reconstructed"
+
+
+def engine_vantage(record: dict) -> str:
+    """The strongest vantage this record's engine set can reach.
+
+    Composition is by weakest input everywhere else, but an engine list is a
+    disjunction -- these are the engines capable of detecting the class, any one
+    of which may be the one that did -- so the set reaches substrate when any
+    member does. A non-list value reaches nothing: a malformed field is not
+    evidence of a strong vantage, and reading it as one would let a typo raise a
+    record's derived basis.
+    """
+    engines = record.get("evidence_basis_engines")
+    if not isinstance(engines, list):
+        return FLOOR_VANTAGE
+    members = {e for e in engines if isinstance(e, str)}
+    return "substrate" if members & SUBSTRATE_ENGINES else FLOOR_VANTAGE
+
+
+def declared_vantage(record: dict) -> str:
+    """What the producer declared, or the floor if it declared nothing legible.
+
+    An unrecognised value is not treated as a new stronger rung. The vocabulary
+    is closed; something outside it is a producer saying something this
+    derivation cannot read, and the honest reading of that is the floor.
+    """
+    value = record.get("evidence_vantage")
+    return value if value in VANTAGE_VALUES else FLOOR_VANTAGE
+
+
+def declared_method(record: dict) -> str:
+    value = record.get("evidence_method")
+    return value if value in METHOD_VALUES else FLOOR_METHOD
+
+
+def derive(record: dict) -> str:
+    """Compose the two axes into verification_basis, weakest input winning.
+
+    The vantage is the weaker of what the producer declared and what its engines
+    can reach, so a producer cannot raise its own basis by asserting a vantage
+    its evidence has no way to occupy, and cannot be credited with one it did
+    not claim. The result names the cell, not a score: it says where the
+    observation was made from and how, and nothing about whether it was right.
+    """
+    vantage = declared_vantage(record)
+    if engine_vantage(record) != "substrate":
+        vantage = FLOOR_VANTAGE
+    return f"{vantage}_{declared_method(record)}"
+
+
+def check_record(record: dict) -> list[str]:
+    """Report a declared verification_basis that the derivation contradicts.
+
+    Only the disagreement is reported. A record carrying no declaration is not a
+    finding here -- the derivation stands on its own and --write will stamp it --
+    and a record whose declaration matches has said something true.
+    """
+    declared = record.get("verification_basis")
+    if declared is None:
+        return []
+    derived = derive(record)
+    if declared == derived:
+        return []
+    return [
+        f"verification_basis declares '{declared}' but the record's own axes derive "
+        f"'{derived}' (evidence_vantage={record.get('evidence_vantage')!r}, "
+        f"evidence_method={record.get('evidence_method')!r}, "
+        f"evidence_basis_engines={record.get('evidence_basis_engines')!r}). "
+        f"verification_basis is derived, not declared: fix the axes or drop the "
+        f"declaration -- see issue #98."
+    ]
+
+
+def serialize(record: dict) -> str:
+    return json.dumps(record, indent=2) + "\n"
+
+
+def is_canonical(raw: str, record: dict) -> bool:
+    """Whether the file on disk is byte-identical to this script's own output.
+
+    Checked before writing, because a writer that reserialises is a writer that
+    reformats: 73 of the 80 records currently on main differ from json.dumps at
+    indent=2 in escaping or whitespace alone, so stamping a one-word field into
+    them would produce a diff nobody can review and would hide the real change
+    inside it. A record that fails this is refused rather than rewritten, which
+    leaves the corpus canonicalisation -- already named as separate work in
+    issue #98 -- as its own reviewable change instead of a side effect of this
+    one.
+    """
+    return serialize(record) == raw
+
+
+def record_paths() -> list[Path]:
+    return sorted(RECORDS_DIR.glob("AVE-*.json"))
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Derive verification_basis from each record's closed evidence axes "
+        "(issue #98). Reports declared values that disagree with the derivation; "
+        "--write stamps the derived value into the records."
+    )
+    parser.add_argument(
+        "--write", action="store_true",
+        help="write the derived verification_basis into each record",
+    )
+    args = parser.parse_args(argv)
+
+    paths = record_paths()
+    if not paths:
+        print(f"No records found under {RECORDS_DIR}/", file=sys.stderr)
+        return 1
+
+    mismatches = 0
+    written = 0
+    refused = 0
+    for path in paths:
+        raw = path.read_text(encoding="utf-8")
+        record = json.loads(raw)
+        rid = record.get("ave_id", path.name)
+
+        if args.write:
+            if not is_canonical(raw, record):
+                print(f"{rid}: refusing to write, the file is not in this script's "
+                      f"serialisation and stamping it would reformat the whole record. "
+                      f"Canonicalise {path} first.", file=sys.stderr)
+                refused += 1
+                continue
+            derived = derive(record)
+            if record.get("verification_basis") != derived:
+                record["verification_basis"] = derived
+                path.write_text(serialize(record), encoding="utf-8")
+                written += 1
+                print(f"{rid}: verification_basis = {derived}")
+            continue
+
+        for problem in check_record(record):
+            print(f"{rid}: {problem}")
+            mismatches += 1
+
+    if args.write:
+        print(f"\n{written} record(s) updated out of {len(paths)}, "
+              f"{refused} refused as non-canonical.")
+        return 1 if refused else 0
+    if mismatches:
+        print(f"\n{mismatches} declared verification_basis value(s) contradicted by "
+              f"the record's own axes.", file=sys.stderr)
+        return 1
+    print(f"All {len(paths)} records agree with their derived verification_basis.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_validate_data.py
+++ b/tests/test_validate_data.py
@@ -297,3 +297,167 @@ def test_an_unpinnable_side_may_still_state_a_count(tmp_path):
     errors = list(validator.iter_errors(crosswalk_document(endpoint)))
 
     assert errors == [], [error.message for error in errors]
+
+
+def record_with(**overrides):
+    record = {
+        "ave_id": "AVE-2026-99999",
+        "schema_version": "1.1.0",
+        "status": "draft",
+        "title": "Verification basis fixture",
+        "description": "A minimal draft record carrying evidence axes.",
+        "attack_class": "test",
+        "behavioral_fingerprint": "test",
+        "references": [{"tag": "Source", "text": "Source", "url": "https://example.com"}],
+        # Section 8 forbids a record with both of these empty, so the fixture
+        # carries one: without it main() returns 1 for a reason that has nothing
+        # to do with verification_basis, and the failing assertions below would
+        # pass while proving nothing.
+        "example_patterns": ["example"],
+    }
+    record.update(overrides)
+    return record
+
+
+def record_validator():
+    schema = json.loads(validate_records.SCHEMA_PATH.read_text(encoding="utf-8"))
+    return validate_records.build_validator(schema)
+
+
+def test_schema_accepts_the_external_authority_engine():
+    """The member issue #98 agreed on. Without it a record whose finding comes
+    from an outside answer has no value to write and its author writes the
+    nearest one, which reads as a pattern match."""
+    errors = validate_records.check_schema(
+        record_with(evidence_basis_engines=["pattern", "external_authority"]),
+        record_validator(),
+    )
+
+    assert errors == [], errors
+
+
+def test_schema_rejects_an_engine_outside_the_enum():
+    """The enum stays closed: the new member is a rung, not an opening."""
+    errors = validate_records.check_schema(
+        record_with(evidence_basis_engines=["external_registry"]), record_validator()
+    )
+
+    assert any("external_registry" in error for error in errors), errors
+
+
+@pytest.mark.parametrize("field,value", [
+    ("evidence_vantage", "substrate"),
+    ("evidence_vantage", "artifact"),
+    ("evidence_method", "intercepted"),
+    ("evidence_method", "reconstructed"),
+    ("verification_basis", "substrate_intercepted"),
+    ("verification_basis", "artifact_reconstructed"),
+])
+def test_schema_accepts_each_axis_value(field, value):
+    errors = validate_records.check_schema(
+        record_with(**{field: value}), record_validator()
+    )
+
+    assert errors == [], errors
+
+
+@pytest.mark.parametrize("field,value", [
+    ("evidence_vantage", "trusted"),
+    ("evidence_method", "live"),
+    ("verification_basis", "substrate"),
+    ("verification_basis", "self_reported"),
+])
+def test_schema_rejects_a_value_outside_a_closed_axis(field, value):
+    """Asserted on the offending value's own message, not on the error list
+    being non-empty: a fixture that failed for an unrelated missing property
+    would satisfy the weaker assertion while proving nothing about the axis."""
+    errors = validate_records.check_schema(
+        record_with(**{field: value}), record_validator()
+    )
+
+    assert any(f"'{value}'" in error and field in error for error in errors), errors
+
+
+def test_a_declared_verification_basis_its_own_axes_refute_is_an_error():
+    """A hard failure, not a warning, and it runs inside the validator CI
+    already invokes rather than beside it. verification_basis is derived, so a
+    value disagreeing with the derivation is refuted by the record's own
+    contents, not a judgement call that wants a human glance."""
+    errors = validate_records.check_verification_basis(
+        record_with(
+            verification_basis="substrate_intercepted",
+            evidence_vantage="artifact",
+            evidence_basis_engines=["pattern"],
+        )
+    )
+
+    assert len(errors) == 1
+    assert "artifact_reconstructed" in errors[0]
+
+
+def test_a_declared_verification_basis_its_axes_support_passes():
+    assert validate_records.check_verification_basis(
+        record_with(
+            verification_basis="substrate_intercepted",
+            evidence_vantage="substrate",
+            evidence_method="intercepted",
+            evidence_basis_engines=["external_authority"],
+        )
+    ) == []
+
+
+def test_a_record_declaring_no_verification_basis_is_not_an_error():
+    """The field is optional and derived; a record that omits it has said
+    nothing false."""
+    assert validate_records.check_verification_basis(record_with()) == []
+
+
+def test_every_shipped_record_passes_the_verification_basis_check():
+    errors = []
+    for path in sorted(validate_records.RECORDS_DIR.glob("AVE-*.json")):
+        record = json.loads(path.read_text(encoding="utf-8"))
+        errors.extend(f"{path.name}: {e}" for e in
+                      validate_records.check_verification_basis(record))
+
+    assert errors == []
+
+
+def test_the_validator_run_itself_fails_on_a_contradicted_declaration(
+    tmp_path, monkeypatch
+):
+    """Asserts the wiring, not the function.
+
+    Calling check_verification_basis directly proves the rule and proves
+    nothing about whether anything runs it: with the call removed from main's
+    error list, every other test in this file still passed. This one drives
+    main() over a directory holding one contradicted record, so deleting the
+    wiring turns it red.
+    """
+    record = record_with(
+        verification_basis="substrate_intercepted",
+        evidence_vantage="artifact",
+        evidence_basis_engines=["pattern"],
+    )
+    (tmp_path / "AVE-2026-99999.json").write_text(
+        json.dumps(record, indent=2) + "\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(validate_records, "RECORDS_DIR", tmp_path)
+
+    assert validate_records.main() == 1
+
+
+def test_the_validator_run_passes_the_same_record_without_the_declaration(
+    tmp_path, monkeypatch
+):
+    """The negative control for the test above: same record, same directory,
+    declaration dropped. Without this, a validator that failed everything would
+    satisfy the assertion above."""
+    record = record_with(
+        evidence_vantage="artifact", evidence_basis_engines=["pattern"]
+    )
+    (tmp_path / "AVE-2026-99999.json").write_text(
+        json.dumps(record, indent=2) + "\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(validate_records, "RECORDS_DIR", tmp_path)
+
+    assert validate_records.main() == 0

--- a/tests/test_verification_basis.py
+++ b/tests/test_verification_basis.py
@@ -1,0 +1,237 @@
+import json
+
+import pytest
+
+from scripts import write_verification_basis as writer
+
+
+def record(**overrides):
+    base = {
+        "ave_id": "AVE-2026-99999",
+        "schema_version": "1.1.0",
+        "status": "active",
+        "title": "Verification basis fixture",
+        "description": "Fixture record for the verification_basis derivation.",
+        "attack_class": "test",
+        "behavioral_fingerprint": "test",
+        "references": [{"tag": "Source", "text": "Source", "url": "https://example.com"}],
+    }
+    base.update(overrides)
+    return base
+
+
+# --- the floor -------------------------------------------------------------
+
+def test_a_record_saying_nothing_derives_the_floor():
+    """Silence is never credited as a claim. A record with no axes at all sits
+    at the weaker value of both, which is the value a producer may always
+    truthfully state."""
+    assert writer.derive(record()) == "artifact_reconstructed"
+
+
+def test_the_floor_is_reachable_without_admitting_anything():
+    """Both floor values are stateable outright, not only by omission."""
+    assert writer.derive(record(
+        evidence_vantage="artifact", evidence_method="reconstructed",
+    )) == "artifact_reconstructed"
+
+
+# --- the ceiling the engine set imposes ------------------------------------
+
+def test_content_engines_cannot_reach_substrate_however_many_there_are():
+    """pattern, yara, semgrep, llm and magika all read what the artifact wrote,
+    so no combination of them lets a declared substrate vantage stand."""
+    assert writer.derive(record(
+        evidence_vantage="substrate",
+        evidence_basis_engines=["pattern", "yara", "semgrep", "llm", "magika"],
+    )) == "artifact_reconstructed"
+
+
+def test_external_authority_makes_the_substrate_claim_reachable():
+    """The member added for issue #98. Before it existed the ceiling was pinned
+    at artifact for a record whose finding came from an outside answer."""
+    assert writer.derive(record(
+        evidence_vantage="substrate",
+        evidence_method="intercepted",
+        evidence_basis_engines=["pattern", "external_authority"],
+    )) == "substrate_intercepted"
+
+
+def test_sandbox_also_reaches_substrate():
+    assert writer.derive(record(
+        evidence_vantage="substrate", evidence_basis_engines=["sandbox"],
+    )) == "substrate_reconstructed"
+
+
+def test_the_ceiling_does_not_raise_a_record_that_claims_nothing():
+    """A strong engine set is permission to make a claim, not the claim. A
+    record that declares no vantage stays at the floor even with the strongest
+    engine present."""
+    assert writer.derive(record(
+        evidence_basis_engines=["external_authority", "sandbox"],
+    )) == "artifact_reconstructed"
+
+
+# --- composition by weakest input ------------------------------------------
+
+@pytest.mark.parametrize("vantage,method,expected", [
+    ("substrate", "intercepted", "substrate_intercepted"),
+    ("substrate", "reconstructed", "substrate_reconstructed"),
+    ("artifact", "intercepted", "artifact_intercepted"),
+    ("artifact", "reconstructed", "artifact_reconstructed"),
+])
+def test_all_four_cells_are_reachable(vantage, method, expected):
+    assert writer.derive(record(
+        evidence_vantage=vantage, evidence_method=method,
+        evidence_basis_engines=["sandbox"],
+    )) == expected
+
+
+def test_method_absent_reads_as_reconstructed_not_intercepted():
+    assert writer.derive(record(
+        evidence_vantage="substrate", evidence_basis_engines=["sandbox"],
+    )) == "substrate_reconstructed"
+
+
+# --- values outside the closed vocabularies --------------------------------
+
+@pytest.mark.parametrize("bad", ["SUBSTRATE", "substrate ", "trusted", "", None, 1, True, ["substrate"]])
+def test_an_unreadable_vantage_reads_as_the_floor_at_its_own_level(bad):
+    """Pinned on the axis reader directly, not only through derive(). Checked
+    through derive() alone this guard is unobservable: a stray value fails the
+    equality against 'substrate' either way, so the closed-vocabulary check
+    could be deleted and every end-to-end assertion would still pass."""
+    assert writer.declared_vantage(record(evidence_vantage=bad)) == "artifact"
+
+
+@pytest.mark.parametrize("bad", ["INTERCEPTED", "live", "", None, 0, []])
+def test_an_unreadable_method_reads_as_the_floor_at_its_own_level(bad):
+    assert writer.declared_method(record(evidence_method=bad)) == "reconstructed"
+
+
+@pytest.mark.parametrize("bad", ["SUBSTRATE", "substrate ", "trusted", "", None, 1, True, ["substrate"]])
+def test_an_unreadable_vantage_is_the_floor_not_a_new_rung(bad):
+    """A value outside the closed vocabulary is a producer saying something the
+    derivation cannot read, and the honest reading of that is the floor, never a
+    stronger rung and never a crash."""
+    assert writer.derive(record(
+        evidence_vantage=bad, evidence_basis_engines=["sandbox"],
+    )) == "artifact_reconstructed"
+
+
+@pytest.mark.parametrize("bad", ["INTERCEPTED", "live", "", None, 0, []])
+def test_an_unreadable_method_is_the_floor(bad):
+    assert writer.derive(record(
+        evidence_vantage="substrate", evidence_method=bad,
+        evidence_basis_engines=["sandbox"],
+    )) == "substrate_reconstructed"
+
+
+@pytest.mark.parametrize("bad", ["sandbox", {"sandbox": 1}, None, 7, [None, 3], []])
+def test_a_malformed_engine_field_reaches_nothing(bad):
+    """A string is not a one-element list and a typo is not a strong vantage.
+    'sandbox' as a bare string must not be read as the sandbox engine."""
+    assert writer.derive(record(
+        evidence_vantage="substrate", evidence_basis_engines=bad,
+    )) == "artifact_reconstructed"
+
+
+def test_a_valid_engine_beside_junk_still_counts():
+    assert writer.derive(record(
+        evidence_vantage="substrate", evidence_basis_engines=[None, 3, "sandbox"],
+    )) == "substrate_reconstructed"
+
+
+# --- the declaration is falsifiable ----------------------------------------
+
+def test_no_declaration_is_not_a_finding():
+    assert writer.check_record(record(evidence_basis_engines=["pattern"])) == []
+
+
+def test_a_matching_declaration_passes():
+    assert writer.check_record(record(
+        verification_basis="artifact_reconstructed", evidence_basis_engines=["pattern"],
+    )) == []
+
+
+def test_a_declaration_stronger_than_the_axes_is_refuted():
+    """The pin_status shape: a side declaring something its own content
+    contradicts fails, which is what makes the declaration worth carrying."""
+    problems = writer.check_record(record(
+        verification_basis="substrate_intercepted",
+        evidence_vantage="artifact",
+        evidence_basis_engines=["pattern"],
+    ))
+    assert len(problems) == 1
+    assert "substrate_intercepted" in problems[0]
+    assert "artifact_reconstructed" in problems[0]
+
+
+def test_a_declaration_weaker_than_the_axes_is_also_refuted():
+    """Understating is a mismatch too. The field states what the derivation
+    computes, so a record cannot quietly opt out of its own stronger basis."""
+    assert writer.check_record(record(
+        verification_basis="artifact_reconstructed",
+        evidence_vantage="substrate",
+        evidence_method="intercepted",
+        evidence_basis_engines=["external_authority"],
+    )) != []
+
+
+# --- the writer refuses to reformat ----------------------------------------
+
+def test_a_non_canonical_file_is_not_canonical():
+    """73 of the 80 records on main differ from this script's serialisation in
+    escaping or whitespace alone; writing into one would reformat it."""
+    rec = record()
+    raw = json.dumps(rec, indent=4) + "\n"
+    assert writer.is_canonical(raw, rec) is False
+
+
+def test_a_canonical_file_is_recognised():
+    rec = record()
+    assert writer.is_canonical(writer.serialize(rec), rec) is True
+
+
+def test_write_refuses_non_canonical_records_and_exits_nonzero(tmp_path, monkeypatch):
+    rec = record()
+    path = tmp_path / "AVE-2026-99999.json"
+    path.write_text(json.dumps(rec, indent=4) + "\n", encoding="utf-8")
+    monkeypatch.setattr(writer, "RECORDS_DIR", tmp_path)
+
+    assert writer.main(["--write"]) == 1
+    assert path.read_text(encoding="utf-8") == json.dumps(rec, indent=4) + "\n"
+
+
+def test_write_stamps_a_canonical_record(tmp_path, monkeypatch):
+    rec = record(evidence_vantage="substrate", evidence_method="intercepted",
+                 evidence_basis_engines=["external_authority"])
+    path = tmp_path / "AVE-2026-99999.json"
+    path.write_text(writer.serialize(rec), encoding="utf-8")
+    monkeypatch.setattr(writer, "RECORDS_DIR", tmp_path)
+
+    assert writer.main(["--write"]) == 0
+    assert json.loads(path.read_text(encoding="utf-8"))["verification_basis"] == \
+        "substrate_intercepted"
+
+
+def test_check_mode_fails_on_a_contradicted_declaration(tmp_path, monkeypatch):
+    rec = record(verification_basis="substrate_intercepted",
+                 evidence_basis_engines=["pattern"])
+    (tmp_path / "AVE-2026-99999.json").write_text(writer.serialize(rec), encoding="utf-8")
+    monkeypatch.setattr(writer, "RECORDS_DIR", tmp_path)
+
+    assert writer.main([]) == 1
+
+
+def test_an_empty_records_directory_is_reported_not_passed(tmp_path, monkeypatch):
+    """An absent corpus must never read as a clean run."""
+    monkeypatch.setattr(writer, "RECORDS_DIR", tmp_path)
+    assert writer.main([]) == 1
+
+
+# --- the shipped corpus -----------------------------------------------------
+
+def test_every_published_record_agrees_with_its_derivation():
+    """Run against records/ as it stands, the same way the check half runs."""
+    assert writer.main([]) == 0


### PR DESCRIPTION
This adds the producer half of #98. Two closed axes go into the record schema. `evidence_vantage` takes substrate or artifact, and `evidence_method` takes intercepted or reconstructed. Both are optional and producer-written, and both are taken from the weakest input a claim rests on. Beside them sits `verification_basis`, which composes the two, and `scripts/write_verification_basis.py` computes it rather than an author typing it. `validate_records.py` recomputes any declared value and fails on a mismatch, the pin_status shape from #171.

That last part is the only reason a declaration is worth carrying. `confidence_baseline` is a float its author assigns, and a check that reads it is still reading a self-report. What changes that is a producer stating structurally what it observed, in a vocabulary a validator can recompute from the record's own contents.

The mechanic is the part worth reviewing. The engine set is a ceiling, the declaration is the claim, and the derived value is the weaker of the two. The pattern, yara, semgrep, llm and magika engines all read content the artifact produced. A record detected only by those cannot reach substrate whatever it declares. The sandbox engine observes execution from outside the artifact, and the new `external_authority` member asks a party outside it entirely. Either of those can reach substrate, so a producer cannot raise its own basis by asserting a vantage its evidence cannot occupy.

That member is load-bearing rather than decorative. Before it existed, a record whose finding came from asking an outside party had its ceiling pinned at artifact. The enum had no member for that rung. No honest author could state the true value, however the evidence was actually obtained. Adding the member raises no record on its own, since an author still declares the vantage. It makes the true statement available.

The floor is what keeps the axes honest. Artifact and reconstructed are the weaker value of each axis, and a producer may always truthfully state either. Absence reads as the floor on both, so silence is never credited as the stronger claim. A value outside the closed vocabulary reads as the floor too, so a typo cannot raise a record. A non-list engine field reaches nothing, for the same reason. Understating fails the check as well, so the field cannot quietly opt out of a stronger basis.

That choice is deliberate. If the weaker value read as a confession, honest authors would avoid it. The values would drift upward, and the axis would die inside a year.

This deliberately does not touch `AVE-2026-00074`. Adding the external_authority member to that record is what clears the fixture in #213. So it belongs in its own commit after that PR merges, not as a side effect of the schema landing. I trial-merged the two branches locally and they do not fight. There is no conflict and the combined suite is green. The consumer check still fires exactly once on that record, and the derivation passes on all 80 records.

One scoping note on the writer. In write mode it refuses any record that is not already byte-identical to its own serialisation. 73 of the 80 records on main differ from it in escaping or whitespace alone. Stamping a one-word field into them would produce a diff nobody can review, and would hide the real change inside it. Those records are refused rather than rewritten. Corpus canonicalisation is already named as separate work in #98, and it stays that way.

All four repository checks pass on this branch: validate_records.py, validate_crosswalks.py, check_fixtures.py, and the pytest suite at 417 passing.

The caveat from the issue thread still holds, and I would keep it in the guide verbatim. The derivation names a vantage, and it says where an observation was made from and how. It does not certify that a record is right, and it does not create an audit trail on its own.
