### PR TITLE
docs: three real improvements surfaced by external critique

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ AVE is a standard, not a product. The `bawbel-scanner` implements it as the
 reference implementation. Any tool can map to it — see the
 [implementer guide](docs/specs/ave-implementer-guide.md) for how.
 
+### What AVE is not
+
+AVE is a naming and classification standard. It assigns stable IDs to
+behavioral vulnerability classes and describes how to detect them. It
+is not a runtime enforcement mechanism, and an AVE ID on its own stops
+nothing. Enforcement requires a separate policy or gating layer that
+consumes AVE's records, the same relationship CWE has to an actual
+static analyzer, or a CVE has to a patch management system.
+
 ```
 Your CI pipeline scans dependencies for known package vulnerabilities.
 It does not scan your SKILL.md for prompt injection.
@@ -527,7 +536,9 @@ See [GOVERNANCE.md](GOVERNANCE.md) for the decision-making process, how records
 are proposed and reviewed, and the path toward neutral governance.
 
 See [docs/specs/scaling-and-governance.md](docs/specs/scaling-and-governance.md)
-for record-growth discipline, schema versioning, and deprecation policy.
+for record-growth discipline, schema versioning, and deprecation policy,
+including AVE's ID stability guarantee: identifiers are never
+renumbered or reused once published.
 
 See [docs/specs/researcher-process.md](docs/specs/researcher-process.md)
 for the practical, step-by-step process a contributor actually follows

--- a/docs/specs/ave-implementer-guide.md
+++ b/docs/specs/ave-implementer-guide.md
@@ -134,6 +134,35 @@ restricted environment but findings are reviewed in a connected dashboard.
 
 ---
 
+## Pattern 4: runtime enforcement input, not just detection
+
+AVE records aren't only useful for scanning already-written skill
+files. Their `indicators_of_compromise` and `behavioral_fingerprint`
+fields are specific enough to drive a pre-execution policy check, not
+just a post-hoc finding.
+
+**Example, [AVE-2026-00048](https://aveproject.org/registry.html#AVE-2026-00048)
+(unsafe agent delegation chain)**: the record's own `indicators_of_compromise`
+names "skill contains delegation instruction with full access or
+inherit permissions language" and "sub-agent spawned without explicit
+tool allowlist in the delegation instruction." A gateway sitting
+between an agent and its sub-agent spawning capability could check for
+exactly those two conditions before allowing the spawn, and block or
+require confirmation before the action executes, rather than only
+flagging it after the fact in a static scan.
+
+This is enforcement built on top of AVE, using AVE's specificity as
+the input, not AVE performing enforcement itself — see
+[README.md's "What AVE is not"](../../README.md#what-ave-is-not) for
+why that distinction matters.
+
+**When to use:** any gating layer, policy engine, or runtime guard
+that sits in front of an agentic action and needs a concrete,
+citable condition to check against, rather than a general category
+name.
+
+---
+
 ## The mapping step
 
 To emit AVE IDs, you need a mapping from your internal rule IDs to AVE IDs. Two

--- a/docs/specs/scaling-and-governance.md
+++ b/docs/specs/scaling-and-governance.md
@@ -105,3 +105,39 @@ case for an unratified standard, not the exception. This applies
 symmetrically: if another project ever crosswalks to AVE's own
 `owasp_mcp` field by number rather than meaning, the same risk runs the
 other way.
+
+## 5. ID stability policy
+
+The pieces of this guarantee already exist scattered across Sections 2
+and 3 above; this section states it once, directly, as a policy
+commitment a compliance-minded reader or implementer can cite without
+reconstructing it from elsewhere in this document.
+
+**An AVE ID, once published, is never renumbered or reused. Full
+stop.** No exception exists for a record later found to be mistaken,
+redundant, or poorly scoped, that is what `deprecated`, `merged`, and
+`rejected` status exist for (Section 3), not a reason to free up a
+number.
+
+**A record's content can be revised as evidence improves; its
+identifier cannot.** Description, remediation, severity, AIVSS score,
+and every other field are expected to be corrected when a better
+understanding of the same behavioral class emerges, the way any of
+this project's own corrections passes have done. None of that touches
+the `ave_id` itself. The number is a permanent pointer; what it points
+at is allowed to get more accurate over time.
+
+**A deprecated or merged record keeps its own number.** If
+`AVE-2026-00019` is later found to be a variant of `AVE-2026-00007`,
+`00019` does not get deleted, freed, or handed to a future unrelated
+record, it is marked `merged` with `merged_into` pointing at `00007`
+(Section 3), and `00019` itself stays permanently resolvable at its own
+URL with its own history intact.
+
+**This is a commitment this project holds itself to going forward, not
+a description of what has merely happened so far.** Nothing has yet
+forced a real test of this guarantee at scale; stating it as policy
+now, while the corpus is still small, is deliberately the same
+discipline Section 1 already applies to record-growth: cheap to commit
+to early, expensive to retrofit credibly after an implementer has
+already depended on a number that then moved.


### PR DESCRIPTION
Source: r/AI_Agents thread feedback (Financial_Lemon34, Accomplished_Dot1445, richard_daly). Three specific, real gaps, not a general response to comments.

**1. ID stability policy** — added as `scaling-and-governance.md` Section 5 (appended, not inserted, since CONTRIBUTING.md cites Section 1 by number directly and renumbering would break that reference). The guarantee already existed scattered across Sections 2-3; this states it once, directly, as a citable policy commitment rather than a description of behavior so far. Linked from README's governance section.

**2. Enforcement-vs-documentation overclaiming audit** — checked every `prevent`/`block`/`stop`/`govern`/`enforce` occurrence in README.md against its actual sentence context. All three hits were already correctly scoped: the `bawbel-scanner` blocking example describes a consuming tool, not AVE itself (correctly left as-is, per the task's own explicit exception); the two "governance" mentions are about project decision-making, not runtime enforcement. No rewording needed. Added an explicit **What AVE is not** section near the top-level "What is AVE?" instead, stating the naming-vs-enforcement distinction directly rather than leaving it implicit.

**3. Implementer guide Pattern 4** — runtime enforcement input, not just detection. Uses `AVE-2026-00048`'s real, current `indicators_of_compromise` text verbatim (pulled fresh from the record, not reused from the task description that referenced it).

**Not in this PR**: Task 4 (tracking the convergence-methodology critique as a future goal) went into `TRUST_STRATEGY.md`, which is deliberately gitignored/untracked — updated locally as requested, but it won't appear in this diff, and I'm not force-adding a private strategy file to a public PR. Tracked separately in #216 instead, since a public issue is the right durable record for a gitignored file.