### PR TITLE
Apply external_authority to AVE-2026-00074, clearing its enum-gap fixture (issue #218)

### DIFF
--- a/records/AVE-2026-00074.json
+++ b/records/AVE-2026-00074.json
@@ -103,6 +103,6 @@
   "detection_stage": "static_detection",
   "detection_layer": "content",
   "confidence_baseline": 0.85,
-  "evidence_basis_engines": ["pattern"],
+  "evidence_basis_engines": ["pattern", "external_authority"],
   "derivable_into": ["remote-control-chain"]
 }

--- a/tests/test_confidence_signal.py
+++ b/tests/test_confidence_signal.py
@@ -26,8 +26,9 @@ def base_record(**overrides):
 def test_high_confidence_on_floor_basis_is_flagged():
     """The issue #98 shape: a high float with no structural verification.
 
-    Mirrors AVE-2026-00074's actual shape: pattern-only engine set, high
-    confidence. The agreed design ships this record as the fixture.
+    Mirrors AVE-2026-00074's pre-#218 shape: pattern-only engine set, high
+    confidence. The record has since gained external_authority (issue #218);
+    this fixture pins the floor behavior the check is designed to catch.
     """
     record = base_record()
     result = check_confidence_signal.confidence_signal(record)
@@ -90,8 +91,10 @@ def test_duplicate_engine_members_are_still_a_floor_basis():
 
 
 def test_authority_probe_note_is_appended_to_00074_shape():
-    """AVE-2026-00074's detection methodology names authority probes; the
-    floor there is an enum gap, not an overclaim, and the signal says so."""
+    """AVE-2026-00074's pre-#218 detection methodology named authority probes
+    while its engine set still sat at the floor; the floor there was an enum
+    gap, not an overclaim, and the signal said so. Pins the note logic that
+    any pre-vocabulary record still gets."""
     record = base_record(
         detection_methodology="Queries GitHub's users API for owners, the package "
         "registry for names, RDAP for domains, provider fingerprints for cloud "
@@ -101,6 +104,19 @@ def test_authority_probe_note_is_appended_to_00074_shape():
     assert result is not None
     assert "external-authority probe" in result
     assert "enum gap" in result
+
+
+def test_external_authority_member_clears_the_00074_enum_gap():
+    """Post-#218 shape: AVE-2026-00074's engines now carry external_authority,
+    so the floor clears and the check stays quiet -- the escalation condition
+    named in #213/#214 is satisfied by the record's own vocabulary."""
+    record = base_record(
+        evidence_basis_engines=["pattern", "external_authority"],
+        detection_methodology="Queries GitHub's users API for owners, the package "
+        "registry for names, RDAP for domains, provider fingerprints for cloud "
+        "subdomains; a failed probe degrades to silence.",
+    )
+    assert check_confidence_signal.confidence_signal(record) is None
 
 
 def test_authority_probe_note_negative_control():


### PR DESCRIPTION
Closes #218.

Both halves of #98 have landed (#213, #214). This is the one remaining piece named in both PRs: AVE-2026-00074 sat at the floor basis because its evidence_basis_engines had no member for "an external authority was queried and returned a determinate answer." The record's detection_methodology already describes probing GitHub's users API, package registries, and RDAP; it just predated the vocabulary.

**Change:**
- `records/AVE-2026-00074.json`: `evidence_basis_engines` is now `["pattern", "external_authority"]`. The engine set clears the floor, so the consumer-side confidence check stops firing on it, which is the escalation condition named in #213/#214: the field carries the member, and a re-run fires zero times on a record whose methodology names an authority probe.
- `tests/test_confidence_signal.py`: adds `test_external_authority_member_clears_the_00074_enum_gap` to pin the post-#218 shape (a multi-engine set containing external_authority is not flagged), and updates the two docstrings that referenced the record's pre-#218 shape so the suite stays honest about what it mirrors.

**Verification (the CI commands, all green):**
- `python scripts/check_confidence_signal.py --json`: findings count 0 (was 1, AVE-2026-00074)
- `python scripts/write_verification_basis.py`: "All 80 records agree with their derived verification_basis." (exit 0)
- `python scripts/validate_records.py`: "All 80 records valid against schema/ave-record-1.1.0.schema.json." (exit 0; two pre-existing researcher-name warnings unrelated to this change)
- `python scripts/check_fixtures.py`: "All 80 records have positive and negative conformance fixtures." (exit 0)
- `python scripts/validate_crosswalks.py`: 9/9 valid (exit 0)
- `pytest tests/ -q`: 428 passed (CI-identical venv with `pip install -e ".[dev]"`)

Note: the record file remains non-canonical relative to write_verification_basis.py's serialisation (73 of 80 records on main are), so this change hand-edits only the one field and leaves the file's existing formatting untouched; corpus canonicalisation stays the separate work already named in #98.
