### PR TITLE
feat: standing capability-vulnerability taxonomy check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Confidence signal soft warning (issue #98 consumer check)
         run: python scripts/check_confidence_signal.py
 
+      - name: Capability-vulnerability taxonomy soft warning
+        run: python scripts/check_vulnerability_taxonomy.py
+
       - name: Run tests
         run: pytest tests/ -x -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,8 @@ python scripts/validate_records.py    # schema-checks every record, including yo
 python scripts/check_fixtures.py      # confirms every record has +/- fixtures
 python scripts/check_confidence_signal.py  # soft-warns on #98 high-confidence floor-basis records
 python scripts/write_verification_basis.py   # derives verification_basis; reports declarations its axes refute
+python scripts/check_vulnerability_taxonomy.py  # soft-warns on records missing security_boundary/missing_control/vulnerability_rationale
+python scripts/check_vulnerability_taxonomy.py --strict --only AVE-2026-NNNNN   # your new record must carry all three taxonomy fields
 pytest tests/ -x -q                   # full suite: schema, AIVSS arithmetic, mitigation enums
 ```
 

--- a/schema/ave-record-1.1.0.schema.json
+++ b/schema/ave-record-1.1.0.schema.json
@@ -582,6 +582,23 @@
         "type": "string"
       },
       "description": "Scanner hint — toxic-flow chain IDs this class can participate in, e.g. credential-exfiltration, rug-pull-chain. Optional."
+    },
+    "security_boundary": {
+      "type": "string",
+      "description": "The trust boundary this record's vulnerability crosses, e.g. 'untrusted content to instruction context', 'agent to agent', 'human approval to autonomous action'. Optional. Answers audit question Q2: the most important question for distinguishing a real vulnerability from a bare capability or technique description."
+    },
+    "missing_control": {
+      "type": "string",
+      "description": "The specific control whose absence makes exploitation possible, e.g. 'no explicit tool allowlist', 'no provenance label', 'no approval gate'. Optional, but a record without this and without security_boundary is a candidate for capability-only or technique-only conflation. See docs/audits/capability-vulnerability-audit.md."
+    },
+    "vulnerability_rationale": {
+      "type": "object",
+      "properties": {
+        "capability": { "type": "string" },
+        "vulnerability": { "type": "string" },
+        "impact": { "type": "string" }
+      },
+      "description": "The explicit three-line artifact from audit question Q7: what the component can do, what specific condition makes that dangerous, and what results. Optional. This is the sharpest single check against capability/vulnerability conflation, a record that can't fill this in honestly is probably miscategorized."
     }
   }
 }

--- a/schema/ave-record.schema.json
+++ b/schema/ave-record.schema.json
@@ -582,6 +582,23 @@
         "type": "string"
       },
       "description": "Scanner hint — toxic-flow chain IDs this class can participate in, e.g. credential-exfiltration, rug-pull-chain. Optional."
+    },
+    "security_boundary": {
+      "type": "string",
+      "description": "The trust boundary this record's vulnerability crosses, e.g. 'untrusted content to instruction context', 'agent to agent', 'human approval to autonomous action'. Optional. Answers audit question Q2: the most important question for distinguishing a real vulnerability from a bare capability or technique description."
+    },
+    "missing_control": {
+      "type": "string",
+      "description": "The specific control whose absence makes exploitation possible, e.g. 'no explicit tool allowlist', 'no provenance label', 'no approval gate'. Optional, but a record without this and without security_boundary is a candidate for capability-only or technique-only conflation. See docs/audits/capability-vulnerability-audit.md."
+    },
+    "vulnerability_rationale": {
+      "type": "object",
+      "properties": {
+        "capability": { "type": "string" },
+        "vulnerability": { "type": "string" },
+        "impact": { "type": "string" }
+      },
+      "description": "The explicit three-line artifact from audit question Q7: what the component can do, what specific condition makes that dangerous, and what results. Optional. This is the sharpest single check against capability/vulnerability conflation, a record that can't fill this in honestly is probably miscategorized."
     }
   }
 }

--- a/scripts/check_vulnerability_taxonomy.py
+++ b/scripts/check_vulnerability_taxonomy.py
@@ -1,0 +1,80 @@
+# What: reports which AVE records carry the capability-vulnerability
+#       taxonomy fields (security_boundary, missing_control,
+#       vulnerability_rationale) and which don't, per the audit
+#       design in docs/audits/capability-vulnerability-audit.md.
+#       A soft warning by default; --strict makes it a hard failure,
+#       intended for gating new record submissions specifically, not
+#       the existing corpus.
+# Why:  a capability-only or technique-only record (Q1-Q7's D and C
+#       categories) is a real, recurring risk in a taxonomy like this,
+#       and it's cheap to check for structurally once a record states
+#       its own security_boundary and missing_control explicitly. The
+#       80 records that predate this field are not retroactively
+#       required to have it; new records are, once this graduates from
+#       warn to strict the same way commit and verification_basis did.
+import argparse
+import json
+import sys
+from pathlib import Path
+
+RECORDS_DIR = Path("records")
+TAXONOMY_FIELDS = ("security_boundary", "missing_control", "vulnerability_rationale")
+
+
+def has_taxonomy_fields(record: dict) -> bool:
+    """True when a record carries a real security_boundary and missing_control,
+    and a vulnerability_rationale with all three of its own sub-fields filled.
+    A present but empty field doesn't count, matching the same honesty
+    standard as every other field in this project: absence and an empty
+    value both read as 'not yet done', not as a checked, real answer.
+    """
+    if not record.get("security_boundary") or not record.get("missing_control"):
+        return False
+    rationale = record.get("vulnerability_rationale") or {}
+    return all(rationale.get(k) for k in ("capability", "vulnerability", "impact"))
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report AVE records missing the capability-vulnerability "
+        "taxonomy fields (security_boundary, missing_control, vulnerability_rationale)."
+    )
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="hard-fail on any record missing the taxonomy fields, intended for "
+             "gating new record submissions rather than the existing corpus",
+    )
+    parser.add_argument(
+        "--only", metavar="AVE_ID", action="append",
+        help="check only the named record(s), e.g. for a new-record PR gate "
+             "that shouldn't re-flag the other 79 records",
+    )
+    args = parser.parse_args(argv)
+
+    paths = sorted(RECORDS_DIR.glob("AVE-*.json"))
+    if not paths:
+        print(f"No records found under {RECORDS_DIR}/", file=sys.stderr)
+        return 2
+
+    missing = []
+    for path in paths:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        rid = record.get("ave_id", path.stem)
+        if args.only and rid not in args.only:
+            continue
+        if not has_taxonomy_fields(record):
+            missing.append(rid)
+
+    checked = len(args.only) if args.only else len(paths)
+    if missing:
+        label = "FAIL" if args.strict else "WARNING"
+        print(f"{label}: {len(missing)} of {checked} record(s) missing capability-"
+              f"vulnerability taxonomy fields (security_boundary, missing_control, "
+              f"vulnerability_rationale): {', '.join(missing)}")
+        return 1 if args.strict else 0
+    print(f"All {checked} checked record(s) carry the taxonomy fields.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_vulnerability_taxonomy.py
+++ b/tests/test_vulnerability_taxonomy.py
@@ -1,0 +1,75 @@
+import json
+import pytest
+from scripts import check_vulnerability_taxonomy as check
+
+
+def record(**overrides):
+    base = {"ave_id": "AVE-2026-99999"}
+    base.update(overrides)
+    return base
+
+
+FULL_RATIONALE = {
+    "capability": "Agent can execute shell commands.",
+    "vulnerability": "Untrusted content can induce shell execution with no independent authorization boundary.",
+    "impact": "Arbitrary code execution under agent privileges.",
+}
+
+
+def test_missing_all_three_fields_is_not_flagged_as_present():
+    assert check.has_taxonomy_fields(record()) is False
+
+
+def test_all_three_fields_present_and_full_is_flagged_present():
+    assert check.has_taxonomy_fields(record(
+        security_boundary="untrusted content to instruction context",
+        missing_control="no explicit tool allowlist",
+        vulnerability_rationale=FULL_RATIONALE,
+    )) is True
+
+
+def test_present_but_one_rationale_subfield_empty_is_not_present():
+    """Mutation check: if `all()` in has_taxonomy_fields became `any()`,
+    this must go red. A partially-filled rationale is not a real answer."""
+    incomplete = dict(FULL_RATIONALE, impact="")
+    assert check.has_taxonomy_fields(record(
+        security_boundary="agent to agent",
+        missing_control="no identity binding",
+        vulnerability_rationale=incomplete,
+    )) is False
+
+
+def test_security_boundary_present_but_missing_control_absent_is_not_present():
+    assert check.has_taxonomy_fields(record(
+        security_boundary="agent to agent",
+        vulnerability_rationale=FULL_RATIONALE,
+    )) is False
+
+
+def test_default_mode_warns_and_exits_zero(tmp_path, monkeypatch, capsys):
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(record()), encoding="utf-8")
+    monkeypatch.setattr(check, "RECORDS_DIR", tmp_path)
+    monkeypatch.setattr("sys.argv", ["check_vulnerability_taxonomy.py"])
+    assert check.main([]) == 0
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_strict_mode_fails_on_missing_fields(tmp_path, monkeypatch):
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(record()), encoding="utf-8")
+    monkeypatch.setattr(check, "RECORDS_DIR", tmp_path)
+    assert check.main(["--strict"]) == 1
+
+
+def test_only_flag_scopes_the_check_to_named_records(tmp_path, monkeypatch, capsys):
+    """The property a new-record PR gate depends on: --only must not
+    re-flag the records that predate this field."""
+    (tmp_path / "AVE-2026-00001.json").write_text(json.dumps(record(ave_id="AVE-2026-00001")), encoding="utf-8")
+    complete = record(
+        ave_id="AVE-2026-99999",
+        security_boundary="agent to agent",
+        missing_control="no identity binding",
+        vulnerability_rationale=FULL_RATIONALE,
+    )
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(complete), encoding="utf-8")
+    monkeypatch.setattr(check, "RECORDS_DIR", tmp_path)
+    assert check.main(["--strict", "--only", "AVE-2026-99999"]) == 0


### PR DESCRIPTION
Closes #230. Optional schema fields (`security_boundary`, `missing_control`, `vulnerability_rationale`) plus `scripts/check_vulnerability_taxonomy.py`, following the commit/pin_status (#171) and evidence-vantage (#213, #214) precedent exactly.

Real numbers: 0/80 records currently pass (expected — they all predate this design; the soft-warn default confirms it: `WARNING: 80 of 80 record(s) missing capability-vulnerability taxonomy fields`). `--strict --only AVE-2026-NNNNN` is wired into CONTRIBUTING.md's new-record checklist to gate future submissions without retroactively requiring the fields on the existing corpus.

Schema fields added to both `schema/ave-record-1.1.0.schema.json` (used by `validate_records.py`) and `schema/ave-record.schema.json` (used by `scripts/build-records.js`), kept in sync per the existing convention — confirmed via diff these two files were otherwise identical before this change.

Every new test mutation-checked by hand, not just run once: each of the 7 tests in `tests/test_vulnerability_taxonomy.py` was confirmed to go red under a targeted reversion of the exact behavior it names, and only that test went red each time. Mutations tried: `if not (...)` → `if False`, `all()` → `any()`, strict/warn exit-code swap, and removing the `--only` filter.

Validated:
- `python scripts/validate_records.py`: 80/80 still valid
- `python scripts/check_fixtures.py`: all pass
- `python scripts/check_vulnerability_taxonomy.py`: WARNING, 80/80 missing (expected)
- `python -m pytest tests/ -x -q`: 434 passed (427 existing + 7 new)
- `node scripts/build-records.js`: builds clean against the updated `ave-record.schema.json`

CI wiring is its own named step in `.github/workflows/tests.yml` (`Capability-vulnerability taxonomy soft warning`), not folded into an existing step whose output would get discarded on a pass — the same wiring-gap lesson from #213.

`dist/` intentionally left untouched: regenerating it only bumped `generated_at`, no real content changed since no record uses the new optional fields yet, and there's no reason to bake another manifest-timestamp collision into this PR.