### PR TITLE
docs: cross-reference the boundary-failure record family

### DIFF
--- a/records/AVE-2026-00002.json
+++ b/records/AVE-2026-00002.json
@@ -4,7 +4,7 @@
   "component_type": "mcp_server",
   "title": "MCP tool description behavioral injection",
   "attack_class": "Prompt Injection - Tool Description",
-  "description": "An MCP server embeds behavioral instructions in tool description fields that are read by the agent during tool discovery. The agent treats these instructions as authoritative context, causing it to follow attacker-controlled directives. This attack fires before any tool is called, at the moment the agent reads the tool manifest.",
+  "description": "An MCP server embeds behavioral instructions in tool description fields that are read by the agent during tool discovery. The agent treats these instructions as authoritative context, causing it to follow attacker-controlled directives. This attack fires before any tool is called, at the moment the agent reads the tool manifest. This record shares its underlying failure with AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at the MCP tool-description field read during discovery, before any tool call occurs.",
   "affected_platforms": [
     "claude-desktop",
     "cursor",
@@ -90,7 +90,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-01T09:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00016.json
+++ b/records/AVE-2026-00016.json
@@ -4,7 +4,7 @@
   "component_type": "other",
   "title": "Indirect Prompt Injection via RAG Retrieval",
   "attack_class": "Prompt Injection - RAG Retrieval",
-  "description": "A Retrieval-Augmented Generation (RAG) pipeline indexes external documents and injects their content into the agent's context at query time. An attacker who controls any document in the indexed corpus can embed instructions that will be treated as trusted context when retrieved, effectively injecting into the agent's reasoning without direct access to the system prompt.",
+  "description": "A Retrieval-Augmented Generation (RAG) pipeline indexes external documents and injects their content into the agent's context at query time. An attacker who controls any document in the indexed corpus can embed instructions that will be treated as trusted context when retrieved, effectively injecting into the agent's reasoning without direct access to the system prompt. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at retrieved document content injected into the agent's context at RAG query time.",
   "affected_platforms": [
     "claude-code",
     "cursor",
@@ -88,7 +88,7 @@
   "researcher": "Zou et al.",
   "researcher_url": "https://arxiv.org/abs/2402.07867",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00020.json
+++ b/records/AVE-2026-00020.json
@@ -4,7 +4,7 @@
   "component_type": "skill",
   "title": "Cross-Agent Prompt Injection (A2A)",
   "attack_class": "Prompt Injection - Cross-Agent A2A",
-  "description": "In agentic pipelines where one agent delegates tasks to sub-agents (A2A - Agent to Agent), the output of the first agent becomes the input of the second. A malicious component in the first agent's context can craft output that contains instructions designed to be interpreted as commands by the sub-agent, bypassing the orchestrator's safety controls.",
+  "description": "In agentic pipelines where one agent delegates tasks to sub-agents (A2A - Agent to Agent), the output of the first agent becomes the input of the second. A malicious component in the first agent's context can craft output that contains instructions designed to be interpreted as commands by the sub-agent, bypassing the orchestrator's safety controls. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at a sub-agent's input, where one agent's output becomes the next agent's trusted instruction stream in an A2A delegation chain.",
   "affected_platforms": [
     "claude-code",
     "any-multi-agent-framework"
@@ -90,7 +90,7 @@
   "researcher": "Bawbel Security Research Team",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-09T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Cohen 2024",

--- a/records/AVE-2026-00028.json
+++ b/records/AVE-2026-00028.json
@@ -4,7 +4,7 @@
   "component_type": "skill",
   "title": "Prompt Injection via File or Document Content",
   "attack_class": "Prompt Injection - File Content",
-  "description": "When an agent is asked to process a user-uploaded document, the document's content should be treated as untrusted data, not as instructions. A component that explicitly tells the agent to follow or execute any instructions found in uploaded files creates a reliable indirect prompt injection vector - the attacker simply needs to convince the user to upload a crafted document.",
+  "description": "When an agent is asked to process a user-uploaded document, the document's content should be treated as untrusted data, not as instructions. A component that explicitly tells the agent to follow or execute any instructions found in uploaded files creates a reliable indirect prompt injection vector - the attacker simply needs to convince the user to upload a crafted document. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at a user-uploaded document's content, which a component explicitly directs the agent to treat as instructions rather than data.",
   "affected_platforms": [
     "claude-code",
     "cursor",
@@ -88,7 +88,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-04-19T09:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00041.json
+++ b/records/AVE-2026-00041.json
@@ -4,7 +4,7 @@
   "component_type": "mcp_server",
   "title": "Prompt injection via MCP server-card tool descriptions before agent makes first call",
   "attack_class": "Prompt Injection - MCP Server-Card Injection",
-  "description": "An attacker poisons the .well-known/mcp-server-card/server.json or .well-known/mcp.json file served by an MCP server. When an agent connects, it fetches the server-card and reads all tool descriptions before making a single tool call. Malicious behavioral instructions embedded in tool descriptions, parameter descriptions, or config schemas are loaded into the agent's context and executed immediately - before any user interaction occurs. This attack surface exists at the discovery layer, not the execution layer, making it invisible to runtime monitoring.",
+  "description": "An attacker poisons the .well-known/mcp-server-card/server.json or .well-known/mcp.json file served by an MCP server. When an agent connects, it fetches the server-card and reads all tool descriptions before making a single tool call. Malicious behavioral instructions embedded in tool descriptions, parameter descriptions, or config schemas are loaded into the agent's context and executed immediately - before any user interaction occurs. This attack surface exists at the discovery layer, not the execution layer, making it invisible to runtime monitoring. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at the MCP server-card fetched at connection time, before any tool call and outside runtime monitoring's reach.",
   "affected_platforms": [
     "claude-desktop",
     "claude-code",
@@ -77,7 +77,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00043.json
+++ b/records/AVE-2026-00043.json
@@ -4,7 +4,7 @@
   "component_type": "mcp_server",
   "title": "Prompt injection via rich UI payload (canvas, artifact, form) rendered by MCP App",
   "attack_class": "Prompt Injection - MCP App UI Payload Injection",
-  "description": "MCP Apps can render rich UI elements - canvases, artifacts, interactive forms, and embedded content - directly in the agent's interface. An attacker crafts a UI payload that renders visually benign content to the user while embedding prompt injection instructions in metadata, alt text, accessibility attributes, or hidden elements that the underlying model reads. The agent acts on the injected instructions while the user sees only the harmless rendered surface. This attack exploits the gap between what the user sees and what the model processes.",
+  "description": "MCP Apps can render rich UI elements - canvases, artifacts, interactive forms, and embedded content - directly in the agent's interface. An attacker crafts a UI payload that renders visually benign content to the user while embedding prompt injection instructions in metadata, alt text, accessibility attributes, or hidden elements that the underlying model reads. The agent acts on the injected instructions while the user sees only the harmless rendered surface. This attack exploits the gap between what the user sees and what the model processes. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here in the gap between a rendered UI surface the user sees and the underlying metadata the model actually reads.",
   "affected_platforms": [
     "claude-desktop",
     "claude-code",
@@ -74,7 +74,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00044.json
+++ b/records/AVE-2026-00044.json
@@ -4,7 +4,7 @@
   "component_type": "skill",
   "title": "Prompt injection via poisoned async task result injected into future agent context",
   "attack_class": "Prompt Injection - Async Task Result Poisoning",
-  "description": "Agentic workflows increasingly use async task queues where the agent dispatches a task, continues other work, and later reads the result. An attacker who controls the task result delivery mechanism (a queue, webhook, or polling endpoint) injects malicious instructions into the result payload. When the agent reads the result in a future turn, the injected content is interpreted as trusted context from a completed task - not as external untrusted input. The temporal gap between task dispatch and result consumption bypasses synchronous safety checks.",
+  "description": "Agentic workflows increasingly use async task queues where the agent dispatches a task, continues other work, and later reads the result. An attacker who controls the task result delivery mechanism (a queue, webhook, or polling endpoint) injects malicious instructions into the result payload. When the agent reads the result in a future turn, the injected content is interpreted as trusted context from a completed task - not as external untrusted input. The temporal gap between task dispatch and result consumption bypasses synchronous safety checks. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at an async task result payload, read across a temporal gap as trusted completed-task context rather than external input.",
   "affected_platforms": [
     "claude-code",
     "any-agent-with-async-task-execution",
@@ -71,7 +71,7 @@
   "researcher": "Saray Chak",
   "researcher_url": "https://bawbel.io",
   "published": "2026-05-01T00:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Greshake 2023",

--- a/records/AVE-2026-00065.json
+++ b/records/AVE-2026-00065.json
@@ -6,7 +6,7 @@
   "title": "A2A agent card poisoning via embedded adversarial instructions",
   "attack_class": "Prompt Injection - A2A Agent Card Poisoning",
   "severity": "HIGH",
-  "description": "A malicious remote agent embeds adversarial instructions within its A2A (Agent-to-Agent) protocol agent card, the structured metadata document describing its capabilities, endpoints, and operational details that a host agent uses to plan task delegation. When agent cards are injected directly into an LLM's reasoning context without strict boundary enforcement, the metadata is reinterpreted as executable instruction rather than descriptive data. This differs from MCP server-card injection (AVE-2026-00041) in protocol, discovery mechanism, and payload surface; A2A has no fixed .well-known path convention and no tool.description field, the payload lives in the agent's own self-declared identity and capability claims within a peer discovery and delegation exchange, not a file fetched before a tool call.",
+  "description": "A malicious remote agent embeds adversarial instructions within its A2A (Agent-to-Agent) protocol agent card, the structured metadata document describing its capabilities, endpoints, and operational details that a host agent uses to plan task delegation. When agent cards are injected directly into an LLM's reasoning context without strict boundary enforcement, the metadata is reinterpreted as executable instruction rather than descriptive data. This differs from MCP server-card injection (AVE-2026-00041) in protocol, discovery mechanism, and payload surface; A2A has no fixed .well-known path convention and no tool.description field, the payload lives in the agent's own self-declared identity and capability claims within a peer discovery and delegation exchange, not a file fetched before a tool call. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, and AVE-2026-00044: the same missing content-versus-instruction boundary, realized here at a remote agent's self-declared A2A agent-card metadata, read as trusted capability description rather than untrusted peer input.",
   "affected_platforms": [
     "any-a2a-protocol-implementation"
   ],
@@ -54,7 +54,7 @@
   "researcher": "Kumar Aditya",
   "researcher_url": "https://www.keysight.com/blogs/en/tech/nwvs/2026/03/12/agent-card-poisoning",
   "published": "2026-07-27T00:00:00Z",
-  "last_updated": "2026-08-26T00:00:00Z",
+  "last_updated": "2026-08-29T00:00:00Z",
   "references": [
     {
       "tag": "Keysight research",


### PR DESCRIPTION
Closes #232. Adds a cross-reference sentence to each of the 8 records PR #224 identified as the same missing content-versus-instruction boundary at different entry points: AVE-2026-00002, 00016, 00020, 00028, 00041, 00043, 00044, 00065.

Text-only, no schema change, per Finding 3's conclusion that this corpus's real gaps are prose, not structure.

Each of the 8 gets its own specific entry-point phrasing rather than identical pasted text:
- 00002: tool-description field, read at discovery, before any tool call
- 00016: retrieved document content, injected at RAG query time
- 00020: sub-agent input, in an A2A delegation chain
- 00028: uploaded document content, directed to be treated as instructions
- 00041: MCP server-card, fetched at connection time, outside runtime monitoring
- 00043: gap between the rendered UI surface and the metadata the model reads
- 00044: async task result payload, read across a temporal gap
- 00065: A2A agent-card self-declared metadata

00065 already carried a differentiation sentence contrasting itself with 00041; the new family cross-reference is appended after it rather than replacing it.

Validated:
- `python scripts/validate_records.py`: 80/80 valid (only pre-existing, unrelated researcher-attribution warnings)
- `python scripts/check_fixtures.py`: all pass
- `python -m pytest tests/ -x -q`: 427 passed

Real, current description text pulled fresh from `dist/ave-records-latest.json` before editing, confirmed unchanged since the audit ran.