### PR TITLE
Split the confidence floor warning into two named findings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Confidence signal soft warning (issue #98 consumer check)
         run: python scripts/check_confidence_signal.py
 
+      - name: Capability-vulnerability taxonomy soft warning
+        run: python scripts/check_vulnerability_taxonomy.py
+
       - name: Run tests
         run: pytest tests/ -x -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Format: [Semantic Versioning](https://semver.org). Schema versions and record se
 ## [Unreleased]
 
 ### Changed
+- `scripts/check_confidence_signal.py` now reports two named findings
+  rather than one warning. Running its engine-set cardinality test and
+  the `verification_basis` derivation against each other over the same
+  `evidence_basis_engines` field showed neither subsumes the other: two
+  engines that both read artifact-produced content derive
+  `artifact_intercepted` and cardinality stayed silent, while a single
+  `sandbox` engine derives `substrate_intercepted` and cardinality
+  flagged it. Cardinality measures corroboration, how many independent
+  sources agreed; the derivation measures vantage, where the observation
+  was made from. Both signals are real and they take different repairs,
+  so the check emits `vantage_floor` and `independence_floor` separately
+  and a record may carry both, one, or neither. The vantage arm imports
+  the derivation from `scripts/write_verification_basis.py` rather than
+  recomputing it, and derives even where a record carries a stamped
+  `verification_basis`, since the stamp is the author's own copy. On the
+  current corpus this turns 0 findings into 8 `vantage_floor` findings
+  across 8 records — all of them records that declare a high
+  `confidence_baseline` and no `evidence_vantage` at all. Still a soft
+  warning; the exit code is untouched. `--json` gains a `finding` key per
+  entry and a `records` count alongside `count`. Consumer guidance in
+  `docs/guides/confidence-baseline-consumer-guide.md`.
 - AVE-2026-00070: `researcher`/`researcher_url` correction — was
   listed as "Saray Chak" / bawbel.io despite the record's own
   `references` entry already citing the actual external source (Zhu,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,8 @@ python scripts/validate_records.py    # schema-checks every record, including yo
 python scripts/check_fixtures.py      # confirms every record has +/- fixtures
 python scripts/check_confidence_signal.py  # soft-warns on #98 high-confidence floor-basis records
 python scripts/write_verification_basis.py   # derives verification_basis; reports declarations its axes refute
+python scripts/check_vulnerability_taxonomy.py  # soft-warns on records missing security_boundary/missing_control/vulnerability_rationale
+python scripts/check_vulnerability_taxonomy.py --strict --only AVE-2026-NNNNN   # your new record must carry all three taxonomy fields
 pytest tests/ -x -q                   # full suite: schema, AIVSS arithmetic, mitigation enums
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ description. Reviewers will ask for this if it is missing.
 pip install -e ".[dev]"
 python scripts/validate_records.py    # schema-checks every record, including yours
 python scripts/check_fixtures.py      # confirms every record has +/- fixtures
-python scripts/check_confidence_signal.py  # soft-warns on #98 high-confidence floor-basis records
+python scripts/check_confidence_signal.py  # soft-warns on #98 high-confidence records, naming the vantage and independence floors separately
 python scripts/write_verification_basis.py   # derives verification_basis; reports declarations its axes refute
 python scripts/check_vulnerability_taxonomy.py  # soft-warns on records missing security_boundary/missing_control/vulnerability_rationale
 python scripts/check_vulnerability_taxonomy.py --strict --only AVE-2026-NNNNN   # your new record must carry all three taxonomy fields

--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -297,7 +297,7 @@
     "component_type": "mcp_server",
     "title": "MCP tool description behavioral injection",
     "attack_class": "Prompt Injection - Tool Description",
-    "description": "An MCP server embeds behavioral instructions in tool description fields that are read by the agent during tool discovery. The agent treats these instructions as authoritative context, causing it to follow attacker-controlled directives. This attack fires before any tool is called, at the moment the agent reads the tool manifest.",
+    "description": "An MCP server embeds behavioral instructions in tool description fields that are read by the agent during tool discovery. The agent treats these instructions as authoritative context, causing it to follow attacker-controlled directives. This attack fires before any tool is called, at the moment the agent reads the tool manifest. This record shares its underlying failure with AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at the MCP tool-description field read during discovery, before any tool call occurs.",
     "affected_platforms": [
       "claude-desktop",
       "cursor",
@@ -385,7 +385,7 @@
     "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-04-01T09:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Greshake 2023",
@@ -557,7 +557,7 @@
     "component_type": "mcp_server",
     "title": "Prompt injection via MCP server-card tool descriptions before agent makes first call",
     "attack_class": "Prompt Injection - MCP Server-Card Injection",
-    "description": "An attacker poisons the .well-known/mcp-server-card/server.json or .well-known/mcp.json file served by an MCP server. When an agent connects, it fetches the server-card and reads all tool descriptions before making a single tool call. Malicious behavioral instructions embedded in tool descriptions, parameter descriptions, or config schemas are loaded into the agent's context and executed immediately - before any user interaction occurs. This attack surface exists at the discovery layer, not the execution layer, making it invisible to runtime monitoring.",
+    "description": "An attacker poisons the .well-known/mcp-server-card/server.json or .well-known/mcp.json file served by an MCP server. When an agent connects, it fetches the server-card and reads all tool descriptions before making a single tool call. Malicious behavioral instructions embedded in tool descriptions, parameter descriptions, or config schemas are loaded into the agent's context and executed immediately - before any user interaction occurs. This attack surface exists at the discovery layer, not the execution layer, making it invisible to runtime monitoring. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at the MCP server-card fetched at connection time, before any tool call and outside runtime monitoring's reach.",
     "affected_platforms": [
       "claude-desktop",
       "claude-code",
@@ -632,7 +632,7 @@
     "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-05-01T00:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Greshake 2023",
@@ -1971,7 +1971,7 @@
     "title": "A2A agent card poisoning via embedded adversarial instructions",
     "attack_class": "Prompt Injection - A2A Agent Card Poisoning",
     "severity": "HIGH",
-    "description": "A malicious remote agent embeds adversarial instructions within its A2A (Agent-to-Agent) protocol agent card, the structured metadata document describing its capabilities, endpoints, and operational details that a host agent uses to plan task delegation. When agent cards are injected directly into an LLM's reasoning context without strict boundary enforcement, the metadata is reinterpreted as executable instruction rather than descriptive data. This differs from MCP server-card injection (AVE-2026-00041) in protocol, discovery mechanism, and payload surface; A2A has no fixed .well-known path convention and no tool.description field, the payload lives in the agent's own self-declared identity and capability claims within a peer discovery and delegation exchange, not a file fetched before a tool call.",
+    "description": "A malicious remote agent embeds adversarial instructions within its A2A (Agent-to-Agent) protocol agent card, the structured metadata document describing its capabilities, endpoints, and operational details that a host agent uses to plan task delegation. When agent cards are injected directly into an LLM's reasoning context without strict boundary enforcement, the metadata is reinterpreted as executable instruction rather than descriptive data. This differs from MCP server-card injection (AVE-2026-00041) in protocol, discovery mechanism, and payload surface; A2A has no fixed .well-known path convention and no tool.description field, the payload lives in the agent's own self-declared identity and capability claims within a peer discovery and delegation exchange, not a file fetched before a tool call. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, and AVE-2026-00044: the same missing content-versus-instruction boundary, realized here at a remote agent's self-declared A2A agent-card metadata, read as trusted capability description rather than untrusted peer input.",
     "affected_platforms": [
       "any-a2a-protocol-implementation"
     ],
@@ -2032,7 +2032,7 @@
     "researcher": "Kumar Aditya",
     "researcher_url": "https://www.keysight.com/blogs/en/tech/nwvs/2026/03/12/agent-card-poisoning",
     "published": "2026-07-27T00:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Keysight research",
@@ -2210,7 +2210,8 @@
     "detection_layer": "content",
     "confidence_baseline": 0.85,
     "evidence_basis_engines": [
-      "pattern"
+      "pattern",
+      "external_authority"
     ],
     "derivable_into": [
       "remote-control-chain"
@@ -3658,7 +3659,7 @@
     "component_type": "other",
     "title": "Indirect Prompt Injection via RAG Retrieval",
     "attack_class": "Prompt Injection - RAG Retrieval",
-    "description": "A Retrieval-Augmented Generation (RAG) pipeline indexes external documents and injects their content into the agent's context at query time. An attacker who controls any document in the indexed corpus can embed instructions that will be treated as trusted context when retrieved, effectively injecting into the agent's reasoning without direct access to the system prompt.",
+    "description": "A Retrieval-Augmented Generation (RAG) pipeline indexes external documents and injects their content into the agent's context at query time. An attacker who controls any document in the indexed corpus can embed instructions that will be treated as trusted context when retrieved, effectively injecting into the agent's reasoning without direct access to the system prompt. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at retrieved document content injected into the agent's context at RAG query time.",
     "affected_platforms": [
       "claude-code",
       "cursor",
@@ -3745,7 +3746,7 @@
     "researcher": "Zou et al.",
     "researcher_url": "https://arxiv.org/abs/2402.07867",
     "published": "2026-04-19T09:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Greshake 2023",
@@ -4160,7 +4161,7 @@
     "component_type": "skill",
     "title": "Cross-Agent Prompt Injection (A2A)",
     "attack_class": "Prompt Injection - Cross-Agent A2A",
-    "description": "In agentic pipelines where one agent delegates tasks to sub-agents (A2A - Agent to Agent), the output of the first agent becomes the input of the second. A malicious component in the first agent's context can craft output that contains instructions designed to be interpreted as commands by the sub-agent, bypassing the orchestrator's safety controls.",
+    "description": "In agentic pipelines where one agent delegates tasks to sub-agents (A2A - Agent to Agent), the output of the first agent becomes the input of the second. A malicious component in the first agent's context can craft output that contains instructions designed to be interpreted as commands by the sub-agent, bypassing the orchestrator's safety controls. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at a sub-agent's input, where one agent's output becomes the next agent's trusted instruction stream in an A2A delegation chain.",
     "affected_platforms": [
       "claude-code",
       "any-multi-agent-framework"
@@ -4246,7 +4247,7 @@
     "researcher": "Bawbel Security Research Team",
     "researcher_url": "https://bawbel.io",
     "published": "2026-04-19T09:00:00Z",
-    "last_updated": "2026-08-09T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Cohen 2024",
@@ -5151,7 +5152,7 @@
     "component_type": "skill",
     "title": "Prompt Injection via File or Document Content",
     "attack_class": "Prompt Injection - File Content",
-    "description": "When an agent is asked to process a user-uploaded document, the document's content should be treated as untrusted data, not as instructions. A component that explicitly tells the agent to follow or execute any instructions found in uploaded files creates a reliable indirect prompt injection vector - the attacker simply needs to convince the user to upload a crafted document.",
+    "description": "When an agent is asked to process a user-uploaded document, the document's content should be treated as untrusted data, not as instructions. A component that explicitly tells the agent to follow or execute any instructions found in uploaded files creates a reliable indirect prompt injection vector - the attacker simply needs to convince the user to upload a crafted document. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00041, AVE-2026-00043, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at a user-uploaded document's content, which a component explicitly directs the agent to treat as instructions rather than data.",
     "affected_platforms": [
       "claude-code",
       "cursor",
@@ -5237,7 +5238,7 @@
     "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-04-19T09:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Greshake 2023",
@@ -6929,7 +6930,7 @@
     "component_type": "mcp_server",
     "title": "Prompt injection via rich UI payload (canvas, artifact, form) rendered by MCP App",
     "attack_class": "Prompt Injection - MCP App UI Payload Injection",
-    "description": "MCP Apps can render rich UI elements - canvases, artifacts, interactive forms, and embedded content - directly in the agent's interface. An attacker crafts a UI payload that renders visually benign content to the user while embedding prompt injection instructions in metadata, alt text, accessibility attributes, or hidden elements that the underlying model reads. The agent acts on the injected instructions while the user sees only the harmless rendered surface. This attack exploits the gap between what the user sees and what the model processes.",
+    "description": "MCP Apps can render rich UI elements - canvases, artifacts, interactive forms, and embedded content - directly in the agent's interface. An attacker crafts a UI payload that renders visually benign content to the user while embedding prompt injection instructions in metadata, alt text, accessibility attributes, or hidden elements that the underlying model reads. The agent acts on the injected instructions while the user sees only the harmless rendered surface. This attack exploits the gap between what the user sees and what the model processes. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00044, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here in the gap between a rendered UI surface the user sees and the underlying metadata the model actually reads.",
     "affected_platforms": [
       "claude-desktop",
       "claude-code",
@@ -6999,7 +7000,7 @@
     "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-05-01T00:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Greshake 2023",
@@ -7065,7 +7066,7 @@
     "component_type": "skill",
     "title": "Prompt injection via poisoned async task result injected into future agent context",
     "attack_class": "Prompt Injection - Async Task Result Poisoning",
-    "description": "Agentic workflows increasingly use async task queues where the agent dispatches a task, continues other work, and later reads the result. An attacker who controls the task result delivery mechanism (a queue, webhook, or polling endpoint) injects malicious instructions into the result payload. When the agent reads the result in a future turn, the injected content is interpreted as trusted context from a completed task - not as external untrusted input. The temporal gap between task dispatch and result consumption bypasses synchronous safety checks.",
+    "description": "Agentic workflows increasingly use async task queues where the agent dispatches a task, continues other work, and later reads the result. An attacker who controls the task result delivery mechanism (a queue, webhook, or polling endpoint) injects malicious instructions into the result payload. When the agent reads the result in a future turn, the injected content is interpreted as trusted context from a completed task - not as external untrusted input. The temporal gap between task dispatch and result consumption bypasses synchronous safety checks. This record shares its underlying failure with AVE-2026-00002, AVE-2026-00016, AVE-2026-00020, AVE-2026-00028, AVE-2026-00041, AVE-2026-00043, and AVE-2026-00065: the same missing content-versus-instruction boundary, realized here at an async task result payload, read across a temporal gap as trusted completed-task context rather than external input.",
     "affected_platforms": [
       "claude-code",
       "any-agent-with-async-task-execution",
@@ -7134,7 +7135,7 @@
     "researcher": "Saray Chak",
     "researcher_url": "https://bawbel.io",
     "published": "2026-05-01T00:00:00Z",
-    "last_updated": "2026-08-26T00:00:00Z",
+    "last_updated": "2026-08-29T00:00:00Z",
     "references": [
       {
         "tag": "Greshake 2023",

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 80,
-  "generated_at": "2026-08-29T03:57:22.345Z",
+  "generated_at": "2026-08-30T00:47:26.044Z",
   "source": "https://github.com/aveproject/ave"
 }

--- a/docs/guides/confidence-baseline-consumer-guide.md
+++ b/docs/guides/confidence-baseline-consumer-guide.md
@@ -15,27 +15,64 @@ speculative pattern match. That asymmetry is the gap this issue names.
 ## How to read it (bands)
 
 - `>= 0.85` — "high-signal" band. Only act on this band when the record's
-  derived evidence basis is structurally strong (multiple engines, or a
-  non-inferred evidence kind).
+  evidence is both observed from a vantage the artifact does not control
+  and corroborated by more than one source.
 - `0.55 to 0.84` — "mid-signal" band. Consistent with a floor basis; treat
   as an unverified declaration unless the basis is strong.
 - `< 0.55` — "low-signal" band. Consistent with a floor basis; safe to
   treat as low-confidence regardless of basis.
 
-## When to distrust the number
+## When to distrust the number: two findings, not one
 
-A record whose `confidence_baseline` is `>= 0.85` while its derived basis
-is at the floor is a "declared, not structurally verified" signal. The
-floor is defined as:
+A record whose `confidence_baseline` is `>= 0.85` can be resting on either
+of two weaknesses, and they are independent. Neither implies the other, so
+a consumer is told which:
 
-- `evidence_basis_engines` has one member (regardless of which engine), or
-- `evidence_kind_default` is `semantic_inference`.
+- **`vantage_floor`** — the observation was made from a place the observed
+  artifact controls. Either the record's derived `verification_basis` puts
+  it at the `artifact` rung, or its `evidence_kind_default` is
+  `semantic_inference`, which is an inference over content the artifact
+  produced however good the inference. Remedied by observing from a vantage
+  the artifact can neither forge nor suppress — a sandbox watching
+  execution from outside, an external authority answering about it — and
+  declaring that on `evidence_vantage`.
+- **`independence_floor`** — the evidence rests on a single source:
+  `evidence_basis_engines` names at most one legible member. Remedied by
+  corroborating with a second, independent engine.
 
-`scripts/check_confidence_signal.py` computes this for every record in
+A record can carry both, one, or neither.
+
+These were one check until the two predicates were run against each other
+over the same field. Engine-set cardinality was the check's original floor
+test, chosen when no measure of vantage existed, and it turns out not to
+approximate vantage at all: a record with two engines that both read
+artifact-produced content derives `artifact_intercepted` and cardinality
+stays silent, while a record with a single `sandbox` engine derives
+`substrate_intercepted` and cardinality flags it. Cardinality measures
+**corroboration**, how many independent sources agreed. The derivation
+measures **vantage**, where the observation was made from. Both are worth
+knowing and they are fixed by different work, so they are reported
+separately rather than collapsed into one warning a consumer cannot act
+on.
+
+`scripts/check_confidence_signal.py` computes both for every record in
 `records/`. It is a soft warning: it prints findings and leaves the exit
 code alone (the same shape as `check_researcher_matches_disclosure` in
 `validate_records.py`), so it fits next to the existing validator machinery
-without changing gate behaviour.
+without changing gate behaviour. `--json` emits
+`{"findings": [{"ave_id", "finding", "signal"}], "count", "records"}`,
+where `finding` is `vantage_floor` or `independence_floor`, `count` is
+findings and `records` is the records they fall on.
+
+The vantage arm asks `scripts/write_verification_basis.py` for the derived
+vantage rather than recomputing it, and derives even where a record carries
+a stamped `verification_basis`. Two reasons: a second predicate over the
+same field is what produced the disagreement above, and the stamp is what
+an author typed, so a consumer-side check reading it would be reading a
+self-report. A record that declares no `evidence_vantage` derives the
+floor — silence is never credited as a claim — so this arm does fire on
+records that simply have not said. Stating the floor is free; stating it
+alongside a 0.9 is the combination this check exists to surface.
 
 ## The disagreement rule
 
@@ -49,25 +86,39 @@ own.
 ## Known false-positive shape
 
 AVE-2026-00074 is deliberately shipped as the fixture for this check. Its
-`confidence_baseline` (0.85) sits at the high band while its basis reads as
-a floor, but its own `detection_methodology` says the finding came from
-querying external authorities (GitHub's users API, package registries,
-RDAP, provider fingerprints). The floor there is an enum gap:
-`evidence_basis_engines` has no member for "an external authority was
-queried and returned a determinate answer." The honest author wrote the
+`confidence_baseline` (0.85) sits at the high band while its own
+`detection_methodology` says the finding came from querying external
+authorities (GitHub's users API, package registries, RDAP, provider
+fingerprints). Before issue #218 the floor there was an enum gap:
+`evidence_basis_engines` had no member for "an external authority was
+queried and returned a determinate answer", so the honest author wrote the
 nearest available value and the derived basis came out at the floor.
 
-The check prints a note on this shape so it reads as an enum gap, not an
-overclaim.
+The check prints a note on this shape so it reads as an enum gap rather
+than an overclaim, and the note has two forms because the gap can now be
+closed. A record whose engine set still cannot reach `substrate` gets the
+original sentence: add the `external_authority` member. A record that has
+already adopted the member — AVE-2026-00074 since #218 — is told the
+opposite: its ceiling permits `substrate` and what holds it at the floor is
+that it has never declared `evidence_vantage`. Sending that author looking
+for a missing enum member would be sending them after a bug that is not
+there.
 
 ## Escalation condition
 
 Per the issue thread: when `evidence_basis_engines` carries a member for an
 external-authority query (the thread's agreed name: `external_authority`),
-and a re-run of this check fires zero times on any record whose
-`detection_methodology` names an authority probe, the field has earned its
-version bump. Both halves of that condition are read off the schema and the
-data, so it needs no date, constant, curation queue, or outcome tracking.
+and a re-run of this check emits the enum-gap form of the note on no record
+at all, the field has earned its version bump. Both halves of that
+condition are read off the schema and the data, so it needs no date,
+constant, curation queue, or outcome tracking.
+
+Note what that condition is now careful not to say. A record naming an
+authority probe can still carry a `vantage_floor` finding after adopting
+the member, because adopting it raises the ceiling and the record must
+still declare the vantage it reached. That is a producer's remaining step,
+not evidence of a vocabulary gap, and it is the enum-gap note rather than
+the finding that has to fall silent.
 
 ## Normalisation
 

--- a/schema/ave-record-1.1.0.schema.json
+++ b/schema/ave-record-1.1.0.schema.json
@@ -582,6 +582,23 @@
         "type": "string"
       },
       "description": "Scanner hint — toxic-flow chain IDs this class can participate in, e.g. credential-exfiltration, rug-pull-chain. Optional."
+    },
+    "security_boundary": {
+      "type": "string",
+      "description": "The trust boundary this record's vulnerability crosses, e.g. 'untrusted content to instruction context', 'agent to agent', 'human approval to autonomous action'. Optional. Answers audit question Q2: the most important question for distinguishing a real vulnerability from a bare capability or technique description."
+    },
+    "missing_control": {
+      "type": "string",
+      "description": "The specific control whose absence makes exploitation possible, e.g. 'no explicit tool allowlist', 'no provenance label', 'no approval gate'. Optional, but a record without this and without security_boundary is a candidate for capability-only or technique-only conflation. See docs/audits/capability-vulnerability-audit.md."
+    },
+    "vulnerability_rationale": {
+      "type": "object",
+      "properties": {
+        "capability": { "type": "string" },
+        "vulnerability": { "type": "string" },
+        "impact": { "type": "string" }
+      },
+      "description": "The explicit three-line artifact from audit question Q7: what the component can do, what specific condition makes that dangerous, and what results. Optional. This is the sharpest single check against capability/vulnerability conflation, a record that can't fill this in honestly is probably miscategorized."
     }
   }
 }

--- a/schema/ave-record.schema.json
+++ b/schema/ave-record.schema.json
@@ -582,6 +582,23 @@
         "type": "string"
       },
       "description": "Scanner hint — toxic-flow chain IDs this class can participate in, e.g. credential-exfiltration, rug-pull-chain. Optional."
+    },
+    "security_boundary": {
+      "type": "string",
+      "description": "The trust boundary this record's vulnerability crosses, e.g. 'untrusted content to instruction context', 'agent to agent', 'human approval to autonomous action'. Optional. Answers audit question Q2: the most important question for distinguishing a real vulnerability from a bare capability or technique description."
+    },
+    "missing_control": {
+      "type": "string",
+      "description": "The specific control whose absence makes exploitation possible, e.g. 'no explicit tool allowlist', 'no provenance label', 'no approval gate'. Optional, but a record without this and without security_boundary is a candidate for capability-only or technique-only conflation. See docs/audits/capability-vulnerability-audit.md."
+    },
+    "vulnerability_rationale": {
+      "type": "object",
+      "properties": {
+        "capability": { "type": "string" },
+        "vulnerability": { "type": "string" },
+        "impact": { "type": "string" }
+      },
+      "description": "The explicit three-line artifact from audit question Q7: what the component can do, what specific condition makes that dangerous, and what results. Optional. This is the sharpest single check against capability/vulnerability conflation, a record that can't fill this in honestly is probably miscategorized."
     }
   }
 }

--- a/scripts/check_confidence_signal.py
+++ b/scripts/check_confidence_signal.py
@@ -1,29 +1,87 @@
 # What: consumer-side confidence signal check for AVE records. Reads every
-#       record in records/ and reports the ones whose self-reported
-#       confidence_baseline sits at the high band while their derived
-#       evidence basis sits at the floor, the exact shape issue #98 names:
-#       "a float the record's author assigns ... the same shape whether the
-#       underlying evidence is a formally disclosed CVE or a speculative
-#       pattern match."
+#       record in records/ and, for each one whose self-reported
+#       confidence_baseline sits in the high band, reports which weakness the
+#       number is resting on. There are two, they are independent, and a record
+#       may carry both, one or neither:
+#         - a vantage floor -- the observation was made from a place the
+#           observed artifact controls. Remedied by observing from a better
+#           place.
+#         - an independence floor -- the evidence rests on a single source.
+#           Remedied by adding a second source.
+#       This is the shape issue #98 names: "a float the record's author assigns
+#       ... the same shape whether the underlying evidence is a formally
+#       disclosed CVE or a speculative pattern match."
 # Why:  confidence_baseline is self-reported today; nothing external verifies
 #       it. A compliance team building workflows on AVE-classified findings
 #       (the r/ai_governance angle in #98) needs to know which records'
-#       confidence they can act on and which are declarations resting on
-#       pattern-level inference alone. This check makes that distinction
-#       computable without a schema change: it reads fields that already
-#       exist on every record.
-# How:  high = confidence_baseline >= HIGH_CONFIDENCE (0.85, matching the
-#       schema's "high-signal" band). Floor = the evidence basis carries a
-#       single engine member (regardless of which) or evidence_kind_default
-#       is semantic_inference. A record in both sets is a "declared, not
-#       structurally verified" signal. List ordering is normalized by
-#       comparing engine sets, so the check sees 13 distinct bases where the
-#       files write them 18 ways (issue #98 comment 2026-08-20). The check
-#       is a soft warning: it prints findings and leaves the exit code
-#       alone, the same shape as check_researcher_matches_disclosure in
+#       confidence they can act on, and -- this is the part a single warning
+#       could not tell them -- what would fix a record that they cannot.
+#
+#       This check predates verification_basis. It floored on engine-set
+#       cardinality because when it was written no measure of vantage existed,
+#       so "one engine" was the available proxy for "weak evidence". One exists
+#       now, and running both predicates over the same field shows the proxy
+#       was never approximating vantage at all. Four combinations, each with
+#       evidence_vantage=substrate, evidence_method=intercepted and
+#       confidence_baseline=0.9:
+#
+#         engines                          cardinality   derived basis
+#         two, neither substrate-capable   silent        artifact_intercepted
+#         one, substrate-capable           fires         substrate_intercepted
+#         one, not substrate-capable       fires         artifact_intercepted
+#         two, one substrate-capable       silent        substrate_intercepted
+#
+#       The first row is a record with a floor-level basis that the check let
+#       through; the second is a record with the strongest basis available that
+#       the check flagged. Neither predicate subsumes the other because they
+#       measure different properties: cardinality measures CORROBORATION, how
+#       many independent sources agreed, and the derivation measures VANTAGE,
+#       where the observation was made from. A record can fail either without
+#       failing the other, and the two are fixed by different work.
+#
+#       So neither retiring cardinality for the derivation nor OR-ing the two
+#       together is the fix. The first drops the corroboration signal, which is
+#       real. The second reports both faults under one string, which leaves a
+#       consumer knowing a record is weak and not knowing which weakness it has
+#       or what would clear it. This project names the thing that is wrong
+#       rather than the bucket it falls in -- the same discipline
+#       check_vulnerability_taxonomy.py applies to security_boundary and
+#       missing_control -- so the check reports two findings and says which.
+# How:  high band = confidence_baseline >= HIGH_CONFIDENCE (0.85, matching the
+#       schema's "high-signal" band), tested once, in confidence_signals(),
+#       because both findings are about a high number and neither is a finding
+#       without one.
+#
+#       The vantage arm asks scripts/write_verification_basis.py for the
+#       derived vantage rather than recomputing it. That import is the point:
+#       a second predicate over the same field is precisely the defect this
+#       split repairs, and validate_records.py already hard-fails a declared
+#       verification_basis the derivation refutes, so the derivation is this
+#       corpus's single answer to "where was this observed from". The check
+#       derives even where a record carries a stamped verification_basis: the
+#       stamp is what the author typed and the derivation is what the record's
+#       axes support, and a consumer-side check reading the author's copy would
+#       be reading a self-report, which is the complaint in #98 wearing a
+#       better field name. Note that a record declaring no vantage derives the
+#       floor -- silence is never credited as a claim, per the producer guide --
+#       so this arm does fire on records that have simply not said. That is
+#       correct and the message says so: stating the floor is free, and stating
+#       it alongside 0.9 is the combination #98 was opened about.
+#
+#       The independence arm keeps the cardinality test, on the set rather than
+#       the list, and now over the legible members only: a duplicated member is
+#       one source wearing a list of length two (astrogilda's attack test,
+#       2026-08-26) and a malformed member is not a source at all, the same
+#       reading write_verification_basis.py gives a malformed engine field.
+#       List ordering is normalised by comparing sets, so the check sees 13
+#       distinct bases where the files write them 18 ways (issue #98 comment
+#       2026-08-20).
+#
+#       The check is a soft warning: it prints findings and leaves the exit
+#       code alone, the same shape as check_researcher_matches_disclosure in
 #       validate_records.py. Escalation condition (per the thread): when
 #       evidence_basis_engines carries a member for an external-authority
-#       query and a re-run fires zero times on any record whose
+#       query and a re-run fires no vantage finding on any record whose
 #       detection_methodology names an authority probe, the field earns its
 #       version bump.
 import argparse
@@ -31,10 +89,31 @@ import json
 import sys
 from pathlib import Path
 
+# CI runs this file as `python scripts/check_confidence_signal.py`, which puts
+# scripts/ on sys.path rather than the repository root, so the sibling module
+# has to be reachable by the same name the tests import it under (pyproject
+# sets pythonpath = ["."] for pytest). Adding the root explicitly makes both
+# entry points resolve one module rather than each resolving a different one --
+# the same fix validate_records.py already carries for the same import.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.write_verification_basis import (  # noqa: E402
+    FLOOR_VANTAGE,
+    derive,
+    derived_vantage,
+    engine_vantage,
+)
+
 RECORDS_DIR = Path("records")
 
 HIGH_CONFIDENCE = 0.85
 FLOOR_KIND = "semantic_inference"
+
+# The two findings, as the names a consumer branches on. They are separate
+# because their remedies are separate: one is fixed by observing from somewhere
+# else, the other by observing a second time from somewhere independent.
+VANTAGE_FLOOR = "vantage_floor"
+INDEPENDENCE_FLOOR = "independence_floor"
 
 # Substrings in a record's detection_methodology that identify an
 # external-authority probe: the case where the floor is an enum gap, not an
@@ -51,22 +130,6 @@ AUTHORITY_PROBE_HINTS = (
 )
 
 
-def is_floor_basis(record: dict) -> bool:
-    """True when the record's evidence basis is at the floor: a single-engine
-    set (regardless of which) or semantic_inference as the kind.
-
-    The cardinality test is on the set, not the list: a duplicated member
-    (["pattern", "pattern"], ["pattern", "PATTERN"]) is a single-engine
-    basis wearing a list of length two, and must not dodge the floor
-    (astrogilda's attack test, 2026-08-26).
-    """
-    engines = record.get("evidence_basis_engines") or []
-    kind = record.get("evidence_kind_default") or ""
-    if len(set(engines)) <= 1:
-        return True
-    return kind == FLOOR_KIND
-
-
 def names_authority_probe(record: dict) -> bool:
     """True when the record's own detection methodology says the finding came
     from querying an external authority, i.e. the floor is an enum gap."""
@@ -74,36 +137,142 @@ def names_authority_probe(record: dict) -> bool:
     return any(h in methodology for h in AUTHORITY_PROBE_HINTS)
 
 
-def confidence_signal(record: dict):
-    """Return a human-readable signal string for a record whose declared
-    confidence sits high while its basis sits at the floor, else None."""
-    cb = record.get("confidence_baseline")
-    if cb is None:
-        return None  # absent confidence is a separate concern, not this check
-    if cb < HIGH_CONFIDENCE or not is_floor_basis(record):
-        return None
-    engines = ", ".join(sorted(set(record.get("evidence_basis_engines") or [])))
-    kind = record.get("evidence_kind_default") or "(none)"
-    note = ""
-    if names_authority_probe(record):
-        note = (
+def authority_probe_note(record: dict) -> str:
+    """The exculpatory sentence for a record whose own methodology says an
+    outside party was asked and answered, or "" for every other record.
+
+    It belongs to the vantage finding alone. What it explains is why a record
+    that did observe from outside the artifact still derives the artifact rung,
+    and that is a statement about vantage vocabulary; the same record's
+    independence finding, if it has one, is true on its own terms and is
+    cleared by the same edit anyway, since adding the missing member also adds
+    a second source.
+
+    Two shapes, because the enum gap it was written for has since been closed
+    for records that adopt the member. A record whose engine set still cannot
+    reach substrate is the original case. A record whose set can, and which
+    still derives the floor, is held there by its own silence rather than by
+    the vocabulary, and telling it to add a member it already carries would
+    send an author looking for a bug that is not there.
+    """
+    if not names_authority_probe(record):
+        return ""
+    if engine_vantage(record) == "substrate":
+        return (
             " NOTE: this record's detection_methodology names an external-authority "
-            "probe (registry/RDAP/API); the floor here is an enum gap, not an "
-            "overclaim. Expected to clear when evidence_basis_engines carries an "
-            "external-authority member."
+            "probe (registry/RDAP/API) and its evidence_basis_engines already carries "
+            "a member that reaches substrate, so the vocabulary is not what holds this "
+            "at the floor: the record has not declared evidence_vantage. Declaring it "
+            "clears this finding."
         )
     return (
-        f"confidence_baseline {cb} sits at the high band while the derived basis "
-        f"is at the floor (engines=[{engines}], evidence_kind_default={kind}). "
-        f"Declared confidence without structural verification -- see issue #98."
-        f"{note}"
+        " NOTE: this record's detection_methodology names an external-authority "
+        "probe (registry/RDAP/API); the floor here is an enum gap, not an "
+        "overclaim. Expected to clear when evidence_basis_engines carries an "
+        "external-authority member."
     )
+
+
+def vantage_floor_signal(record: dict, confidence: float):
+    """The finding for a record whose evidence was obtained from a place the
+    observed artifact controls, else None.
+
+    Two things put a record here and both are reported, because an author
+    fixing one wants to know the other is also holding it down. The derived
+    vantage is the composed answer write_verification_basis.py publishes, so
+    this arm and the corpus's own verification_basis can never disagree.
+    evidence_kind_default of semantic_inference joins it rather than forming a
+    finding of its own: an inference over meaning is a reading of content the
+    artifact produced however good the reading, which is the same rung and the
+    same remedy, and the arms here are divided by remedy.
+    """
+    causes = []
+    remedies = []
+    if derived_vantage(record) == FLOOR_VANTAGE:
+        causes.append(f"derived verification_basis is {derive(record)}")
+        remedies.append(
+            "observe from somewhere the artifact can neither forge nor suppress -- a "
+            "sandbox watching execution from outside it, or an external authority "
+            "answering about it -- and state that on evidence_vantage"
+        )
+    if (record.get("evidence_kind_default") or "") == FLOOR_KIND:
+        causes.append(f"evidence_kind_default is {FLOOR_KIND}")
+        remedies.append(
+            "ground the determination in something observed rather than inferred, and "
+            "stamp the evidence_kind that names it"
+        )
+    if not causes:
+        return None
+    return (
+        f"confidence_baseline {confidence} sits at the high band while the evidence "
+        f"sits at the vantage floor: {'; '.join(causes)}. Remedy: "
+        f"{'; '.join(remedies)}. Declared confidence without structural verification "
+        f"-- see issue #98.{authority_probe_note(record)}"
+    )
+
+
+def independence_floor_signal(record: dict, confidence: float):
+    """The finding for a record whose evidence rests on a single source, else
+    None.
+
+    Cardinality is the honest measure of corroboration and nothing else: how
+    many independent sources had to agree before the class was called. It says
+    nothing about where any of them observed from, which is why it is a finding
+    of its own rather than a proxy for the vantage one.
+
+    Counted over the set, and over the legible members of it. A duplicated
+    member is one source wearing a list of length two (astrogilda's attack
+    test, 2026-08-26), and a member that is not a string is not a source --
+    the same reading write_verification_basis.py gives a malformed engine
+    field, where a typo must not be allowed to raise what a record is credited
+    with.
+    """
+    members = sorted({e for e in (record.get("evidence_basis_engines") or []) if isinstance(e, str)})
+    if len(members) > 1:
+        return None
+    rests_on = (
+        f"evidence_basis_engines names a single source ([{', '.join(members)}])"
+        if members
+        else "evidence_basis_engines names no legible source at all"
+    )
+    return (
+        f"confidence_baseline {confidence} sits at the high band while {rests_on}. "
+        f"Remedy: corroborate with a second, independent engine; a repeated member is "
+        f"one source wearing a list of length two, and a malformed one is not a source. "
+        f"Declared confidence without corroboration -- see issue #98."
+    )
+
+
+def confidence_signals(record: dict) -> list[dict]:
+    """Every finding this record's declared confidence carries, in order, as
+    {"finding": <name>, "signal": <prose>} pairs. Empty for a record whose
+    confidence is absent, below the high band, or fully supported.
+
+    A pair rather than a string because the two findings have different
+    remedies, and a consumer that has to parse prose to tell them apart cannot
+    route them. The names are the stable half; the prose is for a human.
+    """
+    confidence = record.get("confidence_baseline")
+    if confidence is None:
+        return []  # absent confidence is a separate concern, not this check
+    if confidence < HIGH_CONFIDENCE:
+        return []
+    findings = []
+    for name, arm in (
+        (VANTAGE_FLOOR, vantage_floor_signal),
+        (INDEPENDENCE_FLOOR, independence_floor_signal),
+    ):
+        signal = arm(record, confidence)
+        if signal:
+            findings.append({"finding": name, "signal": signal})
+    return findings
 
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         description="Report AVE records whose self-reported confidence_baseline "
-        "sits high while their derived evidence basis sits at the floor (issue #98)."
+        "sits high while their evidence sits at the vantage floor, the "
+        "independence floor, or both (issue #98)."
     )
     parser.add_argument(
         "--json", dest="as_json", action="store_true",
@@ -117,19 +286,28 @@ def main(argv=None) -> int:
         return 2
 
     findings = []
+    flagged = set()
     for path in paths:
         record = json.loads(path.read_text())
-        signal = confidence_signal(record)
-        if signal:
-            findings.append({"ave_id": record.get("ave_id", path.stem), "signal": signal})
+        rid = record.get("ave_id", path.stem)
+        for finding in confidence_signals(record):
+            findings.append({"ave_id": rid, **finding})
+            flagged.add(rid)
 
     if args.as_json:
-        print(json.dumps({"findings": findings, "count": len(findings)}, indent=2))
+        # count is findings and records is the records they fall on; a record
+        # carrying both findings contributes two to one and one to the other,
+        # so a consumer reading either number alone still reads it correctly.
+        print(json.dumps(
+            {"findings": findings, "count": len(findings), "records": len(flagged)},
+            indent=2,
+        ))
     else:
         if findings:
-            print(f"{len(findings)} record(s) with high confidence on a floor-level basis (soft warning):")
+            print(f"{len(findings)} finding(s) across {len(flagged)} of {len(paths)} "
+                  f"record(s) with high confidence on unsupported evidence (soft warning):")
             for f in findings:
-                print(f"- {f['ave_id']}: {f['signal']}")
+                print(f"- {f['ave_id']} [{f['finding']}]: {f['signal']}")
         else:
             print(f"All {len(paths)} records have confidence consistent with their basis.")
 

--- a/scripts/check_vulnerability_taxonomy.py
+++ b/scripts/check_vulnerability_taxonomy.py
@@ -1,0 +1,80 @@
+# What: reports which AVE records carry the capability-vulnerability
+#       taxonomy fields (security_boundary, missing_control,
+#       vulnerability_rationale) and which don't, per the audit
+#       design in docs/audits/capability-vulnerability-audit.md.
+#       A soft warning by default; --strict makes it a hard failure,
+#       intended for gating new record submissions specifically, not
+#       the existing corpus.
+# Why:  a capability-only or technique-only record (Q1-Q7's D and C
+#       categories) is a real, recurring risk in a taxonomy like this,
+#       and it's cheap to check for structurally once a record states
+#       its own security_boundary and missing_control explicitly. The
+#       80 records that predate this field are not retroactively
+#       required to have it; new records are, once this graduates from
+#       warn to strict the same way commit and verification_basis did.
+import argparse
+import json
+import sys
+from pathlib import Path
+
+RECORDS_DIR = Path("records")
+TAXONOMY_FIELDS = ("security_boundary", "missing_control", "vulnerability_rationale")
+
+
+def has_taxonomy_fields(record: dict) -> bool:
+    """True when a record carries a real security_boundary and missing_control,
+    and a vulnerability_rationale with all three of its own sub-fields filled.
+    A present but empty field doesn't count, matching the same honesty
+    standard as every other field in this project: absence and an empty
+    value both read as 'not yet done', not as a checked, real answer.
+    """
+    if not record.get("security_boundary") or not record.get("missing_control"):
+        return False
+    rationale = record.get("vulnerability_rationale") or {}
+    return all(rationale.get(k) for k in ("capability", "vulnerability", "impact"))
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report AVE records missing the capability-vulnerability "
+        "taxonomy fields (security_boundary, missing_control, vulnerability_rationale)."
+    )
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="hard-fail on any record missing the taxonomy fields, intended for "
+             "gating new record submissions rather than the existing corpus",
+    )
+    parser.add_argument(
+        "--only", metavar="AVE_ID", action="append",
+        help="check only the named record(s), e.g. for a new-record PR gate "
+             "that shouldn't re-flag the other 79 records",
+    )
+    args = parser.parse_args(argv)
+
+    paths = sorted(RECORDS_DIR.glob("AVE-*.json"))
+    if not paths:
+        print(f"No records found under {RECORDS_DIR}/", file=sys.stderr)
+        return 2
+
+    missing = []
+    for path in paths:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        rid = record.get("ave_id", path.stem)
+        if args.only and rid not in args.only:
+            continue
+        if not has_taxonomy_fields(record):
+            missing.append(rid)
+
+    checked = len(args.only) if args.only else len(paths)
+    if missing:
+        label = "FAIL" if args.strict else "WARNING"
+        print(f"{label}: {len(missing)} of {checked} record(s) missing capability-"
+              f"vulnerability taxonomy fields (security_boundary, missing_control, "
+              f"vulnerability_rationale): {', '.join(missing)}")
+        return 1 if args.strict else 0
+    print(f"All {checked} checked record(s) carry the taxonomy fields.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/write_verification_basis.py
+++ b/scripts/write_verification_basis.py
@@ -89,6 +89,21 @@ def declared_method(record: dict) -> str:
     return value if value in METHOD_VALUES else FLOOR_METHOD
 
 
+def derived_vantage(record: dict) -> str:
+    """The vantage this record is entitled to: the weaker of what its producer
+    declared and what its engine set can reach.
+
+    Named rather than left inline inside derive() because it is the answer to a
+    question consumers ask on its own -- where was this observed from -- and a
+    consumer that has to recover it by reading the front half of a composed
+    string, or by re-deriving it from SUBSTRATE_ENGINES, is a second definition
+    of the same predicate waiting to disagree with this one.
+    """
+    if engine_vantage(record) != "substrate":
+        return FLOOR_VANTAGE
+    return declared_vantage(record)
+
+
 def derive(record: dict) -> str:
     """Compose the two axes into verification_basis, weakest input winning.
 
@@ -98,10 +113,7 @@ def derive(record: dict) -> str:
     not claim. The result names the cell, not a score: it says where the
     observation was made from and how, and nothing about whether it was right.
     """
-    vantage = declared_vantage(record)
-    if engine_vantage(record) != "substrate":
-        vantage = FLOOR_VANTAGE
-    return f"{vantage}_{declared_method(record)}"
+    return f"{derived_vantage(record)}_{declared_method(record)}"
 
 
 def check_record(record: dict) -> list[str]:

--- a/tests/test_confidence_signal.py
+++ b/tests/test_confidence_signal.py
@@ -23,50 +23,152 @@ def base_record(**overrides):
     return record
 
 
-def test_high_confidence_on_floor_basis_is_flagged():
-    """The issue #98 shape: a high float with no structural verification.
-
-    Mirrors AVE-2026-00074's pre-#218 shape: pattern-only engine set, high
-    confidence. The record has since gained external_authority (issue #218);
-    this fixture pins the floor behavior the check is designed to catch.
-    """
-    record = base_record()
-    result = check_confidence_signal.confidence_signal(record)
-    assert result is not None
-    assert "confidence_baseline 0.85" in result
-    assert "high band" in result
-    assert "floor" in result
+def names(record):
+    """The finding names a record carries, which is the half a consumer routes
+    on. The prose is asserted separately and only where it is the subject."""
+    return [f["finding"] for f in check_confidence_signal.confidence_signals(record)]
 
 
-def test_high_confidence_with_multi_engine_basis_is_not_flagged():
-    """Two or more engines is not a floor basis, regardless of which engines."""
+def signal_for(record, finding):
+    """The prose of one named finding, or None if the record does not carry it."""
+    for f in check_confidence_signal.confidence_signals(record):
+        if f["finding"] == finding:
+            return f["signal"]
+    return None
+
+
+# --- the high band gates both findings ---------------------------------------
+
+def test_low_confidence_is_not_a_finding_whatever_the_basis():
+    """Low declared confidence is consistent with weak evidence. Neither arm is
+    a finding on its own; both are findings about a high number."""
+    assert names(base_record(confidence_baseline=0.45)) == []
+
+
+def test_missing_confidence_is_not_a_finding():
+    """Absent confidence is a separate concern; the signal check stays silent."""
+    assert names(base_record(confidence_baseline=None)) == []
+
+
+def test_evidence_that_supports_the_number_carries_no_findings():
     record = base_record(
-        evidence_basis_engines=["pattern", "semgrep"],
-        evidence_kind_default="behavioral_pattern",
+        confidence_baseline=0.95,
+        evidence_vantage="substrate",
+        evidence_basis_engines=["pattern", "sandbox"],
     )
-    assert check_confidence_signal.confidence_signal(record) is None
+    assert names(record) == []
 
 
-def test_semantic_inference_kind_is_floor_even_with_multiple_engines():
-    """semantic_inference is a floor kind on its own."""
+# --- the four combinations the split was measured against --------------------
+#
+# Each row below is one cell of the table that showed the two predicates
+# disagreeing on main: cardinality and the verification_basis derivation, over
+# the same evidence_basis_engines field, with evidence_vantage=substrate,
+# evidence_method=intercepted and confidence_baseline=0.9.
+
+def four_cell_record(engines):
+    return base_record(
+        confidence_baseline=0.9,
+        evidence_vantage="substrate",
+        evidence_method="intercepted",
+        evidence_basis_engines=engines,
+    )
+
+
+def test_two_engines_neither_reaching_substrate_is_a_vantage_floor():
+    """The miss. Cardinality saw two members and stayed silent while the
+    record's own derived basis was artifact_intercepted -- a floor-level basis
+    carrying a 0.9, which is the exact shape issue #98 exists to surface."""
+    record = four_cell_record(["pattern", "yara"])
+    assert names(record) == [check_confidence_signal.VANTAGE_FLOOR]
+    assert "artifact_intercepted" in signal_for(record, check_confidence_signal.VANTAGE_FLOOR)
+
+
+def test_one_substrate_capable_engine_is_an_independence_floor_only():
+    """The false positive. Cardinality fired on a record whose derived basis
+    was substrate_intercepted, the strongest available, and called it a floor
+    basis. There is a real finding here -- one source -- but it is the
+    corroboration one, and the record's vantage is not at issue."""
+    record = four_cell_record(["sandbox"])
+    assert names(record) == [check_confidence_signal.INDEPENDENCE_FLOOR]
+    assert "single source" in signal_for(record, check_confidence_signal.INDEPENDENCE_FLOOR)
+
+
+def test_one_engine_that_cannot_reach_substrate_carries_both_findings():
+    """Both predicates agreed here, and they agreed because both faults are
+    present, not because they measure the same thing. The record needs two
+    different repairs and now says so."""
+    assert names(four_cell_record(["pattern"])) == [
+        check_confidence_signal.VANTAGE_FLOOR,
+        check_confidence_signal.INDEPENDENCE_FLOOR,
+    ]
+
+
+def test_two_engines_one_reaching_substrate_carries_neither():
+    assert names(four_cell_record(["pattern", "sandbox"])) == []
+
+
+# --- the vantage arm ---------------------------------------------------------
+
+def test_the_vantage_arm_reads_the_derivation_not_the_declaration():
+    """A declared substrate vantage its engines cannot reach derives the floor,
+    and the finding follows the derivation. A producer cannot clear this arm by
+    asserting a vantage its evidence has no way to occupy."""
     record = base_record(
         confidence_baseline=0.9,
-        evidence_basis_engines=["yara", "semgrep"],
+        evidence_vantage="substrate",
+        evidence_basis_engines=["pattern", "yara", "semgrep", "llm", "magika"],
+    )
+    assert names(record) == [check_confidence_signal.VANTAGE_FLOOR]
+
+
+def test_a_stamped_verification_basis_does_not_override_the_derivation():
+    """verification_basis is derived, never authored, and validate_records.py
+    hard-fails a declaration the axes refute. A consumer-side check that read
+    the stamp would be reading the author's own copy -- a self-report, which is
+    the complaint in issue #98 wearing a better field name."""
+    record = base_record(
+        confidence_baseline=0.9,
+        verification_basis="substrate_intercepted",
+        evidence_basis_engines=["pattern", "yara"],
+    )
+    assert check_confidence_signal.VANTAGE_FLOOR in names(record)
+
+
+def test_semantic_inference_is_a_vantage_finding_not_an_independence_one():
+    """An inference over meaning is a reading of content the artifact produced,
+    however good the reading, so it sits at the same rung and takes the same
+    remedy. It says nothing about how many sources agreed, so it must not reach
+    the independence arm."""
+    record = base_record(
+        confidence_baseline=0.9,
+        evidence_vantage="substrate",
+        evidence_basis_engines=["sandbox", "pattern"],
         evidence_kind_default="semantic_inference",
     )
-    assert check_confidence_signal.confidence_signal(record) is not None
+    assert names(record) == [check_confidence_signal.VANTAGE_FLOOR]
+    assert "semantic_inference" in signal_for(record, check_confidence_signal.VANTAGE_FLOOR)
 
 
-def test_low_confidence_on_floor_basis_is_not_flagged():
-    """Low declared confidence is consistent with a weak basis: no signal."""
-    record = base_record(confidence_baseline=0.45)
-    assert check_confidence_signal.confidence_signal(record) is None
+def test_the_vantage_finding_names_every_cause_holding_it_down():
+    """An author who fixes one cause and re-runs should not discover the second
+    only then. Both are reported in the one finding, because both take the
+    vantage remedy."""
+    signal = signal_for(
+        base_record(confidence_baseline=0.9, evidence_kind_default="semantic_inference"),
+        check_confidence_signal.VANTAGE_FLOOR,
+    )
+    assert "artifact_reconstructed" in signal
+    assert "semantic_inference" in signal
 
 
-def test_missing_confidence_is_not_flagged():
-    """Absent confidence is a separate concern; the signal check stays silent."""
-    record = base_record(confidence_baseline=None)
-    assert check_confidence_signal.confidence_signal(record) is None
+# --- the independence arm ----------------------------------------------------
+
+def test_a_duplicated_member_is_one_source():
+    """astrogilda's attack test (2026-08-26): a duplicated member is a single
+    source wearing a list of length two and must not dodge the floor."""
+    record = base_record(confidence_baseline=0.95, evidence_basis_engines=["pattern", "pattern"])
+    assert check_confidence_signal.INDEPENDENCE_FLOOR in names(record)
 
 
 def test_engine_list_ordering_is_normalized():
@@ -74,49 +176,83 @@ def test_engine_list_ordering_is_normalized():
     13 distinct bases); the check must see them as the same basis."""
     a = base_record(evidence_basis_engines=["pattern", "semgrep"])
     b = base_record(evidence_basis_engines=["semgrep", "pattern"])
-    assert check_confidence_signal.confidence_signal(a) == check_confidence_signal.confidence_signal(b)
+    assert check_confidence_signal.confidence_signals(a) == check_confidence_signal.confidence_signals(b)
 
 
-def test_duplicate_engine_members_are_still_a_floor_basis():
-    """astrogilda's attack test (2026-08-26): a duplicated member is a
-    single-engine basis wearing a list of length two and must not dodge
-    the floor. len(set(engines)) <= 1 pins the fixed behaviour."""
-    record = base_record(
-        confidence_baseline=0.95,
-        evidence_basis_engines=["pattern", "pattern"],
+@pytest.mark.parametrize("engines", [[None, 3], [{"engine": "sandbox"}, ["sandbox"]], []])
+def test_a_member_that_is_not_a_string_is_not_a_source(engines):
+    """Two malformed members are not two independent sources, the same reading
+    write_verification_basis.py gives a malformed engine field: a typo must not
+    raise what a record is credited with."""
+    record = base_record(confidence_baseline=0.9, evidence_basis_engines=engines)
+    assert check_confidence_signal.INDEPENDENCE_FLOOR in names(record)
+
+
+def test_no_legible_source_says_so_rather_than_naming_one():
+    signal = signal_for(
+        base_record(confidence_baseline=0.9, evidence_basis_engines=[]),
+        check_confidence_signal.INDEPENDENCE_FLOOR,
     )
-    result = check_confidence_signal.confidence_signal(record)
-    assert result is not None
-    assert "floor" in result
+    assert "no legible source" in signal
 
 
-def test_authority_probe_note_is_appended_to_00074_shape():
-    """AVE-2026-00074's pre-#218 detection methodology named authority probes
-    while its engine set still sat at the floor; the floor there was an enum
-    gap, not an overclaim, and the signal said so. Pins the note logic that
-    any pre-vocabulary record still gets."""
-    record = base_record(
-        detection_methodology="Queries GitHub's users API for owners, the package "
-        "registry for names, RDAP for domains, provider fingerprints for cloud "
-        "subdomains; a failed probe degrades to silence.",
+# --- the external-authority note --------------------------------------------
+
+AUTHORITY_METHODOLOGY = (
+    "Queries GitHub's users API for owners, the package registry for names, RDAP for "
+    "domains, provider fingerprints for cloud subdomains; a failed probe degrades to "
+    "silence."
+)
+
+
+def test_the_note_reads_as_an_enum_gap_while_the_engine_set_cannot_reach_substrate():
+    """AVE-2026-00074's pre-#218 shape: its methodology probed outside parties
+    while its engine set had no member for that rung, so the floor there was a
+    gap in the vocabulary rather than an overclaim, and the signal said so."""
+    signal = signal_for(
+        base_record(detection_methodology=AUTHORITY_METHODOLOGY),
+        check_confidence_signal.VANTAGE_FLOOR,
     )
-    result = check_confidence_signal.confidence_signal(record)
-    assert result is not None
-    assert "external-authority probe" in result
-    assert "enum gap" in result
+    assert "external-authority probe" in signal
+    assert "enum gap" in signal
 
 
-def test_external_authority_member_clears_the_00074_enum_gap():
-    """Post-#218 shape: AVE-2026-00074's engines now carry external_authority,
-    so the floor clears and the check stays quiet -- the escalation condition
-    named in #213/#214 is satisfied by the record's own vocabulary."""
+def test_the_note_stops_blaming_the_vocabulary_once_the_member_is_adopted():
+    """Post-#218 shape. The record now carries external_authority, so its
+    ceiling reaches substrate and the enum gap is closed: what holds it at the
+    floor is that it has never declared evidence_vantage. Telling this author
+    to add a member the record already carries would send them hunting a bug
+    that is not there."""
     record = base_record(
         evidence_basis_engines=["pattern", "external_authority"],
-        detection_methodology="Queries GitHub's users API for owners, the package "
-        "registry for names, RDAP for domains, provider fingerprints for cloud "
-        "subdomains; a failed probe degrades to silence.",
+        detection_methodology=AUTHORITY_METHODOLOGY,
     )
-    assert check_confidence_signal.confidence_signal(record) is None
+    assert names(record) == [check_confidence_signal.VANTAGE_FLOOR]
+    signal = signal_for(record, check_confidence_signal.VANTAGE_FLOOR)
+    assert "has not declared evidence_vantage" in signal
+    assert "enum gap" not in signal
+
+
+def test_declaring_the_vantage_clears_the_record_the_note_points_at():
+    """The other half of the sentence above: doing what the note asks leaves
+    the record with no findings at all."""
+    assert names(base_record(
+        evidence_vantage="substrate",
+        evidence_basis_engines=["pattern", "external_authority"],
+        detection_methodology=AUTHORITY_METHODOLOGY,
+    )) == []
+
+
+def test_the_note_attaches_to_the_vantage_finding_only():
+    """The note explains a vantage-vocabulary gap. The same record's
+    independence finding is true on its own terms, and an exculpatory sentence
+    pasted onto it would excuse a fault it does not describe."""
+    signal = signal_for(
+        base_record(detection_methodology=AUTHORITY_METHODOLOGY),
+        check_confidence_signal.INDEPENDENCE_FLOOR,
+    )
+    assert signal is not None
+    assert "external-authority probe" not in signal
 
 
 def test_authority_probe_note_negative_control():
@@ -129,13 +265,42 @@ def test_authority_probe_note_negative_control():
         "Domain-specific heuristics over the tool description string.",
         "Matches the Windows registry key path written by the installer.",
     ):
-        record = base_record(detection_methodology=methodology)
-        result = check_confidence_signal.confidence_signal(record)
-        assert result is not None
-        assert "external-authority probe" not in result, methodology
+        signal = signal_for(
+            base_record(detection_methodology=methodology),
+            check_confidence_signal.VANTAGE_FLOOR,
+        )
+        assert signal is not None
+        assert "external-authority probe" not in signal, methodology
 
+
+# --- the command line --------------------------------------------------------
 
 def test_main_is_soft_warning_exit_zero():
     """The agreed design: warn-not-fail, exit code untouched (same shape as
     check_researcher_matches_disclosure)."""
     assert check_confidence_signal.main([]) == 0
+
+
+def test_json_output_names_the_finding_and_counts_both_axes(tmp_path, monkeypatch, capsys):
+    """A record carrying both findings contributes two findings on one record,
+    and downstream tooling has to be able to read either number without
+    inferring the other."""
+    record = base_record(confidence_baseline=0.9)
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(record), encoding="utf-8")
+    monkeypatch.setattr(check_confidence_signal, "RECORDS_DIR", tmp_path)
+
+    assert check_confidence_signal.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 2
+    assert payload["records"] == 1
+    assert [f["finding"] for f in payload["findings"]] == [
+        check_confidence_signal.VANTAGE_FLOOR,
+        check_confidence_signal.INDEPENDENCE_FLOOR,
+    ]
+    assert {f["ave_id"] for f in payload["findings"]} == {"AVE-2026-99999"}
+
+
+def test_an_empty_records_directory_is_reported_not_passed(tmp_path, monkeypatch):
+    """An absent corpus must never read as a clean run."""
+    monkeypatch.setattr(check_confidence_signal, "RECORDS_DIR", tmp_path)
+    assert check_confidence_signal.main([]) == 2

--- a/tests/test_verification_basis.py
+++ b/tests/test_verification_basis.py
@@ -63,6 +63,24 @@ def test_sandbox_also_reaches_substrate():
     )) == "substrate_reconstructed"
 
 
+def test_the_derived_vantage_is_readable_without_parsing_the_composed_value():
+    """The vantage half of the composition, pinned as a name of its own.
+
+    scripts/check_confidence_signal.py floors its vantage arm on this. A
+    consumer that had to recover the vantage by splitting
+    'substrate_intercepted' on an underscore, or by re-testing
+    SUBSTRATE_ENGINES itself, would be a second definition of the same
+    predicate -- which is the defect the confidence check was split to fix.
+    """
+    assert writer.derived_vantage(record(
+        evidence_vantage="substrate", evidence_basis_engines=["sandbox"],
+    )) == "substrate"
+    assert writer.derived_vantage(record(
+        evidence_vantage="substrate", evidence_basis_engines=["pattern"],
+    )) == "artifact"
+    assert writer.derived_vantage(record()) == "artifact"
+
+
 def test_the_ceiling_does_not_raise_a_record_that_claims_nothing():
     """A strong engine set is permission to make a claim, not the claim. A
     record that declares no vantage stays at the floor even with the strongest

--- a/tests/test_vulnerability_taxonomy.py
+++ b/tests/test_vulnerability_taxonomy.py
@@ -1,0 +1,75 @@
+import json
+import pytest
+from scripts import check_vulnerability_taxonomy as check
+
+
+def record(**overrides):
+    base = {"ave_id": "AVE-2026-99999"}
+    base.update(overrides)
+    return base
+
+
+FULL_RATIONALE = {
+    "capability": "Agent can execute shell commands.",
+    "vulnerability": "Untrusted content can induce shell execution with no independent authorization boundary.",
+    "impact": "Arbitrary code execution under agent privileges.",
+}
+
+
+def test_missing_all_three_fields_is_not_flagged_as_present():
+    assert check.has_taxonomy_fields(record()) is False
+
+
+def test_all_three_fields_present_and_full_is_flagged_present():
+    assert check.has_taxonomy_fields(record(
+        security_boundary="untrusted content to instruction context",
+        missing_control="no explicit tool allowlist",
+        vulnerability_rationale=FULL_RATIONALE,
+    )) is True
+
+
+def test_present_but_one_rationale_subfield_empty_is_not_present():
+    """Mutation check: if `all()` in has_taxonomy_fields became `any()`,
+    this must go red. A partially-filled rationale is not a real answer."""
+    incomplete = dict(FULL_RATIONALE, impact="")
+    assert check.has_taxonomy_fields(record(
+        security_boundary="agent to agent",
+        missing_control="no identity binding",
+        vulnerability_rationale=incomplete,
+    )) is False
+
+
+def test_security_boundary_present_but_missing_control_absent_is_not_present():
+    assert check.has_taxonomy_fields(record(
+        security_boundary="agent to agent",
+        vulnerability_rationale=FULL_RATIONALE,
+    )) is False
+
+
+def test_default_mode_warns_and_exits_zero(tmp_path, monkeypatch, capsys):
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(record()), encoding="utf-8")
+    monkeypatch.setattr(check, "RECORDS_DIR", tmp_path)
+    monkeypatch.setattr("sys.argv", ["check_vulnerability_taxonomy.py"])
+    assert check.main([]) == 0
+    assert "WARNING" in capsys.readouterr().out
+
+
+def test_strict_mode_fails_on_missing_fields(tmp_path, monkeypatch):
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(record()), encoding="utf-8")
+    monkeypatch.setattr(check, "RECORDS_DIR", tmp_path)
+    assert check.main(["--strict"]) == 1
+
+
+def test_only_flag_scopes_the_check_to_named_records(tmp_path, monkeypatch, capsys):
+    """The property a new-record PR gate depends on: --only must not
+    re-flag the records that predate this field."""
+    (tmp_path / "AVE-2026-00001.json").write_text(json.dumps(record(ave_id="AVE-2026-00001")), encoding="utf-8")
+    complete = record(
+        ave_id="AVE-2026-99999",
+        security_boundary="agent to agent",
+        missing_control="no identity binding",
+        vulnerability_rationale=FULL_RATIONALE,
+    )
+    (tmp_path / "AVE-2026-99999.json").write_text(json.dumps(complete), encoding="utf-8")
+    monkeypatch.setattr(check, "RECORDS_DIR", tmp_path)
+    assert check.main(["--strict", "--only", "AVE-2026-99999"]) == 0


### PR DESCRIPTION
Follows the question left open at the end of #214: whether check_confidence_signal.py should read verification_basis where present, or whether there is a real reason to keep the two independent.

This pull request answers neither. They are not one question at two levels of rigor. is_floor_basis tests cardinality, len(set(engines)) <= 1; engine_vantage tests capability, whether any member reaches substrate. Neither predicate contains the other, and all four combinations on origin/main show where they part:

| # | engines | confidence check | derived basis |
| --- | --- | --- | --- |
| 1 | two, both short of substrate | silent | artifact_intercepted |
| 2 | one, substrate-capable | fires | substrate_intercepted |
| 3 | one, without substrate reach | fires | artifact_intercepted |
| 4 | two, one substrate-capable | silent | substrate_intercepted |

Row 1 is a miss and row 2 fires on a record whose vantage is genuinely strong. The miss is live: of the 80 published records, 8 sit in the high band and every one derives artifact_reconstructed, because none declares evidence_vantage or evidence_method. None of the 8 is single-engine, so cardinality stays silent and the check currently reports that all 80 are consistent with their basis.

Reading verification_basis in place of cardinality would close the miss. It would also lose the corroboration signal, because a single substrate-capable engine has a strong vantage and one source. So this splits the check into two named findings with different remedies. A vantage floor is remedied by observing from somewhere closer. An independence floor is remedied by adding a second source. A record can carry either, both or neither, and the output says which.

## What changed

is_floor_basis is gone. `vantage_floor_signal` and `independence_floor_signal` replace it, assembled by confidence_signals with the high-band gate stated once. The return shape changes with them: confidence_signal returning a string or None becomes confidence_signals returning a list, because a single string cannot carry two faults a consumer routes on differently. There is no alias and no shim, and every caller is updated. The JSON output gains a `records` key, and count keeps meaning findings.

derived_vantage is extracted in write_verification_basis.py so the check imports a name for the value it needs. The obvious move is to read a stamped verification_basis. The vantage arm derives instead: where a stamp exists validate_records.py already hard-fails a declaration the derivation refutes, so in a valid corpus the two agree, and where they could differ the stamp is what the author typed, which is issue #98 wearing a better field name.

semantic_inference folds into the vantage arm where a third finding would have split it, because the arms divide by remedy and an inference over meaning is a reading of artifact-produced content. The authority-probe note gained a second form, and says nothing about cardinality, since 00074 adopted external_authority in #218 and its ceiling now reaches substrate, so only the missing declaration holds it down. The old wording would have told that author to add a member the record already carries.

## Consequences worth stating

The CI log for this check goes from one quiet line to nine. That is the fix working rather than a regression, and the exit code is unchanged; the check stays a soft warning.

Since silence derives the floor, the vantage arm fires on records that have not declared. That is correct for a consumer, because no substrate binding exists either way, and it does not penalise stating the floor: the high band is still required, so an honest artifact record with a mid baseline stays silent.

No record was edited to add evidence_vantage. The 8 findings are real, and each one is a producer-side judgement for that record's author to make.

## Checks

CI's steps in order: validate_records 80 valid, validate_crosswalks 9 of 9, check_fixtures 80, check_confidence_signal 8 findings across 8 of 80, check_vulnerability_taxonomy clean, write_verification_basis all 80 agree with their derivation, pytest 450 passed. Tests went 435 to 450. Each of the three commits was tested independently from a clean snapshot.

Fourteen mutations were run against the new behaviour, one per claim the tests make, and all fourteen were killed.

If you would rather keep one signal and take the OR, say so and I will cut it back to that.
