### PR TITLE
crosswalks: add AVE to MAESTRO pilot (6 records, 3 of 7 layers)

### DIFF
--- a/crosswalks/ave-to-maestro.json
+++ b/crosswalks/ave-to-maestro.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://aveproject.org/schema/crosswalk-1.0.0.schema.json",
+  "source": {
+    "standard": "AVE",
+    "version": "1.1.0",
+    "url": "https://aveproject.org",
+    "record_count": 80,
+    "commit": "f68e8884d50be8d12f970e4f7f3114a3b4dfd7b5"
+  },
+  "target": {
+    "tool": "MAESTRO (Multi-Agent Environment, Security, Threat, Risk, & Outcome)",
+    "vendor": "Cloud Security Alliance",
+    "url": "https://cloudsecurityalliance.org/blog/2025/02/06/agentic-ai-threat-modeling-framework-maestro",
+    "github": "https://github.com/CloudSecurityAlliance/MAESTRO",
+    "status": "Continuously evolving via community contribution, not discretely versioned. Verified before building this crosswalk: the CSA's own framework post carries no version marker, and the CSA's GitHub repo (an AI-powered threat analyzer tool built on the framework, not a versioned spec repo for the framework itself) has zero tags and zero releases despite being actively pushed to as recently as 2026-08-27. A previous internal note treated a future 'v2' as a blocker for this crosswalk; that blocker does not exist and this crosswalk was not waiting on anything real.",
+    "checked_against_live_site": "2026-08-30"
+  },
+  "generated": "2026-08-30",
+  "note": "Deliberate pilot, not a full-corpus crosswalk: 6 AVE records mapped to 5 of MAESTRO's ~49 layer/threat combinations (7 layers, each with 6-8 named threats), the clearest, most unambiguous mechanism matches, following the same pilot-first approach used for the OpenCRE and OWASP GenAI Crosswalk submissions. MAESTRO's own threats are named at a broad, principle level (e.g. 'Agent Tool Misuse' covers any unsafe use of an already-authorized tool); AVE provides the individual behavioral class underneath. Two tempting matches were checked and rejected rather than forced: AVE-2026-00006 (Cryptocurrency Drain) was initially considered for Layer 4's 'Resource Hijacking', but that MAESTRO threat is about hijacked compute/infrastructure resources, not financial/wallet theft via an authorized tool, so it maps to Layer 7's 'Agent Tool Misuse' instead. AVE-2026-00017 (Server Impersonation) was considered for Layer 7's 'Agent Impersonation' but is excluded from this pilot: MAESTRO's threat concerns one agent impersonating another agent within a multi-agent ecosystem, while AVE-2026-00017 describes an MCP server (a tool/service, not itself an agent) impersonating a well-known official server. The trust-exploitation shape is similar; the entity type is not the same, and that distinction is exactly what MAESTRO's own layer boundaries are drawn around. Recorded here rather than silently mapped, the same discipline already applied to AVE-2026-00059/00065 in the OpenCRE pilot.",
+  "mappings": [
+    {
+      "maestro_layer": "Layer 3 - Agent Frameworks",
+      "maestro_threat": "Supply Chain Attacks (targeting dependencies)",
+      "ave_ids": ["AVE-2026-00062"],
+      "primary_ave_id": "AVE-2026-00062",
+      "notes": "Direct match. AVE-2026-00062 (Unpinned Dependency Substitution) is exactly this threat at the level of a single behavioral class: a mutable dependency reference lets the reviewed and executed artifact silently diverge after approval."
+    },
+    {
+      "maestro_layer": "Layer 4 - Deployment and Infrastructure",
+      "maestro_threat": "Infrastructure-as-Code (IaC) Manipulation",
+      "ave_ids": ["AVE-2026-00071"],
+      "primary_ave_id": "AVE-2026-00071",
+      "notes": "AVE-2026-00071 (Container Daemon Redirect) is a declared configuration value (DOCKER_HOST, or a -H/--host flag in a committed command) manipulated to point the container daemon at attacker infrastructure, so every subsequent build, run, pull, and mount silently targets it. This is IaC manipulation specifically, not a compromised image (nothing in the image itself is malicious) and not orchestration-layer exploitation (no Kubernetes/orchestrator component is involved)."
+    },
+    {
+      "maestro_layer": "Layer 7 - Agent Ecosystem",
+      "maestro_threat": "Agent Goal Manipulation",
+      "ave_ids": ["AVE-2026-00007"],
+      "primary_ave_id": "AVE-2026-00007",
+      "notes": "Direct match, close to a shared vocabulary already: AVE-2026-00007's own attack_class is 'Prompt Injection - Goal Hijack', explicit instruction-override language ('ignore all previous instructions') redirecting the agent from its intended task."
+    },
+    {
+      "maestro_layer": "Layer 7 - Agent Ecosystem",
+      "maestro_threat": "Agent Tool Misuse",
+      "ave_ids": ["AVE-2026-00006", "AVE-2026-00068"],
+      "primary_ave_id": "AVE-2026-00068",
+      "notes": "Two distinct AVE mechanisms under the same MAESTRO threat. AVE-2026-00006 (Cryptocurrency Drain): the agent's own wallet tool access is used, under disguised instructions, to transfer funds or approve unlimited token allowances. AVE-2026-00068 (CLI Command Composition): individually-authorized CLI commands compose through shared OS state into a capability beyond task scope. Both are an agent operating within tools it was actually granted, misused, not a boundary or sandbox failure."
+    },
+    {
+      "maestro_layer": "Layer 7 - Agent Ecosystem",
+      "maestro_threat": "Marketplace Manipulation",
+      "ave_ids": ["AVE-2026-00066"],
+      "primary_ave_id": "AVE-2026-00066",
+      "notes": "AVE-2026-00066 (Hallucinated Resource Squatting): an attacker precomputes plausible-but-nonexistent names an LLM is statistically likely to hallucinate, then preemptively registers those exact names on a public registry with malicious content. Considered for Layer 7's 'Malicious Agent Discovery' instead, but that MAESTRO threat reads as agent-specific (a malicious agent being surfaced in an agent directory/registry search); AVE-2026-00066's mechanism is registry-squatting broadly (packages, repos, or skills), which 'Marketplace Manipulation' names without narrowing to agents specifically, so it is the better fit."
+    }
+  ],
+  "gaps_in_ave": [
+    {
+      "topic": "Model Stealing / Model Extraction (Layer 1, Layer 6)",
+      "reason": "AVE catalogs behavioral classes in agentic components (skills, MCP servers, system prompts, agent plugins), not attacks against a foundation model's own weights or training process. Out of AVE's current scope entirely, not a gap to fill."
+    },
+    {
+      "topic": "Denial of Service on computationally expensive queries (Layer 1)",
+      "reason": "A related, unresolved internal question (a possible resource-exhaustion/agentic-DoS gap) is tracked separately and was not resolved as part of building this crosswalk; see the trust-strategy roadmap rather than treating this pilot as having settled it."
+    }
+  ],
+  "gaps_in_maestro": [
+    {
+      "topic": "Server/component impersonation distinct from agent impersonation",
+      "ave_id": "AVE-2026-00017",
+      "reason": "See the note field. MAESTRO's Layer 7 'Agent Impersonation' is scoped to one agent impersonating another; a non-agent component (an MCP server) impersonating a well-known official one has no clean home in the current seven-layer, named-threat list."
+    }
+  ],
+  "coverage": {
+    "maestro_threats_mapped": 5,
+    "ave_classes_covered": 6,
+    "note_on_unmapped": "This is a deliberate pilot covering 3 of 7 layers and 5 of roughly 49 named layer/threat combinations. No claim is made about the other layers or threats; a full-corpus pass was not attempted here."
+  }
+}

--- a/crosswalks/ave-to-maestro.md
+++ b/crosswalks/ave-to-maestro.md
@@ -1,0 +1,99 @@
+# AVE → MAESTRO crosswalk (pilot)
+
+**Source:** AVE v1.1.0 — 80 records
+**Target:** MAESTRO (Multi-Agent Environment, Security, Threat, Risk, & Outcome),
+Cloud Security Alliance
+**Verified against live source:** 2026-08-30
+
+This is a deliberate pilot, not a full-corpus crosswalk: 6 AVE records mapped to
+5 of MAESTRO's roughly 49 layer/threat combinations (7 layers, each with 6-8
+named threats). The clearest, most unambiguous mechanism matches first, the
+same pilot-first approach already used for the OpenCRE and OWASP GenAI
+Crosswalk submissions.
+
+## The versioning premise, checked before building anything
+
+An earlier internal note treated a MAESTRO "v2" as a blocker for this
+crosswalk. That premise was re-verified independently before starting:
+
+- The CSA's own framework announcement carries no version marker anywhere in
+  its text.
+- `github.com/CloudSecurityAlliance/MAESTRO` (an AI-powered threat analyzer
+  tool built on the framework, not a versioned specification repo for the
+  framework itself) has zero tags and zero GitHub releases, despite being
+  actively pushed to as recently as 2026-08-27.
+- No search result, from any source, up to today mentions a "v2" or discrete
+  numbered release of the framework.
+
+MAESTRO evolves continuously through community contribution rather than
+discrete versioning. The blocker did not exist, and this crosswalk was not
+actually waiting on anything real.
+
+## Mapping
+
+| MAESTRO layer | Threat | AVE ids | Basis |
+|---|---|---|---|
+| Layer 3 - Agent Frameworks | Supply Chain Attacks (targeting dependencies) | AVE-2026-00062 | Direct. A mutable dependency reference lets the reviewed and executed artifact silently diverge after approval. |
+| Layer 4 - Deployment and Infrastructure | Infrastructure-as-Code (IaC) Manipulation | AVE-2026-00071 | A declared config value (`DOCKER_HOST`, or a `-H`/`--host` flag) is manipulated to redirect the container daemon to attacker infrastructure. Not a compromised image, not orchestration-layer exploitation. |
+| Layer 7 - Agent Ecosystem | Agent Goal Manipulation | AVE-2026-00007 | Direct, close to shared vocabulary already: AVE's own `attack_class` is "Prompt Injection - Goal Hijack." |
+| Layer 7 - Agent Ecosystem | Agent Tool Misuse | AVE-2026-00006, AVE-2026-00068 | Two distinct mechanisms, same threat: wallet-tool abuse (00006) and CLI command composition through shared OS state (00068). Both are misuse of an already-authorized tool, not a boundary failure. |
+| Layer 7 - Agent Ecosystem | Marketplace Manipulation | AVE-2026-00066 | Preemptive registration of names an LLM is statistically likely to hallucinate, on a public registry, with malicious content. |
+
+## What was checked and rejected, not just what passed
+
+- **AVE-2026-00006 (Cryptocurrency Drain)** was first considered for Layer 4's
+  "Resource Hijacking." That MAESTRO threat is about hijacked compute or
+  infrastructure resources (for example, cryptomining on stolen compute), not
+  financial or wallet theft carried out through an already-authorized tool.
+  Moved to Layer 7's "Agent Tool Misuse" instead, where the mechanism actually
+  matches.
+- **AVE-2026-00017 (Server Impersonation)** was considered for Layer 7's
+  "Agent Impersonation" and excluded from this pilot. MAESTRO's threat
+  concerns one *agent* impersonating another agent inside a multi-agent
+  ecosystem. AVE-2026-00017 describes an MCP server — a tool or service, not
+  itself an agent — impersonating a well-known official server. The
+  trust-exploitation shape is similar; the entity type MAESTRO's own layer
+  boundary is drawn around is not the same. Recorded as a gap rather than
+  forced, the same discipline already applied to AVE-2026-00059/00065 in the
+  OpenCRE pilot.
+- **AVE-2026-00066** was considered for Layer 7's "Malicious Agent Discovery"
+  before landing on "Marketplace Manipulation." "Malicious Agent Discovery"
+  reads as agent-specific (a malicious agent surfaced by a directory or
+  registry search); AVE-2026-00066's mechanism covers registry-squatting more
+  broadly (packages, repos, or skills, not agents specifically), which
+  "Marketplace Manipulation" names without narrowing to agents.
+
+## Gaps
+
+**In AVE, out of scope entirely:** Model Stealing / Model Extraction (Layer 1,
+Layer 6) — AVE catalogs behavioral classes in agentic components, not attacks
+on a foundation model's own weights or training process.
+
+**In AVE, unresolved elsewhere:** Denial of Service on computationally
+expensive queries (Layer 1) overlaps with an open internal question about a
+possible resource-exhaustion/agentic-DoS gap in AVE's own corpus. That
+question was not resolved as part of building this crosswalk; see the
+trust-strategy roadmap.
+
+**In MAESTRO:** no named threat currently covers non-agent component
+impersonation (AVE-2026-00017); see above.
+
+## Context for outreach
+
+MAESTRO's creator, Ken Huang (CSA AI Safety Working Groups co-chair), also
+created AST10 — the same person AVE already has an open crosswalk PR against
+(`crosswalks/ave-to-ast10.json`, `kenhuangus/agentic-skills-top-10#10`,
+currently stalled with no maintainer response). Worth knowing when framing any
+MAESTRO outreach, not a reason for extra hesitancy beyond what any crosswalk
+outreach already gets.
+
+## Scope discipline
+
+3 of 7 layers, 5 of roughly 49 named layer/threat combinations, 6 of 80 AVE
+records. No claim is made about the other layers, threats, or records. More
+can follow once this format is confirmed useful.
+
+---
+
+*Part of [AVE](https://aveproject.org)'s crosswalk set. See `ave-to-maestro.json`
+for the machine-readable version.*


### PR DESCRIPTION
Re-verified a stale premise before building anything: an internal note treated a MAESTRO "v2" as a blocker for this crosswalk. CSA's own framework post carries no version marker anywhere, and `CloudSecurityAlliance/MAESTRO` on GitHub has zero tags and zero releases despite being actively pushed to as recently as 2026-08-27. No search result anywhere mentions a discrete "v2." MAESTRO evolves continuously through community contribution, not by discrete release — the blocker never existed.

6 AVE records mapped to 5 of MAESTRO's named layer/threat combinations (7 layers, ~49 combinations total), a deliberate pilot following the same sizing discipline as the OpenCRE and GenAI Crosswalk pilots. Each mapping checked against the framework's own primary-source text directly, not category-name resemblance.

Two tempting matches were checked and rejected rather than forced, documented in the file's own note field:
- AVE-2026-00006 (Cryptocurrency Drain) doesn't fit Layer 4's "Resource Hijacking" (that's about hijacked compute/infrastructure, not wallet theft via an authorized tool) — mapped to Layer 7's "Agent Tool Misuse" instead.
- AVE-2026-00017 (Server Impersonation) is excluded from this pilot entirely: MAESTRO's "Agent Impersonation" is scoped to one agent impersonating another agent, not a non-agent service (an MCP server) impersonating a well-known one. Recorded as a gap rather than forced.

Validated: `scripts/validate_crosswalks.py` (10/10 pass) and `pytest tests/ -k crosswalk`.