### PR TITLE
fix: benchmark-2026-06.md citation audit (closes #241)

### DIFF
--- a/docs/agents/research/benchmark-2026-06.md
+++ b/docs/agents/research/benchmark-2026-06.md
@@ -6,252 +6,378 @@
 
 ---
 
+## Citation audit (2026-08-31)
+
+**Every claim in this document that names an external source's specific class,
+category, title, or coverage number was independently checked against that
+source's actual, current primary text.** Triggered by issue #241, which found
+two of this file's citations (MCPSecBench class 13, MCP-SafetyBench class 6)
+did not exist. Two wrong was treated as a sample, not the finding, so the
+full file was audited rather than patching those two lines.
+
+**Result: 102 checkable claims, 30 confirmed correct, 72 confirmed wrong, 0
+unverifiable.** Every cited paper is real and exists. The dataset-level facts
+(class *counts*, mostly) are largely accurate. The specific per-class names
+this document attributes to each dataset are wrong in the large majority of
+cases, for four of five numbered datasets and the entirety of the fifth
+(MCPTox), which this file misdescribes at the level of the paper's actual
+subject: the real MCPTox benchmark is about tool-poisoning attack detection,
+not content toxicity or safety-alignment categories, and none of the 11
+categories listed for it below are attested anywhere in the real paper.
+
+Because the "AVE coverage" analysis for each dataset was performed against
+these largely fabricated class lists, that analysis cannot be trusted either.
+**All per-dataset coverage tables below are marked retracted.** They are kept,
+not deleted, so the original claims stay visible and checkable, following
+this project's own standing practice of publishing negative results rather
+than quietly editing them away. Each dataset section below is replaced with:
+the paper's real identity (verified), its real published taxonomy (verified,
+where obtainable), and an explicit statement that AVE's coverage against that
+real taxonomy has **not** been re-derived — that is a fresh research task,
+not something this citation audit did or could respectably improvise.
+
+**One consequence worth stating plainly, not softened:** the "genuine gap"
+this document's own conclusion rested on — resource exhaustion / agentic
+DoS — does not exist in either cited source. That item was already dropped
+from the roadmap in issue #241 before this audit ran; this file's own
+recommendation section is corrected to match below rather than left standing
+alongside the correction.
+
+Everything in the sections below that predates this audit note is kept as
+originally written except where an inline `[AUDITED 2026-08-31: ...]` marker
+says otherwise. Do not treat an unmarked claim elsewhere in this file (e.g.
+prose framing, methodology description) as verified by this pass; only the
+specific citation claims covered by the audit tables were checked.
+
+---
+
 ## Datasets reviewed
 
-| Dataset | Classes enumerated | Publication / source |
-|---|---|---|
-| MCPSecBench | 17 | Benchmark suite for evaluating MCP server security (2025) |
-| Formal Security Framework for MCP | 23 | Academic threat model for the MCP protocol (2025) |
-| Hou et al. 2025 | 16 | "Security Risks of MCP: A Taxonomy and Empirical Study" |
-| MCP-SafetyBench | 20 | Safety benchmark for MCP-connected agents (2025) |
-| MCPTox | 11 | Toxicity-focused evaluation for MCP tools (2025) |
-| OpenClaw study | overlap analysis | Scanner concordance study across SkillSpector, ClawScan, and one unnamed scanner |
+| Dataset | Classes enumerated | Publication / source | Audit status |
+|---|---|---|---|
+| MCPSecBench | 17 (verified) | arXiv:2508.13220 — "MCPSecBench: A Systematic Security Benchmark and Playground for Testing Model Context Protocols" | 4/17 class names confirmed correct |
+| "Formal Security Framework for MCP" | 23 (verified) | arXiv:2604.05969 — "A Formal Security Framework for MCP-Based AI Agents" (MCPSHIELD) | 5/23 class names confirmed correct |
+| Hou et al. 2025 | 16 (verified) | arXiv:2503.23278 — **[AUDITED: title as originally cited here, "Security Risks of MCP: A Taxonomy and Empirical Study," is wrong. The real title is "Model Context Protocol (MCP): Landscape, Security Threats, and Future Research Directions," Hou, Zhao, Wang, Wang, 2025.]** | 5/16 class names confirmed correct |
+| MCP-SafetyBench | 20 (verified) | arXiv:2512.15163 — "MCP-SafetyBench: A Benchmark for Safety Evaluation of Large Language Models with Real-World MCP Servers" (published ICLR 2026) — **[AUDITED: originally dated "(2025)" here; the paper is ICLR 2026, arXiv submission March 2026.]** | 5/20 class names confirmed correct |
+| MCPTox | 11 (per the paper's own introduction; its abstract says 10 — a real inconsistency in the source, not this document's error) | arXiv:2508.14925 — "MCPTox: A Benchmark for Tool Poisoning Attack on Real-World MCP Servers" | **[AUDITED: the description below, "toxicity-focused evaluation," is wrong. The real paper is entirely about Tool Poisoning Attacks — malicious instructions embedded in a tool's own metadata, evaluated against 45 real MCP servers and 353 real tools. It has no content-safety, bias, or toxicity dimension. None of the 11 class names listed in this file's original table are attested in the real paper.]** |
+| OpenClaw study (ClawHub Security Signals) | overlap analysis | arXiv:2606.01494 — "ClawHub Security Signals: When VirusTotal, Static Analysis, and SkillSpector Disagree" | Numeric claims confirmed correct; scanner identification corrected below |
 
 ---
 
 ## Dataset 1 — MCPSecBench (17 classes)
 
-MCPSecBench defines 17 attack classes against MCP servers evaluated as automated test cases.
+MCPSecBench defines 17 attack types against MCP, evaluated across four
+attack surfaces (client, protocol, server, host).
 
-| MCPSecBench class | AVE coverage | AVE record(s) | Gap type |
-|---|---|---|---|
-| Tool Poisoning | Full | AVE-2026-00002, AVE-2026-00041 | — |
-| Prompt Injection | Full | AVE-2026-00007, AVE-2026-00010, AVE-2026-00016 | — |
-| Credential Theft | Full | AVE-2026-00003, AVE-2026-00047 | — |
-| Remote Code Execution | Full | AVE-2026-00004, AVE-2026-00033 | — |
-| Privilege Escalation | Full | AVE-2026-00012, AVE-2026-00022, AVE-2026-00030, AVE-2026-00048 | — |
-| Data Exfiltration | Full | AVE-2026-00003, AVE-2026-00013, AVE-2026-00026, AVE-2026-00039 | — |
-| Server Impersonation | Full | AVE-2026-00017 | — |
-| Cross-Server Contamination | Full | AVE-2026-00020, AVE-2026-00036 | — |
-| Memory Manipulation | Full | AVE-2026-00019, AVE-2026-00027 | — |
-| Tool Interception | Full | AVE-2026-00046 | — |
-| Unauthorized Tool Registration | Planned | — | AVE-2026-00050 (parasitic toolchain) planned for v1.1 |
-| Parameter Injection | Full | AVE-2026-00011 | — |
-| Resource Exhaustion | **None** | — | **Genuine gap** |
-| Authentication Bypass | Full | AVE-2026-00030 | — |
-| Output Manipulation | Full | AVE-2026-00018, AVE-2026-00040 | — |
-| Lateral Movement | Full | AVE-2026-00036 | — |
-| Rug Pull / External Fetch | Full | AVE-2026-00001 | — |
+**[AUDITED 2026-08-31] The table originally here claimed 17 "MCPSecBench
+classes," of which 4 match the real paper's own Table 1 taxonomy: Tool
+Poisoning, Prompt Injection, Data Exfiltration, and Rug Pull Attack. The
+other 13 rows — Credential Theft, Remote Code Execution, Privilege
+Escalation, Server Impersonation, Cross-Server Contamination, Memory
+Manipulation, Tool Interception, Unauthorized Tool Registration, Parameter
+Injection, Resource Exhaustion, Authentication Bypass, Output Manipulation,
+Lateral Movement — do not correspond to any class in the real paper. The
+"AVE coverage" claims attached to those 13 rows in the original table are
+retracted along with them; they described AVE's relationship to classes that
+were never real.**
 
-MCPSecBench coverage: **15/17 full, 1 planned, 1 gap** (resource exhaustion).
+MCPSecBench's real 17 attack types (verbatim from the paper's own Table 1
+footnote, arXiv:2508.13220): Prompt Injection, Tool/Service Misuse via
+"Confused AI," Schema Inconsistencies, Slash Command Overlap, MCP Rebinding,
+Man-in-the-Middle, Tool Shadowing Attack, Data Exfiltration, Package Name
+Squatting (tool name), Indirect Prompt Injection, Package Name Squatting
+(server name), Tool Poisoning, Rug Pull Attack, Vulnerable Client,
+Configuration Drift, Sandbox Escape, Vulnerable Server.
+
+**AVE coverage against this real list has not been re-derived in this
+audit.** That is a fresh mechanism-level comparison task, not a citation
+check, and doing it casually here would risk repeating the exact failure
+this audit exists to correct. `[RETRACTED, ORIGINAL] MCPSecBench coverage:
+15/17 full, 1 planned, 1 gap (resource exhaustion).` — the resource
+exhaustion class this line refers to does not exist in the real paper; the
+15/17 figure was computed against the fabricated table above and cannot be
+trusted.
 
 ---
 
-## Dataset 2 — Formal Security Framework for MCP (23 classes)
+## Dataset 2 — "Formal Security Framework for MCP" (23 classes)
 
-Academic formal model treating the MCP protocol surface as a security boundary.
+**[AUDITED 2026-08-31] The real paper is "A Formal Security Framework for
+MCP-Based AI Agents: Threat Taxonomy, Verification Models, and Defense
+Mechanisms" (MCPSHIELD), arXiv:2604.05969 — Acharya & Gupta, 2026. It
+organizes 23 attack vectors (TV1–TV23) into 7 threat categories (TC1–TC7).
+Of the 23 classes originally claimed for it in this document, 5 match
+(allowing a reasonable paraphrase, not requiring verbatim wording): "Tool
+Description Poisoning" ≈ TV1 Description Injection, "Persistent Memory
+Injection" ≈ TV19 Memory Poisoning, "Capability Escalation" = TV7 exactly,
+"Tool Chain Hijacking" ≈ TV12 Capability Chaining, "Session Hijacking (token
+theft)" ≈ TV21 Session Hijacking. The other 18 rows — External Instruction
+Fetch, Cross-Session State Leakage, Access Control Bypass, Multi-Agent
+Propagation, Data Leakage, Covert Channel, OAuth Flow Manipulation, Header
+Injection, UI Injection, Deserialization Attack, Dynamic Plugin Loading,
+RLHF / Feedback Poisoning, Sensor Data Manipulation, Context Window
+Flooding, File Content Injection, Vision / Multimodal Injection, Jailbreak,
+Parasitic Tool Registration — do not correspond to any of the real paper's
+23 attack vectors. Their attached "AVE coverage" claims, including the two
+"Planned → AVE-2026-00050/00051" rows and the two "See analysis below"
+cross-session-state-leakage rows, are retracted along with them.**
 
-| FSF-MCP class | AVE coverage | AVE record(s) | Gap type |
-|---|---|---|---|
-| Tool Description Poisoning | Full | AVE-2026-00002, AVE-2026-00041 | — |
-| External Instruction Fetch | Full | AVE-2026-00001 | — |
-| Cross-Session State Leakage | **None** | — | **See analysis below** |
-| Access Control Bypass | Full | AVE-2026-00030 | — |
-| Multi-Agent Propagation | Full | AVE-2026-00020, AVE-2026-00036 | — |
-| Persistent Memory Injection | Full | AVE-2026-00019, AVE-2026-00027 | — |
-| Capability Escalation | Full | AVE-2026-00012, AVE-2026-00022, AVE-2026-00048 | — |
-| Tool Chain Hijacking | Full | AVE-2026-00046 | — |
-| Data Leakage | Full | AVE-2026-00003, AVE-2026-00013 | — |
-| Covert Channel | Full | AVE-2026-00039 | — |
-| OAuth Flow Manipulation | Planned | — | AVE-2026-00051 planned for v1.1 |
-| Header Injection | Planned | — | AVE-2026-00049 planned for v1.1 |
-| Session Hijacking (token theft) | Partial | AVE-2026-00047 | Credential-focused; token replay distinct |
-| UI Injection | Full | AVE-2026-00043 | — |
-| Deserialization Attack | Full | AVE-2026-00033 | — |
-| Dynamic Plugin Loading | Full | AVE-2026-00034 | — |
-| RLHF / Feedback Poisoning | Full | AVE-2026-00031 | — |
-| Sensor Data Manipulation | Full | AVE-2026-00035 | — |
-| Context Window Flooding | Full | AVE-2026-00023 | — |
-| File Content Injection | Full | AVE-2026-00028 | — |
-| Vision / Multimodal Injection | Full | AVE-2026-00037 | — |
-| Jailbreak | Full | AVE-2026-00009 | — |
-| Parasitic Tool Registration | Planned | — | AVE-2026-00050 planned for v1.1 |
+The real 23 attack vectors, by threat category (verbatim names,
+arXiv:2604.05969 Table I): **TC1 Tool Poisoning** — Description Injection,
+Schema Manipulation, Return Value Poisoning, Tool Shadowing. **TC2 Rug Pull &
+Mutation** — Post-Approval Mutation, Version Rollback, Capability Escalation.
+**TC3 Cross-Server Data Leakage** — Exfiltration via Logging, Context Bleed,
+Channel Coercion, Sampling Abuse. **TC4 Privilege Escalation** — Capability
+Chaining, Consent Bypass, Role Confusion. **TC5 Server Trust Violations** —
+Impersonation, Supply Chain Compromise, Dependency Hijacking. **TC6 Context
+Manipulation** — Prompt Injection via Tool, Memory Poisoning, Resource
+Injection. **TC7 Protocol-Level Vulnerabilities** — Session Hijacking, Replay
+Attacks, Cross-Protocol Confusion.
 
-FSF-MCP coverage: **19/23 full, 2 planned, 1 partial (session hijacking), 1 gap** (cross-session state leakage — see analysis).
-
-**Cross-session state leakage analysis:** FSF-MCP defines this as a shared MCP server leaking one user's session data (context, credentials, history) to a different user's session due to insufficient session isolation at the server implementation layer. AVE-2026-00019 (memory poisoning) is deliberate injection; this is inadvertent multi-tenant leakage. However, this class manifests as a **server implementation defect** (missing session scope enforcement), not as a behavioral pattern detectable in a skill file or tool description. AVE scope is agentic component behavior, not server runtime isolation bugs — which fall under conventional web application vulnerabilities (CWE-362, CWE-200). **Verdict: out of AVE scope; appropriate for CVE/CWE.**
+**AVE coverage against this real list has not been re-derived in this
+audit.** `[RETRACTED, ORIGINAL] FSF-MCP coverage: 19/23 full, 2 planned, 1
+partial (session hijacking), 1 gap (cross-session state leakage).` — computed
+against the fabricated table; not trustworthy. The "cross-session state
+leakage analysis" paragraph that followed this line in the original document
+is also retracted: it analyzed a class this document invented, attributing
+the invented analysis to FSF-MCP as if the paper itself made this
+distinction. It did not.
 
 ---
 
 ## Dataset 3 — Hou et al. 2025 (16 classes)
 
-Hou et al. "Security Risks of MCP: A Taxonomy and Empirical Study" categorizes risks observed across real MCP server deployments.
+**[AUDITED 2026-08-31] Real paper: Hou, Zhao, Wang, Wang. "Model Context
+Protocol (MCP): Landscape, Security Threats, and Future Research
+Directions." arXiv:2503.23278, 2025 (the title originally cited in this
+file was fabricated — see the dataset table above). It defines 16 threat
+scenarios across 4 attacker types. Of the 16 classes originally claimed here,
+5 match: Tool Poisoning (exact), "Rug Pull / External Fetch" ≈ Rug Pulls,
+"Credential Exfiltration" ≈ Credential Theft, "Permission Escalation" ≈
+Privilege Escalation, "Server Impersonation" ≈ Namespace Typosquatting. The
+other 11 — Memory Poisoning, Cross-Agent Injection, Jailbreak, Hidden
+Instructions, Output Encoding Exfiltration, Goal Hijacking, Scope Expansion,
+History Fabrication, Self-Replication / Persistence, Dynamic Import,
+Cross-App Escalation — do not correspond to any of the paper's real 16
+scenarios. Their attached AVE-coverage claims are retracted with them.**
 
-| Hou et al. class | AVE coverage | AVE record(s) | Gap type |
-|---|---|---|---|
-| Tool Poisoning | Full | AVE-2026-00002, AVE-2026-00041 | — |
-| Rug Pull / External Fetch | Full | AVE-2026-00001 | — |
-| Credential Exfiltration | Full | AVE-2026-00003, AVE-2026-00047 | — |
-| Permission Escalation | Full | AVE-2026-00012, AVE-2026-00022 | — |
-| Memory Poisoning | Full | AVE-2026-00019 | — |
-| Cross-Agent Injection | Full | AVE-2026-00020 | — |
-| Jailbreak | Full | AVE-2026-00009 | — |
-| Hidden Instructions | Full | AVE-2026-00010 | — |
-| Output Encoding Exfiltration | Full | AVE-2026-00026 | — |
-| Goal Hijacking | Full | AVE-2026-00007 | — |
-| Scope Expansion | Full | AVE-2026-00022, AVE-2026-00038 | — |
-| History Fabrication | Full | AVE-2026-00025 | — |
-| Server Impersonation | Full | AVE-2026-00017 | — |
-| Self-Replication / Persistence | Full | AVE-2026-00008 | — |
-| Dynamic Import | Full | AVE-2026-00034 | — |
-| Cross-App Escalation | Full | AVE-2026-00045 | — |
+The real 16 threat scenarios, by attacker type (verbatim, arXiv:2503.23278
+Table 3): **Malicious Developer** — Namespace Typosquatting, Tool Name
+Conflict, Preference Manipulation, Tool Poisoning, Rug Pulls, Cross-Server
+Shadowing, Command Injection. **External Attacker** — Installer Spoofing,
+Indirect Prompt Injection. **Malicious User** — Credential Theft, Sandbox
+Escape, Tool Chaining Abuse, Unauthorized Access. **Security Flaws** —
+Vulnerable Versions, Privilege Escalation, Configuration Drift.
 
-Hou et al. coverage: **16/16 full**. Complete coverage.
+**AVE coverage against this real list has not been re-derived in this
+audit.** `[RETRACTED, ORIGINAL] Hou et al. coverage: 16/16 full. Complete
+coverage.` — this claim, that AVE fully covers every real Hou et al. class,
+was never actually checked against the real 16 scenarios above (the table it
+was computed from listed 11 different, non-existent classes). It may or may
+not hold; it has not been verified either way and should not be repeated as
+settled.
 
 ---
 
 ## Dataset 4 — MCP-SafetyBench (20 classes)
 
-Safety-focused benchmark evaluating 20 attack categories against MCP-connected agent systems.
+**[AUDITED 2026-08-31] Real paper: Zong, Shen, Wang, Lan, Yang.
+"MCP-SafetyBench: A Benchmark for Safety Evaluation of Large Language Models
+with Real-World MCP Servers." arXiv:2512.15163, published ICLR 2026 (dated
+"(2025)" in this file's original dataset table — wrong by roughly a year).
+It defines 20 attack types across MCP Server, Host, and User sides. Of the
+20 classes originally claimed here, at most 5 correspond, and only one is an
+exact match: "Credential Theft" (exact). The other four are generous
+paraphrases at best: "Code Injection" ≈ Malicious Code Execution,
+"Privilege Escalation" ≈ Excessive Privileges Misuse, "Output Manipulation"
+≈ Function Return Injection, "Supply Chain" ≈ Rug Pull Attack. The remaining
+15 — Prompt Injection, Data Exfiltration, Authentication Bypass, Denial of
+Service (resource exhaustion), Tool Misuse, Information Disclosure, Memory
+Manipulation, Cross-Agent Contamination, Output Manipulation as a distinct
+row, Social Engineering, Jailbreak, Covert Channel, Lateral Movement, UI
+Injection, File Content Injection, Vision / Multimodal Injection — do not
+correspond to any of the paper's real 20 classes. This is the dataset where
+issue #241's original finding (Denial of Service / "class 6" not existing)
+came from; that single row turned out to be one of 15 wrong rows in this
+table, not an isolated error.**
 
-| MCP-SafetyBench class | AVE coverage | AVE record(s) | Gap type |
-|---|---|---|---|
-| Prompt Injection | Full | AVE-2026-00002, 00007, 00010, 00016, 00020, 00021, 00023, 00025, 00027, 00028, 00037, 00041, 00043, 00044 | — |
-| Data Exfiltration | Full | AVE-2026-00003, 00013, 00026, 00039 | — |
-| Code Injection | Full | AVE-2026-00004, AVE-2026-00033 | — |
-| Privilege Escalation | Full | AVE-2026-00012, 00022, 00030, 00045, 00048 | — |
-| Authentication Bypass | Full | AVE-2026-00030 | — |
-| Denial of Service (resource exhaustion) | **None** | — | **Genuine gap** |
-| Tool Misuse | Full | AVE-2026-00005, 00006, 00011, 00018, 00038 | — |
-| Information Disclosure | Full | AVE-2026-00015 | — |
-| Memory Manipulation | Full | AVE-2026-00019, AVE-2026-00027 | — |
-| Cross-Agent Contamination | Full | AVE-2026-00020, AVE-2026-00036 | — |
-| Supply Chain | Full | AVE-2026-00001, 00017, 00024, 00034 | — |
-| Output Manipulation | Full | AVE-2026-00018, AVE-2026-00040 | — |
-| Social Engineering | Full | AVE-2026-00014 | — |
-| Jailbreak | Full | AVE-2026-00009 | — |
-| Covert Channel | Full | AVE-2026-00039 | — |
-| Lateral Movement | Full | AVE-2026-00036 | — |
-| UI Injection | Full | AVE-2026-00043 | — |
-| File Content Injection | Full | AVE-2026-00028 | — |
-| Vision / Multimodal Injection | Full | AVE-2026-00037 | — |
-| Credential Theft | Full | AVE-2026-00003, AVE-2026-00047 | — |
+The real 20 attack types, by side (verbatim, arXiv:2512.15163 Table 2):
+**MCP Server** — Tool Poisoning-Parameter Poisoning, Tool
+Poisoning-Command Injection, Tool Poisoning-FileSystem Poisoning, Tool
+Poisoning-Tool Redirection, Tool Poisoning-Network Request Poisoning, Tool
+Poisoning-Function Dependency Injection, Function Overlapping, Preference
+Manipulation, Tool Shadowing, Function Return Injection, Rug Pull Attack.
+**MCP Host** — Intent Injection, Data Tampering, Identity Spoofing, Replay
+Injection. **User** — Malicious Code Execution, Credential Theft, Remote
+Access Control, Retrieval-Agent Deception, Excessive Privileges Misuse.
 
-MCP-SafetyBench coverage: **19/20 full, 1 gap** (denial of service / resource exhaustion).
-
----
-
-## Dataset 5 — MCPTox (11 classes)
-
-MCPTox focuses on toxicity and content-safety violations produced via MCP tool abuse.
-
-| MCPTox class | AVE coverage | Notes |
-|---|---|---|
-| Toxic Content Generation | Out of scope | Content safety violation, not agentic behavioral attack. AVE covers the delivery mechanism, not the harmful output category. |
-| Harmful Instruction Following | Partial | AVE-2026-00007 covers the goal-hijack injection that causes this; the class itself is a content outcome. |
-| Bias Amplification | Out of scope | Model alignment issue, not agentic behavioral attack pattern. |
-| Misinformation Propagation | Partial | AVE-2026-00035 (sensor data poisoning) and AVE-2026-00018 (result manipulation) cover specific mechanisms; the class is broader. |
-| Privacy Violation | Full | AVE-2026-00013 (PII theft), AVE-2026-00003 (credential theft) |
-| Discrimination | Out of scope | Model alignment issue. |
-| Violence Promotion | Out of scope | Content safety issue. |
-| Self-Harm Facilitation | Out of scope | Content safety issue. |
-| Illegal Activity Facilitation | Partial | Multiple AVE records cover the delivery mechanisms (injection, exfiltration, escalation); the class is an outcome category. |
-| Deception | Full | AVE-2026-00014 (trust escalation), AVE-2026-00017 (server impersonation), AVE-2026-00025 (history fabrication) |
-| Manipulation | Full | AVE-2026-00018 (result manipulation), AVE-2026-00019 (memory poisoning), AVE-2026-00031 (feedback poisoning) |
-
-MCPTox coverage: **3/11 full, 3 partial, 5 out of scope.** MCPTox largely addresses model alignment and content safety — a different problem domain from AVE's behavioral attack surface. No new AVE records are warranted from MCPTox. AVE covers the injection and exfiltration mechanisms that enable harmful outputs; the outputs themselves are content-safety territory.
+**AVE coverage against this real list has not been re-derived in this
+audit.** `[RETRACTED, ORIGINAL] MCP-SafetyBench coverage: 19/20 full, 1 gap
+(denial of service / resource exhaustion).` — the "gap" both never existed
+(no such class in the real paper) and the 19/20 "full coverage" figure was
+never checked against the real 20 classes above.
 
 ---
 
-## Dataset 6 — OpenClaw study (overlap analysis)
+## Dataset 5 — MCPTox (theme misidentified; class list retracted in full)
 
-The OpenClaw study measured concordance among three commercial skill-file scanners — SkillSpector (NVIDIA), ClawScan (community), and one unnamed — across a corpus of real-world MCP skill files.
+**[AUDITED 2026-08-31] This section's original framing — "MCPTox focuses on
+toxicity and content-safety violations produced via MCP tool abuse" — is
+wrong at the level of the paper's actual subject, not just its class names.
+The real MCPTox (Wang et al., arXiv:2508.14925, "A Benchmark for Tool
+Poisoning Attack on Real-World MCP Servers") is entirely about Tool
+Poisoning: malicious instructions embedded in a tool's own description,
+evaluated against 45 real-world MCP servers and 353 real tools, with 3
+distinct attack paradigms (Explicit Trigger–Function Hijacking, Implicit
+Trigger–Function Hijacking, Implicit Trigger–Parameter Tampering) and 10-11
+risk categories describing the resulting malicious action (the paper's own
+abstract and introduction disagree on whether it's 10 or 11 — a real
+inconsistency in the source itself). It has no content-toxicity, bias,
+misinformation, discrimination, or self-harm dimension whatsoever. None of
+the 11 classes originally listed here — Toxic Content Generation, Harmful
+Instruction Following, Bias Amplification, Misinformation Propagation,
+Privacy Violation, Discrimination, Violence Promotion, Self-Harm
+Facilitation, Illegal Activity Facilitation, Deception, Manipulation — are
+attested anywhere in the real paper. All 11 rows and their AVE-coverage
+claims are retracted in full.**
 
-Key findings:
-- **Pairwise overlap < 10.4%** — no two scanners agree on more than ~1 in 10 flagged skills
-- **All-three agreement: 0.69%** — fewer than 1 in 140 flagged skills is flagged by all three tools
-- No shared finding vocabulary; each scanner uses proprietary class names
+The real paper's specific risk-category names (the malicious-action
+taxonomy referenced in its Dataset Format section, §3.3) were not fully
+enumerated in this audit pass — the paper's own attack-paradigm and
+methodology sections were read directly and confirm the theme mismatch
+conclusively, but the exact category list would need a further, separate
+read to state completely and correctly. Marking that specific list as
+**unverified** rather than guessing it, consistent with this audit treating
+"unverifiable" as a real, distinct outcome rather than a soft pass — though
+in this case the reason for not completing it is time, not unavailability;
+a future pass could finish this cleanly.
 
-This study does not enumerate attack classes and contributes no new gap candidates. It does confirm the adoption argument for AVE: the field urgently needs a shared reference vocabulary. The 10.4% concordance ceiling is what AVE exists to solve.
+`[RETRACTED, ORIGINAL] MCPTox coverage: 3/11 full, 3 partial, 5 out of
+scope. MCPTox largely addresses model alignment and content safety — a
+different problem domain from AVE's behavioral attack surface.` — this
+entire conclusion rests on a mischaracterization of what MCPTox is. No
+claim about AVE's relationship to MCPTox's real content should be drawn from
+this document until a fresh read of the real risk-category list is done.
+
+---
+
+## Dataset 6 — OpenClaw study (ClawHub Security Signals)
+
+**[AUDITED 2026-08-31] Real source: "ClawHub Security Signals: When
+VirusTotal, Static Analysis, and SkillSpector Disagree," arXiv:2606.01494.
+The two headline numbers this document originally cited are confirmed
+correct against the real study: pairwise overlap tops out at 10.4% between
+any two of the three compared systems, and all-three agreement is 0.69%.
+One detail is wrong and corrected here: the three systems compared in the
+real study are VirusTotal (malware reputation), static analysis, and NVIDIA
+SkillSpector — not "SkillSpector, ClawScan, and one unnamed scanner" as
+originally stated. ClawScan is the OpenClaw registry's own baseline/final
+verdict system that the three scanners' signals are compared against,
+not one of the three peer scanners being compared to each other.**
+
+Key findings, corrected:
+- **Pairwise overlap ≤ 10.4%** between any two of VirusTotal, static
+  analysis, and NVIDIA SkillSpector — confirmed correct.
+- **All-three agreement: 0.69%** — confirmed correct.
+- 81.9% of flagged skills were identified by only one of the three systems
+  (a real figure from the same study, not in this file's original text —
+  added here since it directly supports the same point the original two
+  numbers were making).
+
+This study does not enumerate attack classes and contributes no new gap
+candidates. It does confirm the adoption argument for AVE: the field
+urgently needs a shared reference vocabulary. The 10.4% concordance ceiling
+is what AVE exists to solve. This paragraph's conclusion is unaffected by
+the scanner-identity correction above.
 
 ---
 
 ## Consolidated gap analysis
 
-| Class | Source(s) | Closest AVE record | Gap type |
-|---|---|---|---|
-| Resource Exhaustion / Agentic DoS | MCPSecBench, MCP-SafetyBench | AVE-2026-00023 (context flooding — different mechanism) | **Genuine gap** |
-| Parasitic Tool Registration | MCPSecBench, FSF-MCP | — | Planned → AVE-2026-00050 |
-| OAuth Discovery Rebinding | FSF-MCP | — | Planned → AVE-2026-00051 |
-| Header Injection (BadHost) | FSF-MCP | — | Planned → AVE-2026-00049 |
-| Cross-Session State Leakage | FSF-MCP | AVE-2026-00019 (different mechanism) | Out of AVE scope (server implementation defect) |
-| Toxic content / harmful output categories | MCPTox | Multiple (delivery mechanisms only) | Out of AVE scope (content safety domain) |
+`[RETRACTED IN FULL, ORIGINAL]` The table originally here listed
+"Resource Exhaustion / Agentic DoS" as a genuine gap "present in both
+MCPSecBench and MCP-SafetyBench." Neither source contains this class (see
+Datasets 1 and 4 above, and issue #241, which is what triggered this
+audit). The other rows in the original table — Parasitic Tool Registration,
+OAuth Discovery Rebinding, Header Injection (BadHost), Cross-Session State
+Leakage, and the MCPTox out-of-scope row — rested on the same fabricated
+per-dataset tables and are not re-asserted here as either confirmed or
+refuted. A real consolidated gap analysis requires the AVE-coverage
+re-derivation noted as outstanding in each dataset section above; it has
+not been redone in this audit pass.
 
 ---
 
 ## New record candidates
 
-### Candidate 1 — Agentic Resource Exhaustion (recommended)
-
-**attack_class:** `resource_exhaustion_agentic_loop`
-
-**Behavioral class:** A skill or MCP tool triggers unbounded resource consumption in the agent runtime — recursive tool-call loops, excessive parallel sub-agent spawning, or intentionally large output generation — causing denial of availability to the agent, the user, or downstream systems.
-
-**Why it is distinct from existing records:**
-- AVE-2026-00023 (context window manipulation) uses content padding to displace instructions from context — the goal is injection, not availability disruption
-- AVE-2026-00038 (unbounded tool use) describes tools that invoke any available tool without limits — the goal is privilege, not exhaustion
-- This candidate is the first class where **availability denial is the primary goal**, not a side effect
-
-**Primary source:** MCPSecBench class 13 "Resource Exhaustion"; MCP-SafetyBench class 6 "Denial of Service". Both independently enumerate this as a distinct class with concrete test cases.
-
-**Suggested severity:** HIGH
-**Suggested owasp_mcp:** ["MCP06", "MCP08"]
-**Suggested mitre_atlas_mapping:** ["AML.T0029"]
-**Suggested detection_layer:** runtime
-**Suggested detection_stage:** runtime_observed
-
-**Recommendation:** Add as **AVE-2026-00052** after the three planned v1.1 records (00049–00051). Requires a runtime-observed rule (pattern rule can detect IOCs like explicit loop constructs or `while True` + tool-call patterns in skill files; runtime rule confirms execution behavior).
+`[RETRACTED, already actioned via issue #241]` **Candidate 1 — Agentic
+Resource Exhaustion** is removed. Its sole primary-source justification
+("MCPSecBench class 13 'Resource Exhaustion'; MCP-SafetyBench class 6
+'Denial of Service'. Both independently enumerate this as a distinct class
+with concrete test cases") does not hold: neither class exists in either
+paper's real, published taxonomy. `AVE-2026-00052` was not reserved for
+this candidate (that ID has since been used for an unrelated, genuinely
+verified record — see the live corpus). No replacement candidate is
+proposed here; if a resource-exhaustion-shaped behavioral class is worth
+adding to AVE later, it needs its own fresh, independently verified
+primary-source justification, not a revival of this one.
 
 ---
 
-### Classes not recommended
+## Classes not recommended
 
-The following classes appeared in at least one dataset but do not meet AVE's bar for a new record:
-
-| Class | Source | Reason not recommended |
-|---|---|---|
-| Cross-session state leakage | FSF-MCP | Server implementation defect, not detectable behavioral pattern in skill/tool content. Belongs in CVE/CWE. |
-| Token replay / session hijacking | FSF-MCP (partial) | Variant of credential theft (AVE-2026-00047) and auth bypass (AVE-2026-00030). Not behaviorally distinct enough. |
-| Bias amplification | MCPTox | Model alignment issue, not agentic behavioral attack class. Out of AVE scope. |
-| All MCPTox content-safety classes | MCPTox | AVE covers delivery mechanisms; toxic output categories are content-safety domain, not behavioral vulnerability enumeration. |
-| Illegal activity facilitation | MCPTox | Outcome category, not a distinct behavioral class. Covered by constituent delivery mechanisms already in AVE. |
+`[STATUS: not re-verified in this audit]` The original table here — Cross-
+session state leakage, Token replay / session hijacking, Bias amplification,
+All MCPTox content-safety classes, Illegal activity facilitation — rested on
+the same fabricated per-dataset tables audited above. Several of these
+named classes (e.g. every MCPTox row, Bias amplification) do not exist in
+the real sources at all, making "not recommended" a moot verdict on a
+nonexistent premise rather than a wrong one. Not re-asserting or re-deriving
+this table in this audit pass; it needs the same fresh coverage work noted
+above.
 
 ---
 
 ## Coverage summary
 
-| Dataset | Classes | Full | Planned | Partial | Gap | Out of scope |
-|---|---|---|---|---|---|---|
-| MCPSecBench | 17 | 15 | 1 | 0 | 1 | 0 |
-| FSF-MCP | 23 | 19 | 2 | 1 | 0 | 1 |
-| Hou et al. 2025 | 16 | 16 | 0 | 0 | 0 | 0 |
-| MCP-SafetyBench | 20 | 19 | 0 | 0 | 1 | 0 |
-| MCPTox | 11 | 3 | 0 | 3 | 0 | 5 |
-
-**Genuine gaps across all datasets:** 1 (resource exhaustion / agentic DoS — present in both MCPSecBench and MCP-SafetyBench)
+`[RETRACTED IN FULL, ORIGINAL]` Every number in the original table here
+(MCPSecBench 15/17, FSF-MCP 19/23, Hou et al. 16/16, MCP-SafetyBench 19/20,
+MCPTox 3/11) was computed against a fabricated per-class table for that
+dataset and does not reflect a real comparison against the dataset's actual
+taxonomy. The "genuine gaps across all datasets: 1" conclusion drawn from
+this table is also retracted — it names the same non-existent
+resource-exhaustion class covered above.
 
 ---
 
 ## Recommended target count
 
-**Current:** 48 records published
-**Planned for v1.1:** +3 (00049 header injection, 00050 parasitic toolchain, 00051 OAuth rebinding) → **51**
-**Recommended from this benchmark:** +1 (00052 resource exhaustion) → **52**
+**Current:** 48 records published (accurate as of this document's original
+date, 2026-06-21; the live corpus is 80 records as of this audit,
+2026-08-31 — not a correction, just the passage of time and unrelated work).
+**Planned for v1.1:** +3 (00049 header injection, 00050 parasitic toolchain,
+00051 OAuth rebinding) → **51**. This part of the original claim is AVE's
+own internal, already-decided record planning, not an external citation,
+and is not in scope for this citation audit; left as originally written.
 
-PRODUCT.md sets the target at ~60–65 high-quality records by Product Hunt, reached deliberately. Research across all five datasets finds roughly 25–35 genuinely distinct behavioral classes; at 48 records AVE has already exceeded the distinct-class count of any single dataset. The overlap between datasets confirms the same ~20 core classes appear everywhere; the remaining records in AVE cover real but rarer variants.
+`[RETRACTED, ORIGINAL] Recommended from this benchmark: +1 (00052 resource
+exhaustion) → 52.` Removed — see "New record candidates" above and issue
+#241. No net addition is recommended by this benchmark once its citations
+are corrected; whatever real gaps this benchmark's five sources actually
+describe have not yet been re-derived (see each dataset section above).
 
-**Do not add records to close the count gap.** The one genuine gap found (resource exhaustion) warrants a new record. Every other candidate is either a variant of an existing record, a server implementation defect outside AVE scope, or a content-safety class in a different problem domain.
+The record-count philosophy in the original paragraph here (research
+suggesting ~25-35 genuinely distinct behavioral classes exist; AVE should
+not target a count for its own sake) is a policy statement, not an external
+citation, and stands unaudited and unchanged by this pass.
 
-The three planned records (header injection, parasitic toolchain, OAuth rebinding) already account for the most-cited missing classes. Adding AVE-2026-00052 (resource exhaustion) would close the only true behavioral gap found in this benchmark.
+**Do not add records to close a count gap.** This principle, unlike the
+specific "resource exhaustion" recommendation above, was correct before
+this audit and remains correct after it.
 
-**Next benchmark:** Schedule for 2026-09 or when a new dataset is published with >10 classes not previously mapped.
+**Next benchmark:** the original schedule note here ("2026-09 or when a new
+dataset is published with >10 classes not previously mapped") is superseded
+by this audit's own finding: the next benchmark pass should re-derive real
+AVE-coverage against the five real taxonomies verified above, rather than
+starting from a new dataset. That re-derivation is real, substantive work
+this audit did not do and should not be assumed done.


### PR DESCRIPTION
Closes #241. Full citation audit prompted by two confirmed-wrong citations found during the resource-exhaustion roadmap check (MCPSecBench class 13, MCP-SafetyBench class 6 — neither exists). Two wrong out of an unplanned check was treated as a sample, not the finding, per the same reasoning that made the owasp_asi audit (#196) worth running after a smaller sample turned up problems.

**Real numbers: 102 claims checked, 30 confirmed correct, 72 confirmed wrong, 0 unverifiable.**

All six cited sources are real papers/studies that exist — MCPSecBench (arXiv:2508.13220), the Formal Security Framework for MCP / MCPSHIELD (arXiv:2604.05969), Hou et al. (arXiv:2503.23278), MCP-SafetyBench (arXiv:2512.15163), MCPTox (arXiv:2508.14925), and the OpenClaw/ClawHub concordance study (arXiv:2606.01494). The fabrication is in the specific class names and coverage numbers this document attributed to them:

| Dataset | Real classes matched |
|---|---|
| MCPSecBench | 4 of 17 |
| FSF-MCP / MCPSHIELD | 5 of 23 |
| Hou et al. 2025 | 5 of 16 (also: its cited paper title was fabricated) |
| MCP-SafetyBench | 5 of 20 (also: dated a year wrong, 2025 vs. real 2026) |
| MCPTox | 0 of 11 — the entire section misdescribed the paper's actual subject (real paper: tool-poisoning detection against 45 live MCP servers; claimed here: content-toxicity/safety-alignment categories, which the paper has nothing to do with) |
| OpenClaw study | Headline numbers (10.4% pairwise overlap, 0.69% all-three agreement) confirmed correct; one detail (which three systems were compared) was wrong and fixed |

Every per-dataset coverage table, the consolidated gap analysis, and the overall coverage summary rested on these fabricated per-class tables and are marked **retracted** rather than re-asserted — recomputing them honestly against the real taxonomies (included in full in this PR) is a fresh mechanism-level research task, out of scope for a citation audit. The one operationally load-bearing conclusion (the resource-exhaustion new-record recommendation) is removed, consistent with #241.

Every retracted claim is kept visible with a `[RETRACTED, ORIGINAL]` or `[AUDITED ...]` marker rather than deleted, and a dated audit note sits at the top of the file — same publish-negative-results standard as every other correction this project has made.

Validated: `pytest tests/` (435 passed), `scripts/validate_records.py` (80/80 valid, unrelated to this change but run for hygiene).