### PR TITLE
feat: framework_sources backfill (owasp_asi, mitre_atlas), and a schema fix it needed first

### DIFF
--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -149,7 +149,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00001",
@@ -289,7 +299,17 @@
     "derivable_into": [
       "rug-pull-chain",
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00002",
@@ -420,7 +440,17 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00006",
@@ -549,7 +579,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00041",
@@ -695,7 +735,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00047",
@@ -842,7 +892,13 @@
       "yara",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00048",
@@ -987,7 +1043,17 @@
     ],
     "derivable_into": [
       "privilege-escalation-chain"
-    ]
+    ],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00049",
@@ -1130,7 +1196,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00050",
@@ -1278,7 +1350,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00051",
@@ -1423,7 +1505,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00052",
@@ -1564,7 +1652,13 @@
     "derivable_into": [
       "remote-control-chain",
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00055",
@@ -1706,7 +1800,13 @@
     "derivable_into": [
       "rug-pull-chain",
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00059",
@@ -1848,7 +1948,17 @@
     "derivable_into": [
       "remote-control-chain",
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00060",
@@ -2083,7 +2193,13 @@
     "derivable_into": [
       "remote-control-chain",
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00074",
@@ -2215,7 +2331,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00003",
@@ -2346,7 +2468,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00004",
@@ -2480,7 +2612,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00005",
@@ -2612,7 +2754,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00007",
@@ -2743,7 +2895,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00008",
@@ -2874,7 +3036,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00009",
@@ -3006,7 +3178,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00010",
@@ -3135,7 +3317,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00011",
@@ -3264,7 +3452,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00012",
@@ -3394,7 +3592,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00013",
@@ -3526,7 +3734,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00015",
@@ -3651,7 +3869,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00016",
@@ -3778,7 +4002,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00017",
@@ -3902,7 +4136,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00018",
@@ -4024,7 +4268,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00019",
@@ -4153,7 +4407,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00020",
@@ -4279,7 +4543,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00021",
@@ -4400,7 +4674,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00022",
@@ -4525,7 +4805,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00023",
@@ -4645,7 +4935,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00024",
@@ -4769,7 +5069,13 @@
       "semgrep",
       "magika"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00025",
@@ -4892,7 +5198,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00026",
@@ -5016,7 +5328,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00027",
@@ -5144,7 +5466,17 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00028",
@@ -5270,7 +5602,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00029",
@@ -5392,7 +5734,17 @@
       "pattern",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00030",
@@ -5516,7 +5868,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00031",
@@ -5642,7 +6000,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00032",
@@ -5768,7 +6136,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00033",
@@ -5896,7 +6274,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00034",
@@ -6028,7 +6416,17 @@
       "semgrep",
       "yara"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00035",
@@ -6149,7 +6547,13 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00036",
@@ -6277,7 +6681,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00037",
@@ -6402,7 +6816,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00038",
@@ -6527,7 +6951,13 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00039",
@@ -6654,7 +7084,17 @@
       "yara",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00040",
@@ -6779,7 +7219,13 @@
       "pattern",
       "semgrep"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00042",
@@ -6922,7 +7368,17 @@
     ],
     "derivable_into": [
       "rug-pull-chain"
-    ]
+    ],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00043",
@@ -7058,7 +7514,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00044",
@@ -7193,7 +7659,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00045",
@@ -7342,7 +7818,17 @@
     "derivable_into": [
       "credential-exfiltration",
       "privilege-escalation-chain"
-    ]
+    ],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00053",
@@ -7481,7 +7967,13 @@
     ],
     "derivable_into": [
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00054",
@@ -7611,7 +8103,13 @@
     "derivable_into": [
       "remote-control-chain",
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00056",
@@ -7734,7 +8232,13 @@
     ],
     "derivable_into": [
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00057",
@@ -8064,7 +8568,13 @@
     "evidence_basis_engines": [
       "pattern"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00063",
@@ -8415,7 +8925,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00067",
@@ -8509,7 +9025,13 @@
       "sandbox",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00068",
@@ -8604,7 +9126,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00069",
@@ -8703,7 +9231,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00070",
@@ -8809,7 +9343,13 @@
     "derivable_into": [
       "remote-control-chain",
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00071",
@@ -8928,7 +9468,13 @@
     "evidence_basis_engines": [
       "pattern"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00072",
@@ -9300,7 +9846,13 @@
     ],
     "derivable_into": [
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00076",
@@ -9432,7 +9984,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00077",
@@ -9569,7 +10127,13 @@
     ],
     "derivable_into": [
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00078",
@@ -10068,7 +10632,17 @@
       "semgrep",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "mitre_atlas": {
+        "pin_status": "unknown",
+        "read_date": "2026-08-09"
+      },
+      "owasp_asi": {
+        "version": "2026",
+        "read_date": "2026-08-23"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00058",

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 80,
-  "generated_at": "2026-08-30T00:47:26.044Z",
+  "generated_at": "2026-09-04T22:52:59.880Z",
   "source": "https://github.com/aveproject/ave"
 }

--- a/records/AVE-2026-00001.json
+++ b/records/AVE-2026-00001.json
@@ -136,5 +136,15 @@
   "derivable_into": [
     "rug-pull-chain",
     "remote-control-chain"
-  ]
+  ],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00002.json
+++ b/records/AVE-2026-00002.json
@@ -125,5 +125,15 @@
   ],
   "derivable_into": [
     "remote-control-chain"
-  ]
+  ],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00003.json
+++ b/records/AVE-2026-00003.json
@@ -125,5 +125,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00004.json
+++ b/records/AVE-2026-00004.json
@@ -127,5 +127,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00005.json
+++ b/records/AVE-2026-00005.json
@@ -126,5 +126,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00006.json
+++ b/records/AVE-2026-00006.json
@@ -123,5 +123,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00007.json
+++ b/records/AVE-2026-00007.json
@@ -125,5 +125,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00008.json
+++ b/records/AVE-2026-00008.json
@@ -125,5 +125,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00009.json
+++ b/records/AVE-2026-00009.json
@@ -126,5 +126,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00010.json
+++ b/records/AVE-2026-00010.json
@@ -125,5 +125,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00011.json
+++ b/records/AVE-2026-00011.json
@@ -123,5 +123,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00012.json
+++ b/records/AVE-2026-00012.json
@@ -124,5 +124,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00013.json
+++ b/records/AVE-2026-00013.json
@@ -126,5 +126,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00014.json
+++ b/records/AVE-2026-00014.json
@@ -117,5 +117,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00015.json
+++ b/records/AVE-2026-00015.json
@@ -119,5 +119,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00016.json
+++ b/records/AVE-2026-00016.json
@@ -120,5 +120,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00017.json
+++ b/records/AVE-2026-00017.json
@@ -118,5 +118,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00018.json
+++ b/records/AVE-2026-00018.json
@@ -116,5 +116,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00019.json
+++ b/records/AVE-2026-00019.json
@@ -122,5 +122,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00020.json
+++ b/records/AVE-2026-00020.json
@@ -122,5 +122,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00021.json
+++ b/records/AVE-2026-00021.json
@@ -115,5 +115,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00022.json
+++ b/records/AVE-2026-00022.json
@@ -118,5 +118,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00023.json
+++ b/records/AVE-2026-00023.json
@@ -116,5 +116,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00024.json
+++ b/records/AVE-2026-00024.json
@@ -118,5 +118,11 @@
     "semgrep",
     "magika"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00025.json
+++ b/records/AVE-2026-00025.json
@@ -117,5 +117,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00026.json
+++ b/records/AVE-2026-00026.json
@@ -118,5 +118,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00027.json
+++ b/records/AVE-2026-00027.json
@@ -121,5 +121,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00028.json
+++ b/records/AVE-2026-00028.json
@@ -120,5 +120,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00029.json
+++ b/records/AVE-2026-00029.json
@@ -116,5 +116,15 @@
     "pattern",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00030.json
+++ b/records/AVE-2026-00030.json
@@ -118,5 +118,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00031.json
+++ b/records/AVE-2026-00031.json
@@ -120,5 +120,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00032.json
+++ b/records/AVE-2026-00032.json
@@ -120,5 +120,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00033.json
+++ b/records/AVE-2026-00033.json
@@ -121,5 +121,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00034.json
+++ b/records/AVE-2026-00034.json
@@ -125,5 +125,15 @@
     "semgrep",
     "yara"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00035.json
+++ b/records/AVE-2026-00035.json
@@ -115,5 +115,11 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00036.json
+++ b/records/AVE-2026-00036.json
@@ -122,5 +122,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00037.json
+++ b/records/AVE-2026-00037.json
@@ -119,5 +119,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00038.json
+++ b/records/AVE-2026-00038.json
@@ -121,5 +121,11 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00039.json
+++ b/records/AVE-2026-00039.json
@@ -121,5 +121,15 @@
     "yara",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00040.json
+++ b/records/AVE-2026-00040.json
@@ -118,5 +118,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00041.json
+++ b/records/AVE-2026-00041.json
@@ -140,5 +140,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00042.json
+++ b/records/AVE-2026-00042.json
@@ -136,5 +136,15 @@
   ],
   "derivable_into": [
     "rug-pull-chain"
-  ]
+  ],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00043.json
+++ b/records/AVE-2026-00043.json
@@ -132,5 +132,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00044.json
+++ b/records/AVE-2026-00044.json
@@ -129,5 +129,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00045.json
+++ b/records/AVE-2026-00045.json
@@ -143,5 +143,15 @@
   "derivable_into": [
     "credential-exfiltration",
     "privilege-escalation-chain"
-  ]
+  ],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00046.json
+++ b/records/AVE-2026-00046.json
@@ -146,5 +146,15 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00047.json
+++ b/records/AVE-2026-00047.json
@@ -143,5 +143,11 @@
     "yara",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00048.json
+++ b/records/AVE-2026-00048.json
@@ -139,5 +139,15 @@
   ],
   "derivable_into": [
     "privilege-escalation-chain"
-  ]
+  ],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00049.json
+++ b/records/AVE-2026-00049.json
@@ -137,5 +137,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00050.json
+++ b/records/AVE-2026-00050.json
@@ -142,5 +142,15 @@
     "semgrep",
     "llm"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00051.json
+++ b/records/AVE-2026-00051.json
@@ -138,5 +138,11 @@
     "pattern",
     "semgrep"
   ],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00052.json
+++ b/records/AVE-2026-00052.json
@@ -135,5 +135,11 @@
   "derivable_into": [
     "remote-control-chain",
     "credential-exfiltration"
-  ]
+  ],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00053.json
+++ b/records/AVE-2026-00053.json
@@ -133,5 +133,11 @@
   ],
   "derivable_into": [
     "credential-exfiltration"
-  ]
+  ],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00054.json
+++ b/records/AVE-2026-00054.json
@@ -126,5 +126,11 @@
   "derivable_into": [
     "remote-control-chain",
     "credential-exfiltration"
-  ]
+  ],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00055.json
+++ b/records/AVE-2026-00055.json
@@ -138,5 +138,11 @@
   "derivable_into": [
     "rug-pull-chain",
     "remote-control-chain"
-  ]
+  ],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00056.json
+++ b/records/AVE-2026-00056.json
@@ -119,5 +119,11 @@
   ],
   "derivable_into": [
     "credential-exfiltration"
-  ]
+  ],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00059.json
+++ b/records/AVE-2026-00059.json
@@ -117,5 +117,15 @@
   "detection_layer": "server_card",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["llm", "pattern"],
-  "derivable_into": ["remote-control-chain", "credential-exfiltration"]
+  "derivable_into": ["remote-control-chain", "credential-exfiltration"],
+  "framework_sources": {
+    "mitre_atlas": {
+      "pin_status": "unknown",
+      "read_date": "2026-08-09"
+    },
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00062.json
+++ b/records/AVE-2026-00062.json
@@ -84,5 +84,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.65,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00065.json
+++ b/records/AVE-2026-00065.json
@@ -92,5 +92,11 @@
   "detection_layer": "server_card",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["llm", "pattern"],
-  "derivable_into": ["remote-control-chain", "credential-exfiltration"]
+  "derivable_into": ["remote-control-chain", "credential-exfiltration"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00066.json
+++ b/records/AVE-2026-00066.json
@@ -96,5 +96,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.6,
   "evidence_basis_engines": ["sandbox", "llm"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00067.json
+++ b/records/AVE-2026-00067.json
@@ -72,5 +72,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["sandbox", "llm"],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00068.json
+++ b/records/AVE-2026-00068.json
@@ -73,5 +73,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["sandbox"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00069.json
+++ b/records/AVE-2026-00069.json
@@ -73,5 +73,11 @@
   "detection_layer": "content",
   "confidence_baseline": 0.5,
   "evidence_basis_engines": ["llm", "magika"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00070.json
+++ b/records/AVE-2026-00070.json
@@ -77,5 +77,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.45,
   "evidence_basis_engines": ["sandbox", "llm"],
-  "derivable_into": ["remote-control-chain", "credential-exfiltration"]
+  "derivable_into": ["remote-control-chain", "credential-exfiltration"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00071.json
+++ b/records/AVE-2026-00071.json
@@ -92,5 +92,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.75,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00074.json
+++ b/records/AVE-2026-00074.json
@@ -104,5 +104,11 @@
   "detection_layer": "content",
   "confidence_baseline": 0.85,
   "evidence_basis_engines": ["pattern", "external_authority"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00075.json
+++ b/records/AVE-2026-00075.json
@@ -107,5 +107,11 @@
   "detection_layer": "content",
   "confidence_baseline": 0.7,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["credential-exfiltration"]
+  "derivable_into": ["credential-exfiltration"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00076.json
+++ b/records/AVE-2026-00076.json
@@ -104,5 +104,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["llm"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/records/AVE-2026-00077.json
+++ b/records/AVE-2026-00077.json
@@ -104,5 +104,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.8,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["credential-exfiltration"]
+  "derivable_into": ["credential-exfiltration"],
+  "framework_sources": {
+    "owasp_asi": {
+      "version": "2026",
+      "read_date": "2026-08-23"
+    }
+  }
 }

--- a/schema/ave-record-1.1.0.schema.json
+++ b/schema/ave-record-1.1.0.schema.json
@@ -618,18 +618,19 @@
           "read_date": {
             "type": "string",
             "format": "date",
-            "description": "ISO 8601 date this framework reading was last verified against. Required when pin_status is unpinnable, where it is the nearest thing an unversionable source has to a pin."
+            "description": "ISO 8601 date this framework reading was last verified against. Required when pin_status is unpinnable or unknown, where it is the nearest thing an unversionable or unrecoverable source has to a pin."
           },
           "pin_status": {
             "type": "string",
             "enum": [
-              "unpinnable"
+              "unpinnable",
+              "unknown"
             ],
-            "description": "Present only to declare that the referenced framework has no version, tag, or commit to pin against, e.g. the MCP Top 10 prior to a canonical numbering reference existing. Distinguishes a stated exemption from a field nobody has filled in yet. An entry declaring this should also carry read_date and unpinnable_reason."
+            "description": "Present only to declare a real gap rather than leave a blank field indistinguishable from one nobody has filled in. 'unpinnable': the referenced framework itself has no version, tag, or commit to pin against, e.g. the MCP Top 10 prior to a canonical numbering reference existing. An entry declaring this should also carry read_date and unpinnable_reason. 'unknown': the referenced framework does have real, addressable versions, but this record's mapping predates any tracking of which one was read, and the specific version is not recoverable now. An entry declaring this should carry read_date (the date this gap was confirmed, not a version read); unpinnable_reason does not apply, since the framework itself is not at fault."
           },
           "unpinnable_reason": {
             "type": "string",
-            "description": "Why this framework reading cannot be pinned, in terms a reader can check, e.g. 'MCP Top 10 is in pilot with no canonical numbering reference published (OWASP/www-project-mcp-top-10#52)'. Required when pin_status is unpinnable."
+            "description": "Why this framework reading cannot be pinned, in terms a reader can check, e.g. 'MCP Top 10 is in pilot with no canonical numbering reference published (OWASP/www-project-mcp-top-10#52)'. Required when pin_status is unpinnable. Not used when pin_status is unknown, since that declares a gap in AVE's own recordkeeping, not a property of the framework."
           },
           "content_digest": {
             "type": "string",

--- a/schema/ave-record.schema.json
+++ b/schema/ave-record.schema.json
@@ -618,18 +618,19 @@
           "read_date": {
             "type": "string",
             "format": "date",
-            "description": "ISO 8601 date this framework reading was last verified against. Required when pin_status is unpinnable, where it is the nearest thing an unversionable source has to a pin."
+            "description": "ISO 8601 date this framework reading was last verified against. Required when pin_status is unpinnable or unknown, where it is the nearest thing an unversionable or unrecoverable source has to a pin."
           },
           "pin_status": {
             "type": "string",
             "enum": [
-              "unpinnable"
+              "unpinnable",
+              "unknown"
             ],
-            "description": "Present only to declare that the referenced framework has no version, tag, or commit to pin against, e.g. the MCP Top 10 prior to a canonical numbering reference existing. Distinguishes a stated exemption from a field nobody has filled in yet. An entry declaring this should also carry read_date and unpinnable_reason."
+            "description": "Present only to declare a real gap rather than leave a blank field indistinguishable from one nobody has filled in. 'unpinnable': the referenced framework itself has no version, tag, or commit to pin against, e.g. the MCP Top 10 prior to a canonical numbering reference existing. An entry declaring this should also carry read_date and unpinnable_reason. 'unknown': the referenced framework does have real, addressable versions, but this record's mapping predates any tracking of which one was read, and the specific version is not recoverable now. An entry declaring this should carry read_date (the date this gap was confirmed, not a version read); unpinnable_reason does not apply, since the framework itself is not at fault."
           },
           "unpinnable_reason": {
             "type": "string",
-            "description": "Why this framework reading cannot be pinned, in terms a reader can check, e.g. 'MCP Top 10 is in pilot with no canonical numbering reference published (OWASP/www-project-mcp-top-10#52)'. Required when pin_status is unpinnable."
+            "description": "Why this framework reading cannot be pinned, in terms a reader can check, e.g. 'MCP Top 10 is in pilot with no canonical numbering reference published (OWASP/www-project-mcp-top-10#52)'. Required when pin_status is unpinnable. Not used when pin_status is unknown, since that declares a gap in AVE's own recordkeeping, not a property of the framework."
           },
           "content_digest": {
             "type": "string",

--- a/scripts/check_framework_sources.py
+++ b/scripts/check_framework_sources.py
@@ -30,15 +30,16 @@ FRAMEWORK_FIELDS = ("owasp_mcp", "owasp_asi", "mitre_atlas", "nist_ai_rmf")
 
 def has_real_source(entry: dict) -> bool:
     """True when a framework_sources entry is a real, checkable pin rather
-    than an empty or partial placeholder. An unpinnable declaration counts
-    only with its read_date (the nearest thing an unversionable source has
-    to a pin); anything else needs a version or commit alongside its
-    read_date, matching the same pin_status vocabulary already used on
-    crosswalk endpoints (schema/crosswalk-1.0.0.schema.json).
+    than an empty or partial placeholder. An unpinnable or unknown
+    declaration counts only with its read_date (the nearest thing an
+    unversionable or unrecoverable source has to a pin); anything else
+    needs a version or commit alongside its read_date, matching the same
+    pin_status vocabulary already used on crosswalk endpoints
+    (schema/crosswalk-1.0.0.schema.json).
     """
     if not entry:
         return False
-    if entry.get("pin_status") == "unpinnable":
+    if entry.get("pin_status") in ("unpinnable", "unknown"):
         return bool(entry.get("read_date"))
     return bool((entry.get("version") or entry.get("commit")) and entry.get("read_date"))
 

--- a/tests/test_framework_sources.py
+++ b/tests/test_framework_sources.py
@@ -53,6 +53,24 @@ def test_unpinnable_without_read_date_does_not_count():
     assert check.missing_sources(r) == ["owasp_mcp"]
 
 
+def test_unknown_with_read_date_counts_as_a_real_source():
+    r = record(
+        owasp_mcp=["MCP03"],
+        framework_sources={"owasp_mcp": {"pin_status": "unknown", "read_date": "2026-08-20"}},
+    )
+    assert check.missing_sources(r) == []
+
+
+def test_unknown_without_read_date_does_not_count():
+    """Mutation check: if the unknown branch stopped checking read_date,
+    this must go red -- unknown alone is a bare declaration, not a pin."""
+    r = record(
+        owasp_mcp=["MCP03"],
+        framework_sources={"owasp_mcp": {"pin_status": "unknown"}},
+    )
+    assert check.missing_sources(r) == ["owasp_mcp"]
+
+
 def test_multiple_mapped_fields_each_checked_independently():
     r = record(
         owasp_mcp=["MCP03"],


### PR DESCRIPTION
Resolves the conflict blocking PR #260 (develop → main). Verified before
opening: main was missing PR #256's real content entirely — the
`pin_status: "unknown"` schema addition, its corresponding
`check_framework_sources.py` update, and the two new tests for it — not
a squash-SHA-only mismatch like the earlier #252/#253 case. Cherry-picked
PR #256's actual squashed commit (`1fc097b`) onto a fresh branch off
`main`; it applied with zero conflicts, confirming the content itself was
never in dispute, only which branch had received it.

Note: `develop` has since moved further ahead via #259 (the `owasp_mcp`
audit corrections), which is not yet on `main` either. That's a separate,
later divergence this PR does not attempt to resolve — bringing it over
is its own follow-up sync, same shape as this one.

Once this merges, PR #260 is superseded by this PR having landed the
same content cleanly; recommend closing #260 rather than trying to
re-resolve it directly.

Validated: `python scripts/validate_records.py` (80/80 valid),
`python scripts/check_fixtures.py` (all pass), `pytest tests/ -x -q`
(463 passed).