### PR TITLE
fix: owasp_mcp audit corrections (39 records) and framework_sources backfill

### DIFF
--- a/dist/ave-records-latest.json
+++ b/dist/ave-records-latest.json
@@ -151,6 +151,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -301,6 +305,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -335,8 +343,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP03",
-      "MCP10"
+      "MCP03"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -442,6 +449,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -581,6 +592,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -701,8 +716,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP03",
-      "MCP09"
+      "MCP03"
     ],
     "aivss": {
       "cvss_base": 9.3,
@@ -737,6 +751,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -857,8 +875,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP02",
-      "MCP09"
+      "MCP01"
     ],
     "aivss": {
       "cvss_base": 8.7,
@@ -894,6 +911,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -1007,7 +1028,6 @@
       }
     ],
     "owasp_mcp": [
-      "MCP03",
       "MCP07"
     ],
     "aivss": {
@@ -1045,6 +1065,10 @@
       "privilege-escalation-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -1198,6 +1222,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -1317,7 +1345,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP04",
+      "MCP02",
       "MCP07"
     ],
     "aivss": {
@@ -1352,6 +1380,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -1507,6 +1539,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -1612,8 +1648,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP05",
-      "MCP04"
+      "MCP05"
     ],
     "owasp_asi": [
       "ASI05"
@@ -1654,6 +1689,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -1802,6 +1841,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -1834,8 +1877,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP03",
-      "MCP06"
+      "MCP03"
     ],
     "mitre_atlas": [
       "AML.T0051"
@@ -1950,6 +1992,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -1981,7 +2027,7 @@
     "aivss_score": 7.2,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
     "owasp_mcp": [
-      "MCP01"
+      "MCP05"
     ],
     "behavioral_fingerprint": "Tool call parameters containing shell metacharacters (backticks, pipes, semicolons, command substitution syntax) are passed to a host shell without escaping or parameterization, resulting in execution of attacker-controlled shell commands rather than the parameter being treated as inert string data.",
     "behavioral_vector": [
@@ -2071,7 +2117,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00065",
@@ -2091,7 +2143,6 @@
     "aivss_score": 7.1,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
     "owasp_mcp": [
-      "MCP10",
       "MCP06"
     ],
     "owasp_asi": [
@@ -2195,6 +2246,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -2333,6 +2388,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -2363,8 +2422,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP01",
-      "MCP05"
+      "MCP01"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -2470,6 +2528,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -2599,8 +2661,7 @@
       "notes": "curl|bash pattern. Active in wild. NL delivery invisible to SAST."
     },
     "owasp_mcp": [
-      "MCP01",
-      "MCP03"
+      "MCP05"
     ],
     "severity": "MEDIUM",
     "evidence_kind_default": "multi_engine",
@@ -2614,6 +2675,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -2741,8 +2806,7 @@
       "notes": "rm -rf style. Full autonomy + tool use + data access."
     },
     "owasp_mcp": [
-      "MCP02",
-      "MCP07"
+      "MCP05"
     ],
     "severity": "MEDIUM",
     "evidence_kind_default": "multi_engine",
@@ -2756,6 +2820,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -2882,8 +2950,7 @@
       "notes": "Core goal override. Non-determinism makes detection hard."
     },
     "owasp_mcp": [
-      "MCP01",
-      "MCP03"
+      "MCP06"
     ],
     "severity": "MEDIUM",
     "evidence_kind_default": "multi_engine",
@@ -2897,6 +2964,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -3038,6 +3109,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -3165,7 +3240,6 @@
       "notes": "Safety bypass. Very high non-determinism. NL-only attack surface."
     },
     "owasp_mcp": [
-      "MCP01",
       "MCP03"
     ],
     "severity": "MEDIUM",
@@ -3180,6 +3254,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -3305,7 +3383,6 @@
       "notes": "Conceals instructions. Moderate amplification across most factors."
     },
     "owasp_mcp": [
-      "MCP01",
       "MCP03"
     ],
     "severity": "MEDIUM",
@@ -3319,6 +3396,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -3441,7 +3522,7 @@
       "notes": "Embeds tool calls with attacker parameters. Tool squatting variant."
     },
     "owasp_mcp": [
-      "MCP01"
+      "MCP03"
     ],
     "severity": "MEDIUM",
     "evidence_kind_default": "tool_description_pattern",
@@ -3454,6 +3535,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -3580,8 +3665,7 @@
       "notes": "Claims elevated permissions. Dynamic identity is primary vector."
     },
     "owasp_mcp": [
-      "MCP09",
-      "MCP10"
+      "MCP07"
     ],
     "severity": "MEDIUM",
     "evidence_kind_default": "tool_description_pattern",
@@ -3594,6 +3678,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -3736,6 +3824,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -3871,6 +3963,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -3899,8 +3995,7 @@
       "ASI06"
     ],
     "owasp_mcp": [
-      "MCP10",
-      "MCP03"
+      "MCP06"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -4004,6 +4099,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -4138,6 +4237,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -4168,8 +4271,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP03",
-      "MCP08"
+      "MCP06"
     ],
     "nist_ai_rmf": [
       "MEASURE-2.5",
@@ -4270,6 +4372,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -4409,6 +4515,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -4545,6 +4655,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -4676,6 +4790,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -4807,6 +4925,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -4836,7 +4958,6 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP10",
       "MCP06"
     ],
     "nist_ai_rmf": [
@@ -4937,6 +5058,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -5071,6 +5196,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -5099,7 +5228,6 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP10",
       "MCP06"
     ],
     "nist_ai_rmf": [
@@ -5200,6 +5328,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -5330,6 +5462,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -5468,6 +5604,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -5500,8 +5640,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP10",
-      "MCP03"
+      "MCP06"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -5604,6 +5743,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -5736,6 +5879,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -5768,8 +5915,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP07",
-      "MCP02"
+      "MCP07"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -5870,6 +6016,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -6002,6 +6152,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -6138,6 +6292,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -6276,6 +6434,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -6418,6 +6580,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -6549,6 +6715,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -6683,6 +6853,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -6714,8 +6888,7 @@
       "ASI01"
     ],
     "owasp_mcp": [
-      "MCP10",
-      "MCP03"
+      "MCP06"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -6818,6 +6991,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -6851,8 +7028,7 @@
       "ASI07"
     ],
     "owasp_mcp": [
-      "MCP02",
-      "MCP08"
+      "MCP02"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -6953,6 +7129,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -7086,6 +7266,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -7118,8 +7302,7 @@
       "ASI05"
     ],
     "owasp_mcp": [
-      "MCP05",
-      "MCP10"
+      "MCP05"
     ],
     "nist_ai_rmf": [
       "MAP-1.5",
@@ -7221,6 +7404,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -7333,7 +7520,7 @@
     ],
     "owasp_mcp": [
       "MCP05",
-      "MCP10"
+      "MCP06"
     ],
     "aivss": {
       "cvss_base": 9,
@@ -7370,6 +7557,10 @@
       "rug-pull-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -7480,8 +7671,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP03",
-      "MCP10"
+      "MCP03"
     ],
     "aivss": {
       "cvss_base": 8.5,
@@ -7516,6 +7706,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -7625,8 +7819,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP06",
-      "MCP10"
+      "MCP06"
     ],
     "aivss": {
       "cvss_base": 8.2,
@@ -7661,6 +7854,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -7820,6 +8017,10 @@
       "privilege-escalation-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -7925,7 +8126,6 @@
       }
     ],
     "owasp_mcp": [
-      "MCP02",
       "MCP07"
     ],
     "owasp_asi": [
@@ -7969,6 +8169,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -8062,8 +8266,7 @@
       }
     ],
     "owasp_mcp": [
-      "MCP05",
-      "MCP07"
+      "MCP05"
     ],
     "owasp_asi": [
       "ASI05"
@@ -8105,6 +8308,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -8234,6 +8441,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -8356,7 +8567,13 @@
       "pattern",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00061",
@@ -8378,7 +8595,7 @@
     "aivss_score": 4.1,
     "cvss_base_vector": "CVSS:4.0/AV:A/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
     "owasp_mcp": [
-      "MCP05"
+      "MCP07"
     ],
     "behavioral_fingerprint": "Configuration explicitly sets a TLS verification bypass flag (verify=False, rejectUnauthorized: false, or equivalent) for the component's own outbound network calls, rather than relying on default, enforced certificate validation.",
     "behavioral_vector": [
@@ -8459,7 +8676,13 @@
     "evidence_basis_engines": [
       "pattern"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00062",
@@ -8570,6 +8793,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -8596,7 +8823,7 @@
     "aivss_score": 4.8,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:L/SA:N",
     "owasp_mcp": [
-      "MCP09"
+      "MCP02"
     ],
     "behavioral_fingerprint": "Configuration sets a declarative flag (auto_approve, skip_confirmation, require_approval: false, or equivalent) that removes a human-in-the-loop check for high-risk actions, present in config rather than in instruction text, and therefore invisible to a review process that only inspects a component's stated instructions.",
     "behavioral_vector": [
@@ -8684,7 +8911,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00064",
@@ -8706,7 +8939,7 @@
     "aivss_score": 5.2,
     "cvss_base_vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
     "owasp_mcp": [
-      "MCP01"
+      "MCP05"
     ],
     "behavioral_fingerprint": "A project-level configuration file declares a command or script to execute automatically on project load or open, with no corresponding user confirmation step, distinct from a tool call the model or user explicitly initiates.",
     "behavioral_vector": [
@@ -8790,7 +9023,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00066",
@@ -8927,6 +9166,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -8945,7 +9188,7 @@
     "aivss_score": 5,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:H/SA:N",
     "owasp_mcp": [
-      "MCP02"
+      "MCP07"
     ],
     "owasp_asi": [
       "ASI03",
@@ -9027,6 +9270,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -9128,6 +9375,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -9233,6 +9484,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -9251,7 +9506,7 @@
     "aivss_score": 6.4,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:N",
     "owasp_mcp": [
-      "MCP03"
+      "MCP06"
     ],
     "owasp_asi": [
       "ASI06"
@@ -9345,6 +9600,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -9470,6 +9729,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -9589,7 +9852,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00073",
@@ -9713,7 +9982,13 @@
     ],
     "derivable_into": [
       "credential-exfiltration"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00075",
@@ -9848,6 +10123,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -9874,7 +10153,7 @@
     "aivss_score": 4.5,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:H/SA:N",
     "owasp_mcp": [
-      "MCP02"
+      "MCP03"
     ],
     "owasp_asi": [
       "ASI02"
@@ -9986,6 +10265,10 @@
       "remote-control-chain"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -10016,8 +10299,7 @@
     "aivss_score": 4.8,
     "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
     "owasp_mcp": [
-      "MCP07",
-      "MCP10"
+      "MCP07"
     ],
     "owasp_asi": [
       "ASI02"
@@ -10129,6 +10411,10 @@
       "credential-exfiltration"
     ],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "owasp_asi": {
         "version": "2026",
         "read_date": "2026-08-23"
@@ -10258,7 +10544,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00079",
@@ -10383,7 +10675,13 @@
     ],
     "derivable_into": [
       "remote-control-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00080",
@@ -10509,7 +10807,13 @@
     ],
     "derivable_into": [
       "privilege-escalation-chain"
-    ]
+    ],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   },
   {
     "ave_id": "AVE-2026-00014",
@@ -10620,8 +10924,7 @@
       "notes": "Social engineering. Multi-agent + dynamic identity amplify."
     },
     "owasp_mcp": [
-      "MCP09",
-      "MCP10"
+      "MCP03"
     ],
     "severity": "LOW",
     "evidence_kind_default": "semantic_inference",
@@ -10634,6 +10937,10 @@
     ],
     "derivable_into": [],
     "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      },
       "mitre_atlas": {
         "pin_status": "unknown",
         "read_date": "2026-08-09"
@@ -10764,6 +11071,12 @@
       "pattern",
       "llm"
     ],
-    "derivable_into": []
+    "derivable_into": [],
+    "framework_sources": {
+      "owasp_mcp": {
+        "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+        "read_date": "2026-09-05"
+      }
+    }
   }
 ]

--- a/dist/ave-records-latest.manifest.json
+++ b/dist/ave-records-latest.manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.1.0",
   "record_count": 80,
-  "generated_at": "2026-09-04T22:52:59.880Z",
+  "generated_at": "2026-09-04T23:22:53.346Z",
   "source": "https://github.com/aveproject/ave"
 }

--- a/records/AVE-2026-00001.json
+++ b/records/AVE-2026-00001.json
@@ -138,6 +138,10 @@
     "remote-control-chain"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00002.json
+++ b/records/AVE-2026-00002.json
@@ -20,8 +20,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP03",
-    "MCP10"
+    "MCP03"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -127,6 +126,10 @@
     "remote-control-chain"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00003.json
+++ b/records/AVE-2026-00003.json
@@ -20,8 +20,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP01",
-    "MCP05"
+    "MCP01"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -127,6 +126,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00004.json
+++ b/records/AVE-2026-00004.json
@@ -114,8 +114,7 @@
     "notes": "curl|bash pattern. Active in wild. NL delivery invisible to SAST."
   },
   "owasp_mcp": [
-    "MCP01",
-    "MCP03"
+    "MCP05"
   ],
   "severity": "MEDIUM",
   "evidence_kind_default": "multi_engine",
@@ -129,6 +128,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00005.json
+++ b/records/AVE-2026-00005.json
@@ -113,8 +113,7 @@
     "notes": "rm -rf style. Full autonomy + tool use + data access."
   },
   "owasp_mcp": [
-    "MCP02",
-    "MCP07"
+    "MCP05"
   ],
   "severity": "MEDIUM",
   "evidence_kind_default": "multi_engine",
@@ -128,6 +127,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00006.json
+++ b/records/AVE-2026-00006.json
@@ -125,6 +125,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00007.json
+++ b/records/AVE-2026-00007.json
@@ -112,8 +112,7 @@
     "notes": "Core goal override. Non-determinism makes detection hard."
   },
   "owasp_mcp": [
-    "MCP01",
-    "MCP03"
+    "MCP06"
   ],
   "severity": "MEDIUM",
   "evidence_kind_default": "multi_engine",
@@ -127,6 +126,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00008.json
+++ b/records/AVE-2026-00008.json
@@ -127,6 +127,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00009.json
+++ b/records/AVE-2026-00009.json
@@ -113,7 +113,6 @@
     "notes": "Safety bypass. Very high non-determinism. NL-only attack surface."
   },
   "owasp_mcp": [
-    "MCP01",
     "MCP03"
   ],
   "severity": "MEDIUM",
@@ -128,6 +127,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00010.json
+++ b/records/AVE-2026-00010.json
@@ -113,7 +113,6 @@
     "notes": "Conceals instructions. Moderate amplification across most factors."
   },
   "owasp_mcp": [
-    "MCP01",
     "MCP03"
   ],
   "severity": "MEDIUM",
@@ -127,6 +126,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00011.json
+++ b/records/AVE-2026-00011.json
@@ -112,7 +112,7 @@
     "notes": "Embeds tool calls with attacker parameters. Tool squatting variant."
   },
   "owasp_mcp": [
-    "MCP01"
+    "MCP03"
   ],
   "severity": "MEDIUM",
   "evidence_kind_default": "tool_description_pattern",
@@ -125,6 +125,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00012.json
+++ b/records/AVE-2026-00012.json
@@ -112,8 +112,7 @@
     "notes": "Claims elevated permissions. Dynamic identity is primary vector."
   },
   "owasp_mcp": [
-    "MCP09",
-    "MCP10"
+    "MCP07"
   ],
   "severity": "MEDIUM",
   "evidence_kind_default": "tool_description_pattern",
@@ -126,6 +125,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00013.json
+++ b/records/AVE-2026-00013.json
@@ -128,6 +128,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00014.json
+++ b/records/AVE-2026-00014.json
@@ -105,8 +105,7 @@
     "notes": "Social engineering. Multi-agent + dynamic identity amplify."
   },
   "owasp_mcp": [
-    "MCP09",
-    "MCP10"
+    "MCP03"
   ],
   "severity": "LOW",
   "evidence_kind_default": "semantic_inference",
@@ -119,6 +118,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00015.json
+++ b/records/AVE-2026-00015.json
@@ -121,6 +121,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00016.json
+++ b/records/AVE-2026-00016.json
@@ -17,8 +17,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
   "owasp_asi": ["ASI01", "ASI06"],
   "owasp_mcp": [
-    "MCP10",
-    "MCP03"
+    "MCP06"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -122,6 +121,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00017.json
+++ b/records/AVE-2026-00017.json
@@ -120,6 +120,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00018.json
+++ b/records/AVE-2026-00018.json
@@ -16,8 +16,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:L/SI:H/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP03",
-    "MCP08"
+    "MCP06"
   ],
   "nist_ai_rmf": [
     "MEASURE-2.5",
@@ -118,6 +117,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00019.json
+++ b/records/AVE-2026-00019.json
@@ -124,6 +124,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00020.json
+++ b/records/AVE-2026-00020.json
@@ -124,6 +124,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00021.json
+++ b/records/AVE-2026-00021.json
@@ -117,6 +117,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00022.json
+++ b/records/AVE-2026-00022.json
@@ -120,6 +120,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00023.json
+++ b/records/AVE-2026-00023.json
@@ -17,7 +17,6 @@
     "ASI01"
   ],
   "owasp_mcp": [
-    "MCP10",
     "MCP06"
   ],
   "nist_ai_rmf": [
@@ -118,6 +117,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00024.json
+++ b/records/AVE-2026-00024.json
@@ -120,6 +120,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00025.json
+++ b/records/AVE-2026-00025.json
@@ -18,7 +18,6 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP10",
     "MCP06"
   ],
   "nist_ai_rmf": [
@@ -119,6 +118,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00026.json
+++ b/records/AVE-2026-00026.json
@@ -120,6 +120,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00027.json
+++ b/records/AVE-2026-00027.json
@@ -123,6 +123,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00028.json
+++ b/records/AVE-2026-00028.json
@@ -18,8 +18,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:L/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP10",
-    "MCP03"
+    "MCP06"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -122,6 +121,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00029.json
+++ b/records/AVE-2026-00029.json
@@ -118,6 +118,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00030.json
+++ b/records/AVE-2026-00030.json
@@ -18,8 +18,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP07",
-    "MCP02"
+    "MCP07"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -120,6 +119,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00031.json
+++ b/records/AVE-2026-00031.json
@@ -122,6 +122,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00032.json
+++ b/records/AVE-2026-00032.json
@@ -122,6 +122,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00033.json
+++ b/records/AVE-2026-00033.json
@@ -123,6 +123,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00034.json
+++ b/records/AVE-2026-00034.json
@@ -127,6 +127,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00035.json
+++ b/records/AVE-2026-00035.json
@@ -117,6 +117,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00036.json
+++ b/records/AVE-2026-00036.json
@@ -124,6 +124,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00037.json
+++ b/records/AVE-2026-00037.json
@@ -17,8 +17,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
   "owasp_asi": ["ASI01"],
   "owasp_mcp": [
-    "MCP10",
-    "MCP03"
+    "MCP06"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -121,6 +120,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00038.json
+++ b/records/AVE-2026-00038.json
@@ -21,8 +21,7 @@
     "ASI07"
   ],
   "owasp_mcp": [
-    "MCP02",
-    "MCP08"
+    "MCP02"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -123,6 +122,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00039.json
+++ b/records/AVE-2026-00039.json
@@ -123,6 +123,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00040.json
+++ b/records/AVE-2026-00040.json
@@ -17,8 +17,7 @@
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
   "owasp_asi": ["ASI01", "ASI05"],
   "owasp_mcp": [
-    "MCP05",
-    "MCP10"
+    "MCP05"
   ],
   "nist_ai_rmf": [
     "MAP-1.5",
@@ -120,6 +119,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00041.json
+++ b/records/AVE-2026-00041.json
@@ -106,8 +106,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP03",
-    "MCP09"
+    "MCP03"
   ],
   "aivss": {
     "cvss_base": 9.3,
@@ -142,6 +141,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00042.json
+++ b/records/AVE-2026-00042.json
@@ -101,7 +101,7 @@
   ],
   "owasp_mcp": [
     "MCP05",
-    "MCP10"
+    "MCP06"
   ],
   "aivss": {
     "cvss_base": 9,
@@ -138,6 +138,10 @@
     "rug-pull-chain"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00043.json
+++ b/records/AVE-2026-00043.json
@@ -98,8 +98,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP03",
-    "MCP10"
+    "MCP03"
   ],
   "aivss": {
     "cvss_base": 8.5,
@@ -134,6 +133,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00044.json
+++ b/records/AVE-2026-00044.json
@@ -95,8 +95,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP06",
-    "MCP10"
+    "MCP06"
   ],
   "aivss": {
     "cvss_base": 8.2,
@@ -131,6 +130,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00045.json
+++ b/records/AVE-2026-00045.json
@@ -145,6 +145,10 @@
     "privilege-escalation-chain"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00046.json
+++ b/records/AVE-2026-00046.json
@@ -148,6 +148,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00047.json
+++ b/records/AVE-2026-00047.json
@@ -108,8 +108,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP02",
-    "MCP09"
+    "MCP01"
   ],
   "aivss": {
     "cvss_base": 8.7,
@@ -145,6 +144,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00048.json
+++ b/records/AVE-2026-00048.json
@@ -103,7 +103,6 @@
     }
   ],
   "owasp_mcp": [
-    "MCP03",
     "MCP07"
   ],
   "aivss": {
@@ -141,6 +140,10 @@
     "privilege-escalation-chain"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00049.json
+++ b/records/AVE-2026-00049.json
@@ -139,6 +139,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00050.json
+++ b/records/AVE-2026-00050.json
@@ -109,7 +109,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP04",
+    "MCP02",
     "MCP07"
   ],
   "aivss": {
@@ -144,6 +144,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00051.json
+++ b/records/AVE-2026-00051.json
@@ -140,6 +140,10 @@
   ],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00052.json
+++ b/records/AVE-2026-00052.json
@@ -97,8 +97,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP05",
-    "MCP04"
+    "MCP05"
   ],
   "owasp_asi": ["ASI05"],
   "aivss": {
@@ -137,6 +136,10 @@
     "credential-exfiltration"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00053.json
+++ b/records/AVE-2026-00053.json
@@ -93,7 +93,6 @@
     }
   ],
   "owasp_mcp": [
-    "MCP02",
     "MCP07"
   ],
   "owasp_asi": ["ASI04"],
@@ -135,6 +134,10 @@
     "credential-exfiltration"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00054.json
+++ b/records/AVE-2026-00054.json
@@ -85,8 +85,7 @@
     }
   ],
   "owasp_mcp": [
-    "MCP05",
-    "MCP07"
+    "MCP05"
   ],
   "owasp_asi": [
     "ASI05"
@@ -128,6 +127,10 @@
     "credential-exfiltration"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00055.json
+++ b/records/AVE-2026-00055.json
@@ -140,6 +140,10 @@
     "remote-control-chain"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00056.json
+++ b/records/AVE-2026-00056.json
@@ -121,6 +121,10 @@
     "credential-exfiltration"
   ],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00057.json
+++ b/records/AVE-2026-00057.json
@@ -103,5 +103,11 @@
   "detection_layer": "content",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["pattern", "llm"],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00058.json
+++ b/records/AVE-2026-00058.json
@@ -107,5 +107,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.5,
   "evidence_basis_engines": ["pattern", "llm"],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00059.json
+++ b/records/AVE-2026-00059.json
@@ -21,7 +21,7 @@
   "aivss_score": 7.1,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
   "owasp_asi": ["ASI01"],
-  "owasp_mcp": ["MCP03", "MCP06"],
+  "owasp_mcp": ["MCP03"],
   "mitre_atlas": ["AML.T0051"],
   "behavioral_fingerprint": "Tool descriptions across multiple tools each carry an individually benign-looking fragment of a larger instruction. A separately planted trigger, commonly introduced during a server update, causes the model to reassemble the fragments into a complete, actionable instruction at inference time, after tool discovery and before any tool call.",
   "behavioral_vector": [
@@ -119,6 +119,10 @@
   "evidence_basis_engines": ["llm", "pattern"],
   "derivable_into": ["remote-control-chain", "credential-exfiltration"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "mitre_atlas": {
       "pin_status": "unknown",
       "read_date": "2026-08-09"

--- a/records/AVE-2026-00060.json
+++ b/records/AVE-2026-00060.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 7.2,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_mcp": ["MCP01"],
+  "owasp_mcp": ["MCP05"],
   "behavioral_fingerprint": "Tool call parameters containing shell metacharacters (backticks, pipes, semicolons, command substitution syntax) are passed to a host shell without escaping or parameterization, resulting in execution of attacker-controlled shell commands rather than the parameter being treated as inert string data.",
   "behavioral_vector": [
     "transport-layer-rce",
@@ -89,5 +89,11 @@
   "detection_layer": "transport",
   "confidence_baseline": 0.6,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00061.json
+++ b/records/AVE-2026-00061.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 4.1,
   "cvss_base_vector": "CVSS:4.0/AV:A/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_mcp": ["MCP05"],
+  "owasp_mcp": ["MCP07"],
   "behavioral_fingerprint": "Configuration explicitly sets a TLS verification bypass flag (verify=False, rejectUnauthorized: false, or equivalent) for the component's own outbound network calls, rather than relying on default, enforced certificate validation.",
   "behavioral_vector": [
     "tls-verification-bypass",
@@ -82,5 +82,11 @@
   "detection_layer": "content",
   "confidence_baseline": 0.7,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": []
+  "derivable_into": [],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00062.json
+++ b/records/AVE-2026-00062.json
@@ -86,6 +86,10 @@
   "evidence_basis_engines": ["pattern"],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00063.json
+++ b/records/AVE-2026-00063.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 4.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:L/SA:N",
-  "owasp_mcp": ["MCP09"],
+  "owasp_mcp": ["MCP02"],
   "behavioral_fingerprint": "Configuration sets a declarative flag (auto_approve, skip_confirmation, require_approval: false, or equivalent) that removes a human-in-the-loop check for high-risk actions, present in config rather than in instruction text, and therefore invisible to a review process that only inspects a component's stated instructions.",
   "behavioral_vector": [
     "approval-bypass-config",
@@ -83,5 +83,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.6,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00064.json
+++ b/records/AVE-2026-00064.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 5.2,
   "cvss_base_vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H",
-  "owasp_mcp": ["MCP01"],
+  "owasp_mcp": ["MCP05"],
   "behavioral_fingerprint": "A project-level configuration file declares a command or script to execute automatically on project load or open, with no corresponding user confirmation step, distinct from a tool call the model or user explicitly initiates.",
   "behavioral_vector": [
     "zero-click-execution",
@@ -82,5 +82,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00065.json
+++ b/records/AVE-2026-00065.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 7.1,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L",
-  "owasp_mcp": ["MCP10", "MCP06"],
+  "owasp_mcp": ["MCP06"],
   "owasp_asi": ["ASI01"],
   "behavioral_fingerprint": "A remote agent's A2A agent card contains embedded natural-language instructions disguised as capability descriptions or operational metadata, which the receiving agent's reasoning context treats as authoritative once the card is loaded during discovery or delegation planning, before any explicit task exchange occurs.",
   "behavioral_vector": [
@@ -94,6 +94,10 @@
   "evidence_basis_engines": ["llm", "pattern"],
   "derivable_into": ["remote-control-chain", "credential-exfiltration"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00066.json
+++ b/records/AVE-2026-00066.json
@@ -98,6 +98,10 @@
   "evidence_basis_engines": ["sandbox", "llm"],
   "derivable_into": ["remote-control-chain"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00067.json
+++ b/records/AVE-2026-00067.json
@@ -9,7 +9,7 @@
   "description": "A skill that is entirely benign when reviewed or executed in isolation produces an output, such as an audit finding, an endorsement, a validation result, or another benign-looking artifact, that a separate, later-invoked skill treats as a trust or authorization signal without independently re-verifying the underlying claim. Neither skill individually does anything dangerous; the vulnerability exists only in the composition, when both are invoked along the same task path in a shared execution context. Because per-skill security review evaluates each skill's own behavior in isolation, it structurally cannot see this class of risk: an upstream skill's legitimate, correct output becomes a spoofable trust credential the moment a downstream skill treats it as authoritative rather than re-verifying the claim itself. Published research demonstrates this mechanism accepting harmful software installation at over 96% success across four of five tested model backends when preceded by an approval-like output from an unrelated upstream skill, versus near-zero success when the same downstream skill is invoked in isolation.",
   "aivss_score": 5.0,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:H/SA:N",
-  "owasp_mcp": ["MCP02"],
+  "owasp_mcp": ["MCP07"],
   "owasp_asi": ["ASI03", "ASI08"],
   "mitre_atlas": [],
   "nist_ai_rmf": [],
@@ -74,6 +74,10 @@
   "evidence_basis_engines": ["sandbox", "llm"],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00068.json
+++ b/records/AVE-2026-00068.json
@@ -75,6 +75,10 @@
   "evidence_basis_engines": ["sandbox"],
   "derivable_into": ["remote-control-chain"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00069.json
+++ b/records/AVE-2026-00069.json
@@ -75,6 +75,10 @@
   "evidence_basis_engines": ["llm", "magika"],
   "derivable_into": ["remote-control-chain"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00070.json
+++ b/records/AVE-2026-00070.json
@@ -9,7 +9,7 @@
   "description": "A poisoned tool embeds encrypted attack primitives within its observations, which spread across the memories and context of multiple distinct agents as they use that tool during a multi-agent collaborative task. Each individual primitive remains dormant and inert on its own; no single agent's session, memory, or tool output contains anything a local security check would flag as malicious, and the collaborative task itself completes with no observable degradation to benign performance. Only when an attacker later scans the execution trace or the individual agents' memories, decrypts the primitives using a key established in the original poisoning step, and reassembles them, does the full backdoor payload exist and become executable, entirely after the multi-agent run has already finished. This is distinct from a single-session, single-model reassembly of static tool-description fragments (AVE-2026-00059): the fragments here live in multiple agents' own runtime observations and memories, not one client's static tool schema, and the reassembly is external, offline, and attacker-driven, not performed by any agent's own inference process during the session.",
   "aivss_score": 6.4,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:N",
-  "owasp_mcp": ["MCP03"],
+  "owasp_mcp": ["MCP06"],
   "owasp_asi": ["ASI06"],
   "mitre_atlas": [],
   "nist_ai_rmf": [],
@@ -79,6 +79,10 @@
   "evidence_basis_engines": ["sandbox", "llm"],
   "derivable_into": ["remote-control-chain", "credential-exfiltration"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00071.json
+++ b/records/AVE-2026-00071.json
@@ -94,6 +94,10 @@
   "evidence_basis_engines": ["pattern"],
   "derivable_into": [],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00072.json
+++ b/records/AVE-2026-00072.json
@@ -91,5 +91,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.8,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00073.json
+++ b/records/AVE-2026-00073.json
@@ -99,5 +99,11 @@
   "detection_layer": "registry_metadata",
   "confidence_baseline": 0.8,
   "evidence_basis_engines": ["pattern"],
-  "derivable_into": ["credential-exfiltration"]
+  "derivable_into": ["credential-exfiltration"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00074.json
+++ b/records/AVE-2026-00074.json
@@ -106,6 +106,10 @@
   "evidence_basis_engines": ["pattern", "external_authority"],
   "derivable_into": ["remote-control-chain"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00075.json
+++ b/records/AVE-2026-00075.json
@@ -109,6 +109,10 @@
   "evidence_basis_engines": ["pattern"],
   "derivable_into": ["credential-exfiltration"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00076.json
+++ b/records/AVE-2026-00076.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 4.5,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:L/SC:L/SI:H/SA:N",
-  "owasp_mcp": ["MCP02"],
+  "owasp_mcp": ["MCP03"],
   "owasp_asi": ["ASI02"],
   "mitre_atlas": ["AML.T0015"],
   "nist_ai_rmf": [],
@@ -106,6 +106,10 @@
   "evidence_basis_engines": ["llm"],
   "derivable_into": ["remote-control-chain"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00077.json
+++ b/records/AVE-2026-00077.json
@@ -15,7 +15,7 @@
   ],
   "aivss_score": 4.8,
   "cvss_base_vector": "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:H/SI:H/SA:N",
-  "owasp_mcp": ["MCP07", "MCP10"],
+  "owasp_mcp": ["MCP07"],
   "owasp_asi": ["ASI02"],
   "mitre_atlas": [],
   "nist_ai_rmf": ["MAP-4.2"],
@@ -106,6 +106,10 @@
   "evidence_basis_engines": ["pattern"],
   "derivable_into": ["credential-exfiltration"],
   "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    },
     "owasp_asi": {
       "version": "2026",
       "read_date": "2026-08-23"

--- a/records/AVE-2026-00078.json
+++ b/records/AVE-2026-00078.json
@@ -96,5 +96,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.6,
   "evidence_basis_engines": ["llm", "sandbox"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00079.json
+++ b/records/AVE-2026-00079.json
@@ -96,5 +96,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.65,
   "evidence_basis_engines": ["llm", "sandbox"],
-  "derivable_into": ["remote-control-chain"]
+  "derivable_into": ["remote-control-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }

--- a/records/AVE-2026-00080.json
+++ b/records/AVE-2026-00080.json
@@ -97,5 +97,11 @@
   "detection_layer": "runtime",
   "confidence_baseline": 0.55,
   "evidence_basis_engines": ["llm", "sandbox"],
-  "derivable_into": ["privilege-escalation-chain"]
+  "derivable_into": ["privilege-escalation-chain"],
+  "framework_sources": {
+    "owasp_mcp": {
+      "commit": "165fe0f78ef104459237b4a8e0f6e78db9b02391",
+      "read_date": "2026-09-05"
+    }
+  }
 }


### PR DESCRIPTION
Follow-up to #263. After #263 landed PR #256's content on main, PR #260
(develop → main) still showed CONFLICTING. Checked: #260's own original
content (the pin_status "unknown" schema addition) was confirmed already
identical on main via #263 -- the remaining real gap was develop's
further divergence via #259 (the owasp_mcp audit corrections, 39
records), which had never been synced to main at all.

Cherry-picked PR #259's squashed commit (`fef4109`) onto a fresh branch
off `main`; applied with zero conflicts. A full test-merge of `develop`
into this branch afterward showed only a trivial `dist/` manifest
timestamp conflict (from #258, itself just a regeneration byproduct of
#259) -- no substantive divergence remains.

Once this merges, #260 is fully superseded (both of its real content
sources, #256 and #259, will be on main via #263 and this PR) and can be
closed rather than re-resolved directly.

Validated: `python scripts/validate_records.py` (80/80 valid),
`python scripts/check_fixtures.py` (all pass), `pytest tests/ -x -q`
(463 passed).