### PR TITLE
feat: add source_url to framework_sources

### DIFF
--- a/docs/terms-relationships.md
+++ b/docs/terms-relationships.md
@@ -74,3 +74,14 @@ OWASP/www-project-mcp-top-10#52, the live case (not a hypothetical) that
 prompted the field, where two independent projects assigned the same MCP
 category number to genuinely unrelated categories because each read the
 spec at a different point while it was still moving.
+`framework_sources.*.source_url` was added afterward, once an unrelated
+project facing the same #52 gap converged on the same shape:
+BerkantACUN/guardmcp PR #3 ("Pin the OWASP spec commit the mapping was
+drafted against") pins its SARIF taxonomy to the OWASP MCP Top 10 with a
+`specCommit`/`specSource` pair -- not a comment posted in #52 itself, a
+separate repo's independent fix for the versioning gap #52 describes --
+and its `specCommit` happens to be the exact same commit sha AVE's own
+`owasp_mcp` backfill pinned, `165fe0f78ef104459237b4a8e0f6e78db9b02391`.
+`source_url` mirrors `specSource`: the resolved tree URL at `commit`, so
+a reader can check the mapping without reconstructing it from repo and
+sha by hand. Optional even when `commit` is present.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -80,6 +80,17 @@ OWASP/www-project-mcp-top-10#52, the live case (not a hypothetical) that
 prompted the field, where two independent projects assigned the same MCP
 category number to genuinely unrelated categories because each read the
 spec at a different point while it was still moving.
+`framework_sources.*.source_url` was added afterward, once an unrelated
+project facing the same #52 gap converged on the same shape:
+BerkantACUN/guardmcp PR #3 ("Pin the OWASP spec commit the mapping was
+drafted against") pins its SARIF taxonomy to the OWASP MCP Top 10 with a
+`specCommit`/`specSource` pair -- not a comment posted in #52 itself, a
+separate repo's independent fix for the versioning gap #52 describes --
+and its `specCommit` happens to be the exact same commit sha AVE's own
+`owasp_mcp` backfill pinned, `165fe0f78ef104459237b4a8e0f6e78db9b02391`.
+`source_url` mirrors `specSource`: the resolved tree URL at `commit`, so
+a reader can check the mapping without reconstructing it from repo and
+sha by hand. Optional even when `commit` is present.
 
 <!-- GENERATED FROM schema/ave-record-1.1.0.schema.json, DO NOT HAND-EDIT BELOW THIS LINE -->
 

--- a/schema/ave-record-1.1.0.schema.json
+++ b/schema/ave-record-1.1.0.schema.json
@@ -615,6 +615,11 @@
             "pattern": "^[0-9a-f]{40}$",
             "description": "Full 40-character commit sha pinning the tree this mapping was read against, where the referenced framework has git history to pin. Same convention as crosswalk endpoint commit pinning: full, not abbreviated."
           },
+          "source_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The resolved tree URL at commit, where a reader can go check the mapping directly without reconstructing it from commit and repo. Optional even when commit is present. Matches the specCommit/specSource pairing independently designed by BerkantACUN/guardmcp (PR #3, 'Pin the OWASP spec commit the mapping was drafted against') for the same OWASP MCP Top 10 versioning gap OWASP/www-project-mcp-top-10#52 raised and this field exists to close -- guardmcp's PR pins the identical commit sha AVE's own owasp_mcp backfill used (165fe0f78ef104459237b4a8e0f6e78db9b02391), independent convergence on the same fix from two unrelated projects reading the same gap."
+          },
           "read_date": {
             "type": "string",
             "format": "date",

--- a/schema/ave-record.schema.json
+++ b/schema/ave-record.schema.json
@@ -615,6 +615,11 @@
             "pattern": "^[0-9a-f]{40}$",
             "description": "Full 40-character commit sha pinning the tree this mapping was read against, where the referenced framework has git history to pin. Same convention as crosswalk endpoint commit pinning: full, not abbreviated."
           },
+          "source_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The resolved tree URL at commit, where a reader can go check the mapping directly without reconstructing it from commit and repo. Optional even when commit is present. Matches the specCommit/specSource pairing independently designed by BerkantACUN/guardmcp (PR #3, 'Pin the OWASP spec commit the mapping was drafted against') for the same OWASP MCP Top 10 versioning gap OWASP/www-project-mcp-top-10#52 raised and this field exists to close -- guardmcp's PR pins the identical commit sha AVE's own owasp_mcp backfill used (165fe0f78ef104459237b4a8e0f6e78db9b02391), independent convergence on the same fix from two unrelated projects reading the same gap."
+          },
           "read_date": {
             "type": "string",
             "format": "date",


### PR DESCRIPTION
## What

Adds `source_url` as a new optional field to every `framework_sources.<field>` entry: the resolved tree URL at `commit`, so a reader can check a framework mapping's source directly without reconstructing it from repo and sha by hand. Optional even when `commit` is present.

## Why

`BerkantACUN/guardmcp` PR #3 ("Pin the OWASP spec commit the mapping was drafted against") independently designed the same shape -- a `specCommit`/`specSource` pair in its SARIF taxonomy properties -- for the same OWASP MCP Top 10 versioning gap that `OWASP/www-project-mcp-top-10#52` raised and that `framework_sources` itself exists to close. That PR is a separate repo's own fix for the gap #52 describes, not a comment posted in #52 -- worth being precise about since it's easy to conflate the two.

Notably, guardmcp's `specCommit` pins the exact same commit sha AVE's own `owasp_mcp` backfill already used: `165fe0f78ef104459237b4a8e0f6e78db9b02391`. Two unrelated projects independently converged on pinning the same commit to close the same gap -- `source_url` closes the remaining gap between the two shapes (a resolved link, not just a bare sha).

## Why no issue

Per CONTRIBUTING.md's Schema changes section: additive changes (new optional field, no version bump, no new required field, no rename/removal, no changed validation rule) are a standard PR. This isn't a structural change, so it doesn't need the issue-first + 30-day comment period that applies to those.

## Changes

- `schema/ave-record-1.1.0.schema.json`, `schema/ave-record.schema.json` (kept byte-identical): add `framework_sources.*.source_url` (`type: string`, `format: uri`)
- `docs/terms-relationships.md`: extended the existing `framework_sources` relationship note with the `source_url` addition and its real origin (appended, not rewritten)
- `docs/terms.md`: regenerated via `scripts/generate_terms.py`, confirmed with `scripts/check_terms_sync.py`

## Validation

- `python3 scripts/validate_records.py` -- all 80 records still valid
- `pytest tests/ -x -q` -- 470 passed
- `python3 scripts/check_terms_sync.py` -- docs/terms.md matches the live schema
- Both schema mirror files confirmed byte-identical after the edit